### PR TITLE
Add smoothly-menu-options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,8 +7,7 @@
 		"@angular/compiler": {
 			"version": "9.0.5",
 			"resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-9.0.5.tgz",
-			"integrity": "sha512-TeyhRGefTOtA9N3udMrvheafoXcz/dvTTdZLcieeZQxm1SSeaQDUQ/rUH6QTOiHVNMtjOCrZ9J5rk1A4mPYuag==",
-			"dev": true
+			"integrity": "sha512-TeyhRGefTOtA9N3udMrvheafoXcz/dvTTdZLcieeZQxm1SSeaQDUQ/rUH6QTOiHVNMtjOCrZ9J5rk1A4mPYuag=="
 		},
 		"@babel/code-frame": {
 			"version": "7.10.4",
@@ -394,14 +393,12 @@
 		"@glimmer/env": {
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/@glimmer/env/-/env-0.1.7.tgz",
-			"integrity": "sha1-/S0rVakCnGs3psk16MiHGucN+gc=",
-			"dev": true
+			"integrity": "sha1-/S0rVakCnGs3psk16MiHGucN+gc="
 		},
 		"@glimmer/interfaces": {
 			"version": "0.56.1",
 			"resolved": "https://registry.npmjs.org/@glimmer/interfaces/-/interfaces-0.56.1.tgz",
 			"integrity": "sha512-+0KvSd7c9QmkEeCFHaBDub1DBeTONw+x6MZUcb/MlA3FfNis2aFs7kHVkjkdzp0Ust54Wn448dgWZFW27EuVJA==",
-			"dev": true,
 			"requires": {
 				"@simple-dom/interface": "^1.4.0"
 			}
@@ -410,7 +407,6 @@
 			"version": "0.56.0",
 			"resolved": "https://registry.npmjs.org/@glimmer/syntax/-/syntax-0.56.0.tgz",
 			"integrity": "sha512-bh0pYOIRKABm6hy2B0QDL1+iJHafDj+lwaLQGtuoDBd2rfbJdmeOfGuKPjU51gQ7tllt/6lOdkQQG4yuO2CNRQ==",
-			"dev": true,
 			"requires": {
 				"@glimmer/interfaces": "^0.56.0",
 				"@glimmer/util": "^0.56.0",
@@ -422,7 +418,6 @@
 			"version": "0.56.1",
 			"resolved": "https://registry.npmjs.org/@glimmer/util/-/util-0.56.1.tgz",
 			"integrity": "sha512-g7R5hMtZ2BLF+AsYhSE1xoh0gOJALof4/JL6zovYvqrsKTLYGK1Qe3RKXSt8dPav8Ac0LXt+cOd6jHPGSrEs+A==",
-			"dev": true,
 			"requires": {
 				"@glimmer/env": "0.1.7",
 				"@glimmer/interfaces": "^0.56.1",
@@ -432,8 +427,7 @@
 		"@iarna/toml": {
 			"version": "2.2.5",
 			"resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
-			"integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==",
-			"dev": true
+			"integrity": "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg=="
 		},
 		"@istanbuljs/load-nyc-config": {
 			"version": "1.1.0",
@@ -926,7 +920,6 @@
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
 			"integrity": "sha512-eGmwYQn3gxo4r7jdQnkrrN6bY478C3P+a/y72IJukF8LjB6ZHeB3c+Ehacj3sYeSmUXGlnA67/PmbM9CVwL7Dw==",
-			"dev": true,
 			"requires": {
 				"@nodelib/fs.stat": "2.0.3",
 				"run-parallel": "^1.1.9"
@@ -935,14 +928,12 @@
 		"@nodelib/fs.stat": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
-			"integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==",
-			"dev": true
+			"integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA=="
 		},
 		"@nodelib/fs.walk": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz",
 			"integrity": "sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==",
-			"dev": true,
 			"requires": {
 				"@nodelib/fs.scandir": "2.1.3",
 				"fastq": "^1.6.0"
@@ -984,8 +975,7 @@
 		"@simple-dom/interface": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/@simple-dom/interface/-/interface-1.4.0.tgz",
-			"integrity": "sha512-l5qumKFWU0S+4ZzMaLXFU8tQZsicHEMEyAxI5kDFGhJsRqDwe0a7/iPA/GdxlGyDKseQQAgIz5kzU7eXTrlSpA==",
-			"dev": true
+			"integrity": "sha512-l5qumKFWU0S+4ZzMaLXFU8tQZsicHEMEyAxI5kDFGhJsRqDwe0a7/iPA/GdxlGyDKseQQAgIz5kzU7eXTrlSpA=="
 		},
 		"@sinonjs/commons": {
 			"version": "1.8.1",
@@ -1009,6 +999,12 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/@stencil/core/-/core-2.0.3.tgz",
 			"integrity": "sha512-d4qLDN7HKwJEK+ljhknD8azpM4bF49Dv7h5yG3RF+SPo8uozDq3p5ZNj1MgZoRgzh04kXNyG/MKnD8H2QN5YVw==",
+			"dev": true
+		},
+		"@stencil/sass": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/@stencil/sass/-/sass-1.4.1.tgz",
+			"integrity": "sha512-aFKoqtxZ/8BRbvNFiWRycGiqvMI22Ifn5qsKfq0U23j43XD81jT6d7K0WQd55ejNpoSpdxJcbOuFgQy3mXizfA==",
 			"dev": true
 		},
 		"@stencil/store": {
@@ -1068,8 +1064,7 @@
 		"@types/color-name": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
-			"integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
-			"dev": true
+			"integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
 		},
 		"@types/eslint-visitor-keys": {
 			"version": "1.0.0",
@@ -1145,8 +1140,7 @@
 		"@types/parse-json": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
-			"integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
-			"dev": true
+			"integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
 		},
 		"@types/prettier": {
 			"version": "2.0.2",
@@ -1177,8 +1171,7 @@
 		"@types/unist": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.3.tgz",
-			"integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ==",
-			"dev": true
+			"integrity": "sha512-FvUupuM3rlRsRtCN+fDudtmytGO6iHJuuRKS1Ss0pG5z8oX0diNEw94UEL7hgDbpN94rgaK5R7sWm6RrSkZuAQ=="
 		},
 		"@types/yargs": {
 			"version": "15.0.5",
@@ -1322,7 +1315,6 @@
 			"version": "2.34.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.34.0.tgz",
 			"integrity": "sha512-OMAr+nJWKdlVM9LOqCqh3pQQPwxHAN7Du8DR6dmwCrAmxtiXQnhHJ6tBNtf+cggqfo51SG/FCwnKhXCIM7hnVg==",
-			"dev": true,
 			"requires": {
 				"debug": "^4.1.1",
 				"eslint-visitor-keys": "^1.1.0",
@@ -1337,7 +1329,6 @@
 					"version": "7.3.5",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
 					"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-					"dev": true,
 					"requires": {
 						"lru-cache": "^6.0.0"
 					}
@@ -1418,7 +1409,6 @@
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/angular-estree-parser/-/angular-estree-parser-1.3.1.tgz",
 			"integrity": "sha512-jvlnNk4aoEmA6EKK12OnsOkCSdsWleBsYB+aWyH8kpfTB6Li1kxWVbHKVldH9zDCwVVi1hXfqPi/gbSv49tkbQ==",
-			"dev": true,
 			"requires": {
 				"lines-and-columns": "^1.1.6",
 				"tslib": "^1.9.3"
@@ -1428,7 +1418,6 @@
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/angular-html-parser/-/angular-html-parser-1.7.0.tgz",
 			"integrity": "sha512-/yjeqDQXGblZuFMI6vpDgiIDuv816QpIqa/mCotc0I4R0F5t5sfX1ntZ8VsBVQOUYRjPw8ggYlPZto76gHtf7Q==",
-			"dev": true,
 			"requires": {
 				"tslib": "^1.9.3"
 			}
@@ -1459,14 +1448,12 @@
 		"ansi-regex": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-			"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-			"dev": true
+			"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
 		},
 		"ansi-styles": {
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
 			"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-			"dev": true,
 			"requires": {
 				"@types/color-name": "^1.1.1",
 				"color-convert": "^2.0.1"
@@ -1524,8 +1511,7 @@
 		"array-union": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-			"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-			"dev": true
+			"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw=="
 		},
 		"array-unique": {
 			"version": "0.3.2",
@@ -1748,8 +1734,7 @@
 		"bail": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/bail/-/bail-1.0.5.tgz",
-			"integrity": "sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ==",
-			"dev": true
+			"integrity": "sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ=="
 		},
 		"balanced-match": {
 			"version": "1.0.0",
@@ -1850,7 +1835,6 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
 			"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-			"dev": true,
 			"requires": {
 				"fill-range": "^7.0.1"
 			}
@@ -1921,8 +1905,7 @@
 		"callsites": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-			"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-			"dev": true
+			"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
 		},
 		"camelcase": {
 			"version": "5.3.1",
@@ -1964,20 +1947,17 @@
 		"character-entities": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.4.tgz",
-			"integrity": "sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw==",
-			"dev": true
+			"integrity": "sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw=="
 		},
 		"character-entities-legacy": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz",
-			"integrity": "sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==",
-			"dev": true
+			"integrity": "sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA=="
 		},
 		"character-reference-invalid": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz",
-			"integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==",
-			"dev": true
+			"integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg=="
 		},
 		"chownr": {
 			"version": "1.1.4",
@@ -1994,7 +1974,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/cjk-regex/-/cjk-regex-2.0.0.tgz",
 			"integrity": "sha512-E4gFi2f3jC0zFVHpaAcupW+gv9OejZ2aV3DP/LlSO0dDcZJAXw7W0ivn+vN17edN/PhU4HCgs1bfx7lPK7FpdA==",
-			"dev": true,
 			"requires": {
 				"regexp-util": "^1.2.1",
 				"unicode-regex": "^2.0.0"
@@ -2004,7 +1983,6 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/unicode-regex/-/unicode-regex-2.0.0.tgz",
 					"integrity": "sha512-5nbEG2YU7loyTvPABaKb+8B0u8L7vWCsVmCSsiaO249ZdMKlvrXlxR2ex4TUVAdzv/Cne/TdoXSSaJArGXaleQ==",
-					"dev": true,
 					"requires": {
 						"regexp-util": "^1.2.0"
 					}
@@ -2062,8 +2040,7 @@
 		"collapse-white-space": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/collapse-white-space/-/collapse-white-space-1.0.6.tgz",
-			"integrity": "sha512-jEovNnrhMuqyCcjfEJA56v0Xq8SkIoPKDyaHahwo3POf4qcSXqMYuwNcOTzp74vTsR9Tn08z4MxWqAhcekogkQ==",
-			"dev": true
+			"integrity": "sha512-jEovNnrhMuqyCcjfEJA56v0Xq8SkIoPKDyaHahwo3POf4qcSXqMYuwNcOTzp74vTsR9Tn08z4MxWqAhcekogkQ=="
 		},
 		"collect-v8-coverage": {
 			"version": "1.0.1",
@@ -2085,7 +2062,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
 			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-			"dev": true,
 			"requires": {
 				"color-name": "~1.1.4"
 			}
@@ -2093,8 +2069,7 @@
 		"color-name": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-			"dev": true
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
 		},
 		"combined-stream": {
 			"version": "1.0.8",
@@ -2108,8 +2083,7 @@
 		"commander": {
 			"version": "2.20.3",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-			"dev": true
+			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
 		},
 		"component-emitter": {
 			"version": "1.3.0",
@@ -2157,7 +2131,6 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.0.tgz",
 			"integrity": "sha512-pondGvTuVYDk++upghXJabWzL6Kxu6f26ljFw64Swq9v6sQPUL3EUlVDV56diOjpCayKihL6hVe8exIACU4XcA==",
-			"dev": true,
 			"requires": {
 				"@types/parse-json": "^4.0.0",
 				"import-fresh": "^3.2.1",
@@ -2214,8 +2187,7 @@
 		"dashify": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/dashify/-/dashify-2.0.0.tgz",
-			"integrity": "sha512-hpA5C/YrPjucXypHPPc0oJ1l9Hf6wWbiOL7Ik42cxnsUOhWiCB/fylKbKqqJalW9FgkNQCw16YO8uW9Hs0Iy1A==",
-			"dev": true
+			"integrity": "sha512-hpA5C/YrPjucXypHPPc0oJ1l9Hf6wWbiOL7Ik42cxnsUOhWiCB/fylKbKqqJalW9FgkNQCw16YO8uW9Hs0Iy1A=="
 		},
 		"data-urls": {
 			"version": "2.0.0",
@@ -2257,8 +2229,7 @@
 		"dedent": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
-			"integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
-			"dev": true
+			"integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw="
 		},
 		"deep-is": {
 			"version": "0.1.3",
@@ -2329,8 +2300,7 @@
 		"detect-newline": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
-			"integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
-			"dev": true
+			"integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA=="
 		},
 		"devtools-protocol": {
 			"version": "0.0.781568",
@@ -2341,8 +2311,7 @@
 		"diff": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-			"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-			"dev": true
+			"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
 		},
 		"diff-sequences": {
 			"version": "25.2.6",
@@ -2354,7 +2323,6 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
 			"integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-			"dev": true,
 			"requires": {
 				"path-type": "^4.0.0"
 			}
@@ -2399,7 +2367,6 @@
 			"version": "0.15.3",
 			"resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.15.3.tgz",
 			"integrity": "sha512-M9wIMFx96vq0R4F+gRpY3o2exzb8hEj/n9S8unZtHSvYjibBp/iMufSzvmOcV/laG0ZtuTVGtiJggPOSW2r93g==",
-			"dev": true,
 			"requires": {
 				"commander": "^2.19.0",
 				"lru-cache": "^4.1.5",
@@ -2411,7 +2378,6 @@
 					"version": "4.1.5",
 					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
 					"integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-					"dev": true,
 					"requires": {
 						"pseudomap": "^1.0.2",
 						"yallist": "^2.1.2"
@@ -2420,16 +2386,14 @@
 				"yallist": {
 					"version": "2.1.2",
 					"resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-					"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-					"dev": true
+					"integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
 				}
 			}
 		},
 		"editorconfig-to-prettier": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/editorconfig-to-prettier/-/editorconfig-to-prettier-0.1.1.tgz",
-			"integrity": "sha512-MMadSSVRDb4uKdxV6bCXXN4cTsxIsXYtV4XdPu6FOCSAw6zsCIDA+QEktEU+u6h+c/mTrul5NR+pwFpPxwetiQ==",
-			"dev": true
+			"integrity": "sha512-MMadSSVRDb4uKdxV6bCXXN4cTsxIsXYtV4XdPu6FOCSAw6zsCIDA+QEktEU+u6h+c/mTrul5NR+pwFpPxwetiQ=="
 		},
 		"emittery": {
 			"version": "0.7.1",
@@ -2440,14 +2404,12 @@
 		"emoji-regex": {
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-			"dev": true
+			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
 		},
 		"end-of-stream": {
 			"version": "1.4.4",
 			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
 			"integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-			"dev": true,
 			"requires": {
 				"once": "^1.4.0"
 			}
@@ -2680,7 +2642,6 @@
 			"version": "6.11.0",
 			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.11.0.tgz",
 			"integrity": "sha512-oB8cpLWSAjOVFEJhhyMZh6NOEOtBVziaqdDQ86+qhDHFbZXoRTM7pNSvFRfW/W/L/LrQ38C99J5CGuRBBzBsdA==",
-			"dev": true,
 			"requires": {
 				"get-stdin": "^6.0.0"
 			}
@@ -2940,7 +2901,6 @@
 		"eslint-plugin-prettierx": {
 			"version": "github:nilssonemma/eslint-plugin-prettierx#bf35950d2cb3628839dbf21fdc032ae47350f9d0",
 			"from": "github:nilssonemma/eslint-plugin-prettierx#master",
-			"dev": true,
 			"requires": {
 				"eslint-config-prettier": "~6.11.0",
 				"prettier-linter-helpers": "~1.0.0",
@@ -2950,20 +2910,17 @@
 				"@babel/parser": {
 					"version": "7.11.2",
 					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.2.tgz",
-					"integrity": "sha512-Vuj/+7vLo6l1Vi7uuO+1ngCDNeVmNbTngcJFKCR/oEtz8tKz0CJxZEGmPt9KcIloZhOZ3Zit6xbpXT2MDlS9Vw==",
-					"dev": true
+					"integrity": "sha512-Vuj/+7vLo6l1Vi7uuO+1ngCDNeVmNbTngcJFKCR/oEtz8tKz0CJxZEGmPt9KcIloZhOZ3Zit6xbpXT2MDlS9Vw=="
 				},
 				"camelcase": {
 					"version": "6.0.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.0.0.tgz",
-					"integrity": "sha512-8KMDF1Vz2gzOq54ONPJS65IvTUaB1cHJ2DMM7MbPmLZljDH1qpzzLsWdiN9pHh6qvkRVDTi/07+eNGch/oLU4w==",
-					"dev": true
+					"integrity": "sha512-8KMDF1Vz2gzOq54ONPJS65IvTUaB1cHJ2DMM7MbPmLZljDH1qpzzLsWdiN9pHh6qvkRVDTi/07+eNGch/oLU4w=="
 				},
 				"chalk": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
 					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "^4.1.0",
 						"supports-color": "^7.1.0"
@@ -2972,14 +2929,12 @@
 				"escape-string-regexp": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-					"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-					"dev": true
+					"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
 				},
 				"get-stream": {
 					"version": "5.1.0",
 					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
 					"integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
-					"dev": true,
 					"requires": {
 						"pump": "^3.0.0"
 					}
@@ -2987,7 +2942,6 @@
 				"prettierx": {
 					"version": "github:simonmika/prettierx#4025f0e218ba6171fe27612f58007b492fc03d08",
 					"from": "github:simonmika/prettierx#newline-before-clause",
-					"dev": true,
 					"requires": {
 						"@angular/compiler": "9.0.5",
 						"@babel/code-frame": "7.10.4",
@@ -3052,8 +3006,7 @@
 				"semver": {
 					"version": "7.3.2",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-					"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
-					"dev": true
+					"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
 				}
 			}
 		},
@@ -3381,8 +3334,7 @@
 		"extend": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-			"dev": true
+			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
 		},
 		"extend-shallow": {
 			"version": "3.0.2",
@@ -3508,14 +3460,12 @@
 		"fast-diff": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
-			"integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
-			"dev": true
+			"integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w=="
 		},
 		"fast-glob": {
 			"version": "3.2.4",
 			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.4.tgz",
 			"integrity": "sha512-kr/Oo6PX51265qeuCYsyGypiO5uJFgBS0jksyG7FUeCyQzNwYnzrNIMR1NXfkZXsMYXYLRAHgISHBz8gQcxKHQ==",
-			"dev": true,
 			"requires": {
 				"@nodelib/fs.stat": "^2.0.2",
 				"@nodelib/fs.walk": "^1.2.3",
@@ -3541,7 +3491,6 @@
 			"version": "1.8.0",
 			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.8.0.tgz",
 			"integrity": "sha512-SMIZoZdLh/fgofivvIkmknUXyPnvxRE3DhtZ5Me3Mrsk5gyPL42F0xr51TdRXskBxHfMp+07bcYzfsYEsSQA9Q==",
-			"dev": true,
 			"requires": {
 				"reusify": "^1.0.4"
 			}
@@ -3577,7 +3526,6 @@
 			"version": "7.0.1",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
 			"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-			"dev": true,
 			"requires": {
 				"to-regex-range": "^5.0.1"
 			}
@@ -3585,14 +3533,12 @@
 		"find-parent-dir": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/find-parent-dir/-/find-parent-dir-0.3.0.tgz",
-			"integrity": "sha1-M8RLQpqysvBkYpnF+fcY83b/jVQ=",
-			"dev": true
+			"integrity": "sha1-M8RLQpqysvBkYpnF+fcY83b/jVQ="
 		},
 		"find-project-root": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/find-project-root/-/find-project-root-1.1.1.tgz",
-			"integrity": "sha1-0kJyei2QRyXfVxTyPf3N7doLbvg=",
-			"dev": true
+			"integrity": "sha1-0kJyei2QRyXfVxTyPf3N7doLbvg="
 		},
 		"find-up": {
 			"version": "4.1.0",
@@ -3634,14 +3580,12 @@
 		"flatten": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/flatten/-/flatten-1.0.3.tgz",
-			"integrity": "sha512-dVsPA/UwQ8+2uoFe5GHtiBMu48dWLTdsuEd7CKGlZlD78r1TTWBvDuFaFGKCo/ZfEr95Uk56vZoX86OsHkUeIg==",
-			"dev": true
+			"integrity": "sha512-dVsPA/UwQ8+2uoFe5GHtiBMu48dWLTdsuEd7CKGlZlD78r1TTWBvDuFaFGKCo/ZfEr95Uk56vZoX86OsHkUeIg=="
 		},
 		"flow-parser": {
 			"version": "0.122.0",
 			"resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.122.0.tgz",
-			"integrity": "sha512-rb4pLIb7JAWn4dnO+fB9YLTUOM0SvY1ZN2yeu2NOyL7f2JeXBp9Nevqf+h4OluQcdI+9CnGa/if/HUy1YOX0dA==",
-			"dev": true
+			"integrity": "sha512-rb4pLIb7JAWn4dnO+fB9YLTUOM0SvY1ZN2yeu2NOyL7f2JeXBp9Nevqf+h4OluQcdI+9CnGa/if/HUy1YOX0dA=="
 		},
 		"for-in": {
 			"version": "1.0.2",
@@ -3734,8 +3678,7 @@
 		"get-stdin": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
-			"integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
-			"dev": true
+			"integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g=="
 		},
 		"get-stream": {
 			"version": "4.1.0",
@@ -3778,7 +3721,6 @@
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
 			"integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
-			"dev": true,
 			"requires": {
 				"is-glob": "^4.0.1"
 			}
@@ -3792,7 +3734,6 @@
 			"version": "11.0.1",
 			"resolved": "https://registry.npmjs.org/globby/-/globby-11.0.1.tgz",
 			"integrity": "sha512-iH9RmgwCmUJHi2z5o2l3eTtGBtXek1OYlHrbcxOYugyHLmAsZrPj43OtHThd62Buh/Vv6VyCBD2bdyWcGNQqoQ==",
-			"dev": true,
 			"requires": {
 				"array-union": "^2.1.0",
 				"dir-glob": "^3.0.1",
@@ -3805,8 +3746,7 @@
 				"ignore": {
 					"version": "5.1.8",
 					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
-					"integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
-					"dev": true
+					"integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw=="
 				}
 			}
 		},
@@ -3818,8 +3758,7 @@
 		"graphql": {
 			"version": "15.3.0",
 			"resolved": "https://registry.npmjs.org/graphql/-/graphql-15.3.0.tgz",
-			"integrity": "sha512-GTCJtzJmkFLWRfFJuoo9RWWa/FfamUHgiFosxi/X1Ani4AVWbeyBenZTNX6dM+7WSbbFfTo/25eh0LLkwHMw2w==",
-			"dev": true
+			"integrity": "sha512-GTCJtzJmkFLWRfFJuoo9RWWa/FfamUHgiFosxi/X1Ani4AVWbeyBenZTNX6dM+7WSbbFfTo/25eh0LLkwHMw2w=="
 		},
 		"growly": {
 			"version": "1.3.0",
@@ -3832,7 +3771,6 @@
 			"version": "4.7.7",
 			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
 			"integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
-			"dev": true,
 			"requires": {
 				"minimist": "^1.2.5",
 				"neo-async": "^2.6.0",
@@ -3868,8 +3806,7 @@
 		"has-flag": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-			"dev": true
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
 		},
 		"has-symbols": {
 			"version": "1.0.1",
@@ -3936,8 +3873,7 @@
 		"html-element-attributes": {
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/html-element-attributes/-/html-element-attributes-2.2.1.tgz",
-			"integrity": "sha512-gGTgCeQu+g1OFExZKWQ1LwbFXxLJ6cGdCGj64ByEaxatr/EPVc23D6Gxngb37ao+SNInP/sGu8FXxRsSxMm7aQ==",
-			"dev": true
+			"integrity": "sha512-gGTgCeQu+g1OFExZKWQ1LwbFXxLJ6cGdCGj64ByEaxatr/EPVc23D6Gxngb37ao+SNInP/sGu8FXxRsSxMm7aQ=="
 		},
 		"html-encoding-sniffer": {
 			"version": "2.0.1",
@@ -3957,14 +3893,12 @@
 		"html-styles": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/html-styles/-/html-styles-1.0.0.tgz",
-			"integrity": "sha1-oYBh/WUfmca3XEXI4FSaO8PgGnU=",
-			"dev": true
+			"integrity": "sha1-oYBh/WUfmca3XEXI4FSaO8PgGnU="
 		},
 		"html-tag-names": {
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/html-tag-names/-/html-tag-names-1.1.5.tgz",
-			"integrity": "sha512-aI5tKwNTBzOZApHIynaAwecLBv8TlZTEy/P4Sj2SzzAhBrGuI8yGZ0UIXVPQzOHGS+to2mjb04iy6VWt/8+d8A==",
-			"dev": true
+			"integrity": "sha512-aI5tKwNTBzOZApHIynaAwecLBv8TlZTEy/P4Sj2SzzAhBrGuI8yGZ0UIXVPQzOHGS+to2mjb04iy6VWt/8+d8A=="
 		},
 		"http-signature": {
 			"version": "1.2.0",
@@ -4011,14 +3945,12 @@
 		"ignore": {
 			"version": "4.0.6",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-			"integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
-			"dev": true
+			"integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
 		},
 		"import-fresh": {
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
 			"integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
-			"dev": true,
 			"requires": {
 				"parent-module": "^1.0.0",
 				"resolve-from": "^4.0.0"
@@ -4027,8 +3959,7 @@
 				"resolve-from": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-					"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-					"dev": true
+					"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
 				}
 			}
 		},
@@ -4056,8 +3987,7 @@
 		"indexes-of": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
-			"integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc=",
-			"dev": true
+			"integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc="
 		},
 		"inflight": {
 			"version": "1.0.6",
@@ -4132,14 +4062,12 @@
 		"is-alphabetical": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.4.tgz",
-			"integrity": "sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==",
-			"dev": true
+			"integrity": "sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg=="
 		},
 		"is-alphanumerical": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.4.tgz",
 			"integrity": "sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==",
-			"dev": true,
 			"requires": {
 				"is-alphabetical": "^1.0.0",
 				"is-decimal": "^1.0.0"
@@ -4198,8 +4126,7 @@
 		"is-decimal": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.4.tgz",
-			"integrity": "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==",
-			"dev": true
+			"integrity": "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw=="
 		},
 		"is-descriptor": {
 			"version": "0.1.6",
@@ -4241,8 +4168,7 @@
 		"is-fullwidth-code-point": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-			"dev": true
+			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
 		},
 		"is-generator-fn": {
 			"version": "2.1.0",
@@ -4261,8 +4187,7 @@
 		"is-hexadecimal": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz",
-			"integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==",
-			"dev": true
+			"integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw=="
 		},
 		"is-negative-zero": {
 			"version": "2.0.1",
@@ -4272,14 +4197,12 @@
 		"is-number": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-			"dev": true
+			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
 		},
 		"is-plain-obj": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-			"integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
-			"dev": true
+			"integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA=="
 		},
 		"is-plain-object": {
 			"version": "2.0.4",
@@ -4332,8 +4255,7 @@
 		"is-whitespace-character": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/is-whitespace-character/-/is-whitespace-character-1.0.4.tgz",
-			"integrity": "sha512-SDweEzfIZM0SJV0EUga669UTKlmL0Pq8Lno0QDQsPnvECB3IM2aP0gdx5TrU0A01MAPfViaZiI2V1QMZLaKK5w==",
-			"dev": true
+			"integrity": "sha512-SDweEzfIZM0SJV0EUga669UTKlmL0Pq8Lno0QDQsPnvECB3IM2aP0gdx5TrU0A01MAPfViaZiI2V1QMZLaKK5w=="
 		},
 		"is-windows": {
 			"version": "1.0.2",
@@ -4344,8 +4266,7 @@
 		"is-word-character": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/is-word-character/-/is-word-character-1.0.4.tgz",
-			"integrity": "sha512-5SMO8RVennx3nZrqtKwCGyyetPE9VDba5ugvKLaD4KopPG5kR4mQ7tNt/r7feL5yt5h3lpuBbIUmCOG2eSzXHA==",
-			"dev": true
+			"integrity": "sha512-5SMO8RVennx3nZrqtKwCGyyetPE9VDba5ugvKLaD4KopPG5kR4mQ7tNt/r7feL5yt5h3lpuBbIUmCOG2eSzXHA=="
 		},
 		"is-wsl": {
 			"version": "2.2.0",
@@ -4730,7 +4651,6 @@
 			"version": "26.0.0",
 			"resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-26.0.0.tgz",
 			"integrity": "sha512-RDZ4Iz3QbtRWycd8bUEPxQsTlYazfYn/h5R65Fc6gOfwozFhoImx+affzky/FFBuqISPTqjXomoIGJVKBWoo0w==",
-			"dev": true,
 			"requires": {
 				"detect-newline": "^3.0.0"
 			}
@@ -5876,7 +5796,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
 			"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-			"dev": true,
 			"requires": {
 				"jsonify": "~0.0.0"
 			}
@@ -5905,8 +5824,7 @@
 		"jsonify": {
 			"version": "0.0.0",
 			"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-			"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-			"dev": true
+			"integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
 		},
 		"jsprim": {
 			"version": "1.4.1",
@@ -6075,8 +5993,7 @@
 		"leven": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
-			"integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
-			"dev": true
+			"integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A=="
 		},
 		"levn": {
 			"version": "0.3.0",
@@ -6096,8 +6013,7 @@
 		"linguist-languages": {
 			"version": "7.10.0",
 			"resolved": "https://registry.npmjs.org/linguist-languages/-/linguist-languages-7.10.0.tgz",
-			"integrity": "sha512-Uqt94P4iAznscZtccnNE1IBi105U+fmQKEUlDJv54JDdFZDInomkepEIRpZLOQcPyGdcNu3JO9Tvo5wpQVbfKw==",
-			"dev": true
+			"integrity": "sha512-Uqt94P4iAznscZtccnNE1IBi105U+fmQKEUlDJv54JDdFZDInomkepEIRpZLOQcPyGdcNu3JO9Tvo5wpQVbfKw=="
 		},
 		"load-json-file": {
 			"version": "2.0.0",
@@ -6166,7 +6082,6 @@
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
 			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-			"dev": true,
 			"requires": {
 				"yallist": "^4.0.0"
 			}
@@ -6201,7 +6116,6 @@
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
 			"integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
-			"dev": true,
 			"requires": {
 				"p-defer": "^1.0.0"
 			}
@@ -6224,14 +6138,12 @@
 		"markdown-escapes": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.4.tgz",
-			"integrity": "sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg==",
-			"dev": true
+			"integrity": "sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg=="
 		},
 		"mem": {
 			"version": "6.1.0",
 			"resolved": "https://registry.npmjs.org/mem/-/mem-6.1.0.tgz",
 			"integrity": "sha512-RlbnLQgRHk5lwqTtpEkBTQ2ll/CG/iB+J4Hy2Wh97PjgZgXgWJWrFF+XXujh3UUVLvR4OOTgZzcWMMwnehlEUg==",
-			"dev": true,
 			"requires": {
 				"map-age-cleaner": "^0.1.3",
 				"mimic-fn": "^3.0.0"
@@ -6240,8 +6152,7 @@
 				"mimic-fn": {
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-3.1.0.tgz",
-					"integrity": "sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==",
-					"dev": true
+					"integrity": "sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ=="
 				}
 			}
 		},
@@ -6254,14 +6165,12 @@
 		"merge2": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-			"integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-			"dev": true
+			"integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="
 		},
 		"micromatch": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
 			"integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
-			"dev": true,
 			"requires": {
 				"braces": "^3.0.1",
 				"picomatch": "^2.0.5"
@@ -6352,8 +6261,7 @@
 		"n-readlines": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/n-readlines/-/n-readlines-1.0.0.tgz",
-			"integrity": "sha512-ISDqGcspVu6U3VKqtJZG1uR55SmNNF9uK0EMq1IvNVVZOui6MW6VR0+pIZhqz85ORAGp+4zW+5fJ/SE7bwEibA==",
-			"dev": true
+			"integrity": "sha512-ISDqGcspVu6U3VKqtJZG1uR55SmNNF9uK0EMq1IvNVVZOui6MW6VR0+pIZhqz85ORAGp+4zW+5fJ/SE7bwEibA=="
 		},
 		"nan": {
 			"version": "2.14.1",
@@ -6388,8 +6296,7 @@
 		"neo-async": {
 			"version": "2.6.2",
 			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
-			"integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-			"dev": true
+			"integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
 		},
 		"nice-try": {
 			"version": "1.0.5",
@@ -6640,8 +6547,7 @@
 		"p-defer": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
-			"integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
-			"dev": true
+			"integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww="
 		},
 		"p-each-series": {
 			"version": "2.1.0",
@@ -6680,7 +6586,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
 			"integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-			"dev": true,
 			"requires": {
 				"callsites": "^3.0.0"
 			}
@@ -6689,7 +6594,6 @@
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.2.2.tgz",
 			"integrity": "sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==",
-			"dev": true,
 			"requires": {
 				"character-entities": "^1.0.0",
 				"character-entities-legacy": "^1.0.0",
@@ -6746,8 +6650,7 @@
 		"path-type": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-			"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-			"dev": true
+			"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
 		},
 		"pend": {
 			"version": "1.2.0",
@@ -6764,8 +6667,7 @@
 		"picomatch": {
 			"version": "2.2.2",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
-			"integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
-			"dev": true
+			"integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg=="
 		},
 		"pify": {
 			"version": "2.3.0",
@@ -6794,7 +6696,6 @@
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz",
 			"integrity": "sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==",
-			"dev": true,
 			"requires": {
 				"semver-compare": "^1.0.0"
 			}
@@ -6814,7 +6715,6 @@
 			"version": "7.0.35",
 			"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
 			"integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
-			"dev": true,
 			"requires": {
 				"chalk": "^2.4.2",
 				"source-map": "^0.6.1",
@@ -6825,7 +6725,6 @@
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
 					"requires": {
 						"color-convert": "^1.9.0"
 					}
@@ -6834,7 +6733,6 @@
 					"version": "2.4.2",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
 					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
@@ -6845,7 +6743,6 @@
 							"version": "5.5.0",
 							"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
 							"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-							"dev": true,
 							"requires": {
 								"has-flag": "^3.0.0"
 							}
@@ -6856,7 +6753,6 @@
 					"version": "1.9.3",
 					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
 					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-					"dev": true,
 					"requires": {
 						"color-name": "1.1.3"
 					}
@@ -6864,20 +6760,17 @@
 				"color-name": {
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-					"dev": true
+					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 				},
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-					"dev": true
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 				},
 				"supports-color": {
 					"version": "6.1.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
 					"integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
 					}
@@ -6888,7 +6781,6 @@
 			"version": "3.1.4",
 			"resolved": "https://registry.npmjs.org/postcss-less/-/postcss-less-3.1.4.tgz",
 			"integrity": "sha512-7TvleQWNM2QLcHqvudt3VYjULVB49uiW6XzEUFmvwHzvsOEF5MwBrIXZDJQvJNFGjJQTzSzZnDoCJ8h/ljyGXA==",
-			"dev": true,
 			"requires": {
 				"postcss": "^7.0.14"
 			}
@@ -6896,14 +6788,12 @@
 		"postcss-media-query-parser": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz",
-			"integrity": "sha1-J7Ocb02U+Bsac7j3Y1HGCeXO8kQ=",
-			"dev": true
+			"integrity": "sha1-J7Ocb02U+Bsac7j3Y1HGCeXO8kQ="
 		},
 		"postcss-scss": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-2.1.1.tgz",
 			"integrity": "sha512-jQmGnj0hSGLd9RscFw9LyuSVAa5Bl1/KBPqG1NQw9w8ND55nY4ZEsdlVuYJvLPpV+y0nwTV5v/4rHPzZRihQbA==",
-			"dev": true,
 			"requires": {
 				"postcss": "^7.0.6"
 			}
@@ -6912,7 +6802,6 @@
 			"version": "2.2.3",
 			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz",
 			"integrity": "sha1-+UN3iGBsPJrO4W/+jYsWKX8nu5A=",
-			"dev": true,
 			"requires": {
 				"flatten": "^1.0.2",
 				"indexes-of": "^1.0.1",
@@ -6923,7 +6812,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/postcss-values-parser/-/postcss-values-parser-2.0.1.tgz",
 			"integrity": "sha512-2tLuBsA6P4rYTNKCXYG/71C7j1pU6pK503suYOmn4xYrQIzW+opD+7FAFNuGSdZC/3Qfy334QbeMu7MEb8gOxg==",
-			"dev": true,
 			"requires": {
 				"flatten": "^1.0.2",
 				"indexes-of": "^1.0.1",
@@ -6940,7 +6828,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
 			"integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
-			"dev": true,
 			"requires": {
 				"fast-diff": "^1.1.2"
 			}
@@ -6948,7 +6835,6 @@
 		"prettierx": {
 			"version": "github:simonmika/prettierx#9a7e9ad784e8fdec51da60ee21a1f00c521d913f",
 			"from": "github:simonmika/prettierx#newline-before-clause",
-			"dev": true,
 			"requires": {
 				"@angular/compiler": "9.0.5",
 				"@babel/code-frame": "7.10.4",
@@ -7013,20 +6899,17 @@
 				"@babel/parser": {
 					"version": "7.11.2",
 					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.2.tgz",
-					"integrity": "sha512-Vuj/+7vLo6l1Vi7uuO+1ngCDNeVmNbTngcJFKCR/oEtz8tKz0CJxZEGmPt9KcIloZhOZ3Zit6xbpXT2MDlS9Vw==",
-					"dev": true
+					"integrity": "sha512-Vuj/+7vLo6l1Vi7uuO+1ngCDNeVmNbTngcJFKCR/oEtz8tKz0CJxZEGmPt9KcIloZhOZ3Zit6xbpXT2MDlS9Vw=="
 				},
 				"camelcase": {
 					"version": "6.0.0",
 					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.0.0.tgz",
-					"integrity": "sha512-8KMDF1Vz2gzOq54ONPJS65IvTUaB1cHJ2DMM7MbPmLZljDH1qpzzLsWdiN9pHh6qvkRVDTi/07+eNGch/oLU4w==",
-					"dev": true
+					"integrity": "sha512-8KMDF1Vz2gzOq54ONPJS65IvTUaB1cHJ2DMM7MbPmLZljDH1qpzzLsWdiN9pHh6qvkRVDTi/07+eNGch/oLU4w=="
 				},
 				"chalk": {
 					"version": "4.1.0",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
 					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "^4.1.0",
 						"supports-color": "^7.1.0"
@@ -7035,14 +6918,12 @@
 				"escape-string-regexp": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-					"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-					"dev": true
+					"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
 				},
 				"get-stream": {
 					"version": "5.1.0",
 					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
 					"integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
-					"dev": true,
 					"requires": {
 						"pump": "^3.0.0"
 					}
@@ -7050,8 +6931,7 @@
 				"semver": {
 					"version": "7.3.2",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-					"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
-					"dev": true
+					"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
 				}
 			}
 		},
@@ -7102,8 +6982,7 @@
 		"pseudomap": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
-			"dev": true
+			"integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
 		},
 		"psl": {
 			"version": "1.8.0",
@@ -7115,7 +6994,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
 			"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-			"dev": true,
 			"requires": {
 				"end-of-stream": "^1.1.0",
 				"once": "^1.3.1"
@@ -7221,7 +7099,6 @@
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/regexp-util/-/regexp-util-1.2.2.tgz",
 			"integrity": "sha512-5/rl2UD18oAlLQEIuKBeiSIOp1hb5wCXcakl5yvHxlY1wyWI4D5cUKKzCibBeu741PA9JKvZhMqbkDQqPusX3w==",
-			"dev": true,
 			"requires": {
 				"tslib": "^1.9.0"
 			}
@@ -7264,7 +7141,6 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/remark-math/-/remark-math-1.0.6.tgz",
 			"integrity": "sha512-I43wU/QOQpXvVFXKjA4FHp5xptK65+5F6yolm8+69/JV0EqSOB64wURUZ3JK50JtnTL8FvwLiH2PZ+fvsBxviA==",
-			"dev": true,
 			"requires": {
 				"trim-trailing-lines": "^1.1.0"
 			}
@@ -7273,7 +7149,6 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-5.0.0.tgz",
 			"integrity": "sha512-b3iXszZLH1TLoyUzrATcTQUZrwNl1rE70rVdSruJFlDaJ9z5aMkhrG43Pp68OgfHndL/ADz6V69Zow8cTQu+JA==",
-			"dev": true,
 			"requires": {
 				"collapse-white-space": "^1.0.2",
 				"is-alphabetical": "^1.0.0",
@@ -7307,8 +7182,7 @@
 		"repeat-string": {
 			"version": "1.6.1",
 			"resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-			"dev": true
+			"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
 		},
 		"request": {
 			"version": "2.88.2",
@@ -7443,8 +7317,7 @@
 		"reusify": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
-			"integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
-			"dev": true
+			"integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw=="
 		},
 		"rimraf": {
 			"version": "3.0.2",
@@ -7464,8 +7337,7 @@
 		"run-parallel": {
 			"version": "1.1.9",
 			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
-			"integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==",
-			"dev": true
+			"integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q=="
 		},
 		"safe-buffer": {
 			"version": "5.1.2",
@@ -7646,8 +7518,7 @@
 		"semver-compare": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
-			"integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w=",
-			"dev": true
+			"integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w="
 		},
 		"set-blocking": {
 			"version": "2.0.0",
@@ -7712,8 +7583,7 @@
 		"sigmund": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-			"integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
-			"dev": true
+			"integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA="
 		},
 		"signal-exit": {
 			"version": "3.0.3",
@@ -7724,8 +7594,7 @@
 		"simple-html-tokenizer": {
 			"version": "0.5.11",
 			"resolved": "https://registry.npmjs.org/simple-html-tokenizer/-/simple-html-tokenizer-0.5.11.tgz",
-			"integrity": "sha512-C2WEK/Z3HoSFbYq8tI7ni3eOo/NneSPRoPpcM7WdLjFOArFuyXEjAoCdOC3DgMfRyziZQ1hCNR4mrNdWEvD0og==",
-			"dev": true
+			"integrity": "sha512-C2WEK/Z3HoSFbYq8tI7ni3eOo/NneSPRoPpcM7WdLjFOArFuyXEjAoCdOC3DgMfRyziZQ1hCNR4mrNdWEvD0og=="
 		},
 		"sisteransi": {
 			"version": "1.0.5",
@@ -7736,8 +7605,7 @@
 		"slash": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-			"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-			"dev": true
+			"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
 		},
 		"slice-ansi": {
 			"version": "2.1.0",
@@ -7913,8 +7781,7 @@
 		"source-map": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-			"dev": true
+			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 		},
 		"source-map-resolve": {
 			"version": "0.5.3",
@@ -7991,8 +7858,7 @@
 		"srcset": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/srcset/-/srcset-3.0.0.tgz",
-			"integrity": "sha512-D59vF08Qzu/C4GAOXVgMTLfgryt5fyWo93FZyhEWANo0PokFz/iWdDe13mX3O5TRf6l8vMTqckAfR4zPiaH0yQ==",
-			"dev": true
+			"integrity": "sha512-D59vF08Qzu/C4GAOXVgMTLfgryt5fyWo93FZyhEWANo0PokFz/iWdDe13mX3O5TRf6l8vMTqckAfR4zPiaH0yQ=="
 		},
 		"sshpk": {
 			"version": "1.16.1",
@@ -8031,8 +7897,7 @@
 		"state-toggle": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/state-toggle/-/state-toggle-1.0.3.tgz",
-			"integrity": "sha512-d/5Z4/2iiCnHw6Xzghyhb+GcmF89bxwgXG60wjIiZaxnymbyOmI8Hk4VqHXiVVp6u2ysaskFfXg3ekCj4WNftQ==",
-			"dev": true
+			"integrity": "sha512-d/5Z4/2iiCnHw6Xzghyhb+GcmF89bxwgXG60wjIiZaxnymbyOmI8Hk4VqHXiVVp6u2ysaskFfXg3ekCj4WNftQ=="
 		},
 		"static-extend": {
 			"version": "0.1.2",
@@ -8083,7 +7948,6 @@
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
 			"integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
-			"dev": true,
 			"requires": {
 				"emoji-regex": "^8.0.0",
 				"is-fullwidth-code-point": "^3.0.0",
@@ -8143,7 +8007,6 @@
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
 			"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-			"dev": true,
 			"requires": {
 				"ansi-regex": "^5.0.0"
 			}
@@ -8176,7 +8039,6 @@
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
 			"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-			"dev": true,
 			"requires": {
 				"has-flag": "^4.0.0"
 			}
@@ -8318,7 +8180,9 @@
 			"resolved": "https://registry.npmjs.org/tidily/-/tidily-0.0.41.tgz",
 			"integrity": "sha512-ecEqiroFNIUPo0yeCVaV6mk+h4RdrdzA/k2mkhqACD23AccMAR8FsvSkKKQO19aqH8Hlfy2tfLm7K9omprITaQ==",
 			"requires": {
-				"isoly": "0.0.25"
+				"eslint-plugin-prettierx": "github:nilssonemma/eslint-plugin-prettierx#master",
+				"isoly": "0.0.25",
+				"prettierx": "github:simonmika/prettierx#newline-before-clause"
 			},
 			"dependencies": {
 				"isoly": {
@@ -8375,7 +8239,6 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
 			"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-			"dev": true,
 			"requires": {
 				"is-number": "^7.0.0"
 			}
@@ -8403,20 +8266,17 @@
 		"trim": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
-			"integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0=",
-			"dev": true
+			"integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0="
 		},
 		"trim-trailing-lines": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/trim-trailing-lines/-/trim-trailing-lines-1.1.4.tgz",
-			"integrity": "sha512-rjUWSqnfTNrjbB9NQWfPMH/xRK1deHeGsHoVfpxJ++XeYXE0d6B1En37AHfw3jtfTU7dzMzZL2jjpe8Qb5gLIQ==",
-			"dev": true
+			"integrity": "sha512-rjUWSqnfTNrjbB9NQWfPMH/xRK1deHeGsHoVfpxJ++XeYXE0d6B1En37AHfw3jtfTU7dzMzZL2jjpe8Qb5gLIQ=="
 		},
 		"trough": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/trough/-/trough-1.0.5.tgz",
-			"integrity": "sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==",
-			"dev": true
+			"integrity": "sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA=="
 		},
 		"tsconfig-paths": {
 			"version": "3.9.0",
@@ -8511,7 +8371,6 @@
 			"version": "3.13.3",
 			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.3.tgz",
 			"integrity": "sha512-otIc7O9LyxpUcQoXzj2hL4LPWKklO6LJWoJUzNa8A17Xgi4fOeDC8FBDOLHnC/Slo1CQgsZMcM6as0M76BZaig==",
-			"dev": true,
 			"optional": true
 		},
 		"unbzip2-stream": {
@@ -8528,7 +8387,6 @@
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.3.tgz",
 			"integrity": "sha512-Ft16BJcnapDKp0+J/rqFC3Rrk6Y/Ng4nzsC028k2jdDII/rdZ7Wd3pPT/6+vIIxRagwRc9K0IUX0Ra4fKvw+WQ==",
-			"dev": true,
 			"requires": {
 				"inherits": "^2.0.0",
 				"xtend": "^4.0.0"
@@ -8538,7 +8396,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/unicode-regex/-/unicode-regex-3.0.0.tgz",
 			"integrity": "sha512-WiDJdORsqgxkZrjC8WsIP573130HNn7KsB0IDnUccW2BG2b19QQNloNhVe6DKk3Aef0UcoIHhNVj7IkkcYWrNw==",
-			"dev": true,
 			"requires": {
 				"regexp-util": "^1.2.0"
 			}
@@ -8547,7 +8404,6 @@
 			"version": "9.1.0",
 			"resolved": "https://registry.npmjs.org/unified/-/unified-9.1.0.tgz",
 			"integrity": "sha512-VXOv7Ic6twsKGJDeZQ2wwPqXs2hM0KNu5Hkg9WgAZbSD1pxhZ7p8swqg583nw1Je2fhwHy6U8aEjiI79x1gvag==",
-			"dev": true,
 			"requires": {
 				"bail": "^1.0.0",
 				"extend": "^3.0.0",
@@ -8560,8 +8416,7 @@
 				"is-buffer": {
 					"version": "2.0.5",
 					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
-					"integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
-					"dev": true
+					"integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ=="
 				}
 			}
 		},
@@ -8580,20 +8435,17 @@
 		"uniq": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
-			"integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
-			"dev": true
+			"integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8="
 		},
 		"unist-util-is": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-3.0.0.tgz",
-			"integrity": "sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A==",
-			"dev": true
+			"integrity": "sha512-sVZZX3+kspVNmLWBPAB6r+7D9ZgAFPNWm66f7YNb420RlQSbn+n8rG8dGZSkrER7ZIXGQYNm5pqC3v3HopH24A=="
 		},
 		"unist-util-remove-position": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-1.1.4.tgz",
 			"integrity": "sha512-tLqd653ArxJIPnKII6LMZwH+mb5q+n/GtXQZo6S6csPRs5zB0u79Yw8ouR3wTw8wxvdJFhpP6Y7jorWdCgLO0A==",
-			"dev": true,
 			"requires": {
 				"unist-util-visit": "^1.1.0"
 			}
@@ -8602,7 +8454,6 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.3.tgz",
 			"integrity": "sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==",
-			"dev": true,
 			"requires": {
 				"@types/unist": "^2.0.2"
 			}
@@ -8611,7 +8462,6 @@
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-1.4.1.tgz",
 			"integrity": "sha512-AvGNk7Bb//EmJZyhtRUnNMEpId/AZ5Ph/KUpTI09WHQuDZHKovQ1oEv3mfmKpWKtoMzyMC4GLBm1Zy5k12fjIw==",
-			"dev": true,
 			"requires": {
 				"unist-util-visit-parents": "^2.0.0"
 			}
@@ -8620,7 +8470,6 @@
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-2.1.2.tgz",
 			"integrity": "sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==",
-			"dev": true,
 			"requires": {
 				"unist-util-is": "^3.0.0"
 			}
@@ -8748,7 +8597,6 @@
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/vfile/-/vfile-4.2.1.tgz",
 			"integrity": "sha512-O6AE4OskCG5S1emQ/4gl8zK586RqA3srz3nfK/Viy0UPToBc5Trp9BVFb1u0CjsKrAWwnpr4ifM/KBXPWwJbCA==",
-			"dev": true,
 			"requires": {
 				"@types/unist": "^2.0.0",
 				"is-buffer": "^2.0.0",
@@ -8759,22 +8607,19 @@
 				"is-buffer": {
 					"version": "2.0.5",
 					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
-					"integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
-					"dev": true
+					"integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ=="
 				}
 			}
 		},
 		"vfile-location": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/vfile-location/-/vfile-location-2.0.6.tgz",
-			"integrity": "sha512-sSFdyCP3G6Ka0CEmN83A2YCMKIieHx0EDaj5IDP4g1pa5ZJ4FJDvpO0WODLxo4LUX4oe52gmSCK7Jw4SBghqxA==",
-			"dev": true
+			"integrity": "sha512-sSFdyCP3G6Ka0CEmN83A2YCMKIieHx0EDaj5IDP4g1pa5ZJ4FJDvpO0WODLxo4LUX4oe52gmSCK7Jw4SBghqxA=="
 		},
 		"vfile-message": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-2.0.4.tgz",
 			"integrity": "sha512-DjssxRGkMvifUOJre00juHoP9DPWuzjxKuMDrhNbk2TdaYYBNMStsNhEOt3idrtI12VQYM/1+iM0KOzXi4pxwQ==",
-			"dev": true,
 			"requires": {
 				"@types/unist": "^2.0.0",
 				"unist-util-stringify-position": "^2.0.0"
@@ -8784,7 +8629,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/vnopts/-/vnopts-1.0.2.tgz",
 			"integrity": "sha512-d2rr2EFhAGHnTlURu49G7GWmiJV80HbAnkYdD9IFAtfhmxC+kSWEaZ6ZF064DJFTv9lQZQV1vuLTntyQpoanGQ==",
-			"dev": true,
 			"requires": {
 				"chalk": "^2.4.1",
 				"leven": "^2.1.0",
@@ -8795,7 +8639,6 @@
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-					"dev": true,
 					"requires": {
 						"color-convert": "^1.9.0"
 					}
@@ -8804,7 +8647,6 @@
 					"version": "2.4.2",
 					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
 					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-					"dev": true,
 					"requires": {
 						"ansi-styles": "^3.2.1",
 						"escape-string-regexp": "^1.0.5",
@@ -8815,7 +8657,6 @@
 					"version": "1.9.3",
 					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
 					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-					"dev": true,
 					"requires": {
 						"color-name": "1.1.3"
 					}
@@ -8823,26 +8664,22 @@
 				"color-name": {
 					"version": "1.1.3",
 					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-					"dev": true
+					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 				},
 				"has-flag": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-					"dev": true
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 				},
 				"leven": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
-					"integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
-					"dev": true
+					"integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA="
 				},
 				"supports-color": {
 					"version": "5.5.0",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
 					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-					"dev": true,
 					"requires": {
 						"has-flag": "^3.0.0"
 					}
@@ -8959,8 +8796,7 @@
 		"wordwrap": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-			"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
-			"dev": true
+			"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
 		},
 		"wrap-ansi": {
 			"version": "6.2.0",
@@ -9031,8 +8867,7 @@
 		"xtend": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-			"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-			"dev": true
+			"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
 		},
 		"y18n": {
 			"version": "4.0.3",
@@ -9043,20 +8878,17 @@
 		"yallist": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-			"dev": true
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
 		},
 		"yaml": {
 			"version": "1.10.2",
 			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-			"integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
-			"dev": true
+			"integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg=="
 		},
 		"yaml-unist-parser": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/yaml-unist-parser/-/yaml-unist-parser-1.3.0.tgz",
 			"integrity": "sha512-kF1OS6fi9BzqX+vVC5hp+R5mmrHLH4f19Nx8fAwb08VqUwgFDBPOOu24VZO06nSOur13CGUTgHuaw5RIzpRnCw==",
-			"dev": true,
 			"requires": {
 				"lines-and-columns": "^1.1.6",
 				"tslib": "^1.10.0",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
 	},
 	"devDependencies": {
 		"@stencil/core": "^2.0.3",
+		"@stencil/sass": "^1.4.1",
 		"@types/jest": "26.0.9",
 		"@types/puppeteer": "3.0.1",
 		"@typescript-eslint/eslint-plugin": "^4.1.0",

--- a/src/components/input/style.css
+++ b/src/components/input/style.css
@@ -23,6 +23,8 @@ input {
 	border: 0;
 	z-index: 1;
 	position: relative;
+	font-size: 1rem;
+	font-family: var(--smoothly-font-family);
 }
 smoothly-icon {
 	display: none;

--- a/src/components/menu-options/index.tsx
+++ b/src/components/menu-options/index.tsx
@@ -1,0 +1,115 @@
+import { Component, Element, h, Host, Listen, Method, Prop } from "@stencil/core"
+
+@Component({
+	tag: "smoothly-menu-options",
+	styleUrl: "style.scss",
+	shadow: true,
+})
+export class SmoothlyMenuOptions {
+	private emptyMenuElement: HTMLDivElement
+	private filteredOptions: HTMLElement[] = []
+	private highlightIndex = 0
+	@Element() element: HTMLElement
+	@Prop({ mutable: true }) emptyMenuLabel = "No Options"
+	@Prop() maxMenuHeight: "inherit"
+	@Prop({ mutable: true }) width = "85%"
+	componentDidRender() {
+		this.filterOptions("")
+	}
+	@Listen("optionHover")
+	optionHoverHandler(event: CustomEvent<{ name: string; value: string }>) {
+		if (event.detail.value)
+			this.setHighlight(event.detail.value)
+		event.stopPropagation()
+	}
+	@Method()
+	async moveHighlight(step: number) {
+		this.setHighlight((this.highlightIndex + step + this.filteredOptions.length) % this.filteredOptions.length, true)
+	}
+	@Method()
+	async setHighlight(newIndex: number | string, scrollToHighlight = false) {
+		if (typeof newIndex == "number") {
+			this.highlightIndex = newIndex
+			this.filteredOptions.forEach((option, index) => {
+				if (index == this.highlightIndex) {
+					option.setAttribute("data-highlight", "")
+					scrollToHighlight ? this.scrollTo(index, option.getBoundingClientRect().height) : undefined
+				} else
+					option.removeAttribute("data-highlight")
+			})
+		} else {
+			const value = newIndex
+			let isHighlightSet = false
+			this.filteredOptions.forEach((option, index) => {
+				const highlight = option.getAttribute("value") == value
+				this.highlightIndex = highlight ? index : this.highlightIndex
+				highlight ? option.setAttribute("data-highlight", "") : option.removeAttribute("data-highlight")
+				highlight && scrollToHighlight ? this.scrollTo(index, option.getBoundingClientRect().height) : undefined
+				isHighlightSet = highlight ? true : isHighlightSet
+			})
+			if (!isHighlightSet)
+				this.setHighlight(0, true)
+		}
+	}
+	@Method()
+	async getHighlighted(): Promise<{ name: string; value: string } | undefined> {
+		let result = undefined
+		let selectedOption: HTMLElement | null = null
+		for (let index = 0; index < this.filteredOptions.length; index++) {
+			const currentOption = this.filteredOptions[index]
+			if (index == this.highlightIndex) {
+				selectedOption = currentOption
+				break
+			}
+		}
+		if (selectedOption) {
+			const value = selectedOption.getAttribute("value")
+			const name = selectedOption.getAttribute("name")
+			if (name && value) {
+				const selection = { name, value }
+				result = selection
+			}
+		}
+		return result
+	}
+	@Method()
+	async filterOptions(keyword: string, excludeValues: string[] = []) {
+		const keywordLowercase = keyword.toLowerCase()
+		this.filteredOptions = []
+		const options = Array.from(this.element.children as HTMLCollectionOf<HTMLElement>)
+		if (options) {
+			for (const option of options) {
+				const isValidOption =
+					option.nodeName == "SMOOTHLY-OPTION" && option.hasAttribute("value") && option.hasAttribute("name")
+				const name = option.getAttribute("name")
+				const aliases = option.getAttribute("aliases")?.toLowerCase()
+				const names = `${name ? name : ""} ${aliases ? aliases : ""}`
+				const value = option.getAttribute("value")
+				const isVisible = names?.toLowerCase().includes(keywordLowercase) && value && !excludeValues.includes(value)
+				option.style.display = isValidOption && isVisible ? "" : "none"
+				if (isValidOption && isVisible)
+					this.filteredOptions.push(option)
+			}
+			this.emptyMenuElement.style.display = this.filteredOptions.length == 0 ? "block" : "none"
+		}
+	}
+	scrollTo(optionIndex: number, optionHeight: number) {
+		const menuHeight = this.element.getBoundingClientRect().height
+		const scrollPosition = this.element.scrollTop
+		const optionPosition = optionIndex * optionHeight
+		const numOptionsInMenu = Math.floor(menuHeight / optionHeight)
+		if (optionPosition - optionHeight / 2 < scrollPosition)
+			this.element.scrollTo({ top: (optionIndex - 1) * optionHeight })
+		else if (scrollPosition < optionPosition + optionHeight - menuHeight)
+			this.element.scrollTo({ top: (optionIndex + 1 - numOptionsInMenu) * optionHeight })
+	}
+
+	render() {
+		return (
+			<Host style={{ "--width": this.width, "--max-menu-height": this.maxMenuHeight }}>
+				<slot></slot>
+				<div ref={(el: HTMLDivElement) => (this.emptyMenuElement = el)}>{this.emptyMenuLabel}</div>
+			</Host>
+		)
+	}
+}

--- a/src/components/menu-options/style.scss
+++ b/src/components/menu-options/style.scss
@@ -1,0 +1,16 @@
+:host {
+	display: grid;
+	grid-template-columns: 1rf;
+	grid-template-rows: repeat();
+	max-height: 300px;
+	width: var(--width);
+	border: 1px solid black;
+	box-sizing: border-box;
+	background-color: rgb(var(--smoothly-secondary-color));
+	max-height: var(--max-menu-height);
+	overflow-y: auto;
+}
+div:last-child {
+	padding: 0.5em 1em;
+	font-style: italic;
+}

--- a/src/components/option/index.tsx
+++ b/src/components/option/index.tsx
@@ -1,0 +1,35 @@
+import { Component, Element, Event, EventEmitter, h, Host, Prop } from "@stencil/core"
+
+@Component({
+	tag: "smoothly-option",
+	styleUrl: "style.scss",
+	shadow: true,
+})
+export class SmoothlyOption {
+	@Element() element: HTMLElement
+	@Prop({ mutable: true, reflect: true }) dataHighlight = false
+	@Prop({ mutable: true, reflect: true }) name: string
+	@Prop({ mutable: true, reflect: true }) value: string
+	@Event() optionHover: EventEmitter<{ name: string; value: string }>
+	@Event() optionSelect: EventEmitter<{ name: string; value: string }>
+	onHover(event: MouseEvent) {
+		this.optionHover.emit({ name: this.name, value: this.value })
+	}
+	onSelect(event: UIEvent) {
+		if (this.value)
+			this.optionSelect.emit({ name: this.name, value: this.value })
+		else
+			throw `smoothly-option ${this.element.innerHTML} lacks value-property and can therefore not be selected`
+	}
+
+	render() {
+		return (
+			<Host onMouseDown={(e: any) => this.onSelect(e)} onMouseOver={(e: MouseEvent) => this.onHover(e)}>
+				<div>{this.name}</div>
+				<div>
+					<slot></slot>
+				</div>
+			</Host>
+		)
+	}
+}

--- a/src/components/option/style.scss
+++ b/src/components/option/style.scss
@@ -1,0 +1,11 @@
+:host {
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+	justify-content: space-between;
+	padding: 0.5em 1em;
+}
+
+:host([data-highlight]) {
+	background-color: rgb(var(--smoothly-secondary-tint));
+}

--- a/src/components/select-demo/index.tsx
+++ b/src/components/select-demo/index.tsx
@@ -51,6 +51,19 @@ export class SmoothlySelectDemo {
 				<option value="3">3</option>
 			</smoothly-select>,
 			<button onClick={() => this.alertf()}>press here</button>,
+			<smoothly-menu-options>
+				<smoothly-option name="Dog" value="dog">
+					🐶
+				</smoothly-option>
+				<smoothly-option name="Cat" value="cat">
+					🐱
+				</smoothly-option>
+				<smoothly-option name="Parrot" value="parrot"></smoothly-option>
+				<smoothly-option name="Dragon" value="dragon"></smoothly-option>
+				<smoothly-option name="Unicorn" value="unicorn">
+					🦄
+				</smoothly-option>
+			</smoothly-menu-options>,
 		]
 	}
 }

--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -1,5 +1,6 @@
 // tslint:disable-next-line: no-implicit-dependencies
 import { Config } from "@stencil/core"
+import { sass } from "@stencil/sass"
 
 export const config: Config = {
 	namespace: "smoothly",
@@ -21,4 +22,5 @@ export const config: Config = {
 	devServer: {
 		openBrowser: false,
 	},
+	plugins: [sass()],
 }


### PR DESCRIPTION
`ArrowUp/Down` does not change cursor to start/end of string in `smoothly-input`. 
This is so that when using `smoothly-input` with `smoothly-menu-options`, `ArrowUp/Down` can navigate `smoohtly-menu-options` without changing cursor position.

Specify `font` and `font-size` for `smoothly-input`, this is so identical font can be used  in autocomplete object in [component repo](https://github.com/payfunc/component)

`smoothly-input`'s variable `state` changed from `@State` to `private`. This removes unnecessary re-renderings and warnings. `smoothly-input` is already re-rendered on property `value` change.

`smoothly-menu-options` can scroll men highlighting options with arrow keys. 