### PR TITLE
Fixes for autocomplete

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1422,7 +1422,7 @@
 				"tsutils": "^3.17.1"
 			},
 			"engines": {
-				"node": "^8.10.0 || ^10.13.0 || >=11.10.1"
+				"node": "^10.12.0 || >=12.0.0"
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
@@ -2563,6 +2563,9 @@
 			"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
 			"dependencies": {
 				"ms": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=6.0"
 			}
 		},
 		"node_modules/decamelize": {
@@ -2735,9 +2738,6 @@
 				"lru-cache": "^4.1.5",
 				"semver": "^5.6.0",
 				"sigmund": "^1.0.1"
-			},
-			"bin": {
-				"editorconfig": "bin/editorconfig"
 			}
 		},
 		"node_modules/editorconfig-to-prettier": {
@@ -3587,7 +3587,7 @@
 			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
 			"integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
 			"engines": {
-				"node": ">=4"
+				"node": ">=10"
 			}
 		},
 		"node_modules/eslint/node_modules/@babel/code-frame": {
@@ -4414,7 +4414,7 @@
 			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
 			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
 			"engines": {
-				"node": ">=4"
+				"node": ">=8"
 			}
 		},
 		"node_modules/globby": {
@@ -4595,9 +4595,9 @@
 			}
 		},
 		"node_modules/hosted-git-info": {
-			"version": "2.8.9",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
-			"integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw=="
+			"version": "2.8.8",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
+			"integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg=="
 		},
 		"node_modules/html-element-attributes": {
 			"version": "2.2.1",
@@ -4836,7 +4836,10 @@
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
 			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-			"dev": true
+			"dev": true,
+			"engines": {
+				"node": ">=4"
+			}
 		},
 		"node_modules/is-callable": {
 			"version": "1.2.2",
@@ -6369,7 +6372,7 @@
 				"picomatch": "^2.0.5"
 			},
 			"engines": {
-				"node": ">=8"
+				"node": ">=8.6"
 			}
 		},
 		"node_modules/mime-db": {
@@ -7851,7 +7854,7 @@
 			"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
 			"dev": true,
 			"engines": {
-				"node": ">=8"
+				"node": ">=4"
 			}
 		},
 		"node_modules/resolve-url": {
@@ -8227,7 +8230,10 @@
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
 			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
 			"bin": {
-				"semver": "bin/semver"
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/semver-compare": {
@@ -8664,11 +8670,6 @@
 				"jsbn": "~0.1.0",
 				"safer-buffer": "^2.0.2",
 				"tweetnacl": "~0.14.0"
-			},
-			"bin": {
-				"sshpk-conv": "bin/sshpk-conv",
-				"sshpk-sign": "bin/sshpk-sign",
-				"sshpk-verify": "bin/sshpk-verify"
 			},
 			"engines": {
 				"node": ">=0.10.0"
@@ -9291,7 +9292,7 @@
 			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
 			"integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
 			"engines": {
-				"node": ">=8"
+				"node": ">=10"
 			}
 		},
 		"node_modules/typedarray-to-buffer": {
@@ -13644,9 +13645,9 @@
 			}
 		},
 		"hosted-git-info": {
-			"version": "2.8.9",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
-			"integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw=="
+			"version": "2.8.8",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
+			"integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg=="
 		},
 		"html-element-attributes": {
 			"version": "2.2.1",

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -5,7 +5,7 @@
  * It contains typing information for all components that exist in this project.
  */
 import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
-import { Autocomplete, Color, Expand, Fill, Message, Notice, OptionType, Trigger } from "./model";
+import { Color, Expand, Fill, Message, Notice, OptionType, Trigger } from "./model";
 import { Direction, Type } from "tidily";
 import { CountryCode, Currency, DateTime } from "isoly";
 export namespace Components {
@@ -64,7 +64,7 @@ export namespace Components {
     interface SmoothlyIconDemo {
     }
     interface SmoothlyInput {
-        "autocomplete": Autocomplete;
+        "autocomplete": boolean;
         "currency"?: Currency;
         "disabled": boolean;
         "maxLength": number;
@@ -86,9 +86,7 @@ export namespace Components {
         "getHighlighted": () => Promise<OptionType | undefined>;
         "maxMenuHeight": "inherit";
         "moveHighlight": (step: number) => Promise<void>;
-        /**
-          * @Prop options: is only needed if ig-options are inserted via slot
-         */
+        "optionStyle": any;
         "options": OptionType[];
         "order": boolean;
         "setHighlight": (newIndex: number | string, scrollToHighlight?: boolean) => Promise<void>;
@@ -108,6 +106,7 @@ export namespace Components {
         "label": string;
         "maxMenuHeight": "inherit";
         "multiple": boolean;
+        "optionStyle": any;
         "options": OptionType[];
         "selections": { name: string; value: string }[];
     }
@@ -480,7 +479,7 @@ declare namespace LocalJSX {
     interface SmoothlyIconDemo {
     }
     interface SmoothlyInput {
-        "autocomplete"?: Autocomplete;
+        "autocomplete"?: boolean;
         "currency"?: Currency;
         "disabled"?: boolean;
         "maxLength"?: number;
@@ -498,9 +497,7 @@ declare namespace LocalJSX {
     interface SmoothlyMenuOptions {
         "emptyMenuLabel"?: string;
         "maxMenuHeight"?: "inherit";
-        /**
-          * @Prop options: is only needed if ig-options are inserted via slot
-         */
+        "optionStyle"?: any;
         "options"?: OptionType[];
         "order"?: boolean;
     }
@@ -522,6 +519,7 @@ declare namespace LocalJSX {
         "label"?: string;
         "maxMenuHeight"?: "inherit";
         "multiple"?: boolean;
+        "optionStyle"?: any;
         "options"?: OptionType[];
         "selections"?: { name: string; value: string }[];
     }

--- a/src/components/input/index.tsx
+++ b/src/components/input/index.tsx
@@ -1,7 +1,6 @@
 import { Component, Event, EventEmitter, h, Host, Method, Prop, Watch } from "@stencil/core"
 import { Currency } from "isoly"
 import { Action, Converter, Direction, Formatter, get, Settings, State, StateEditor, Type } from "tidily"
-import { Autocomplete } from "../../model"
 @Component({
 	tag: "smoothly-input",
 	styleUrl: "style.css",
@@ -19,7 +18,7 @@ export class SmoothlyInput {
 	@Prop({ mutable: true, reflect: true }) required = false
 	@Prop({ mutable: true }) minLength = 0
 	@Prop({ mutable: true }) maxLength: number = Number.POSITIVE_INFINITY
-	@Prop({ mutable: true }) autocomplete: Autocomplete = "on"
+	@Prop({ mutable: true }) autocomplete = true
 	@Prop({ mutable: true }) pattern: RegExp | undefined
 	@Prop({ mutable: true }) placeholder: string | undefined
 	@Prop({ mutable: true }) disabled = false
@@ -189,6 +188,7 @@ export class SmoothlyInput {
 		)
 	}
 	render() {
+		console.log(this.state)
 		return (
 			<Host class={{ "has-value": this.state?.value != "" }}>
 				<input
@@ -196,7 +196,7 @@ export class SmoothlyInput {
 					type={this.state.type}
 					placeholder={this.placeholder}
 					required={this.required}
-					autocomplete={this.state.autocomplete}
+					autocomplete={this.autocomplete ? this.state.autocomplete : "off"}
 					disabled={this.disabled}
 					pattern={this.state.pattern && this.state.pattern.source}
 					value={this.state.value}

--- a/src/components/menu-options/index.tsx
+++ b/src/components/menu-options/index.tsx
@@ -1,4 +1,4 @@
-import { Component, Element, h, Host, Listen, Method, Prop, State } from "@stencil/core"
+import { Component, Element, h, Host, Listen, Method, Prop, State, Watch } from "@stencil/core"
 import { OptionType } from "../../model"
 
 @Component({
@@ -14,8 +14,12 @@ export class SmoothlyMenuOptions {
 	@Prop({ mutable: true }) emptyMenuLabel = "No Options"
 	@Prop() maxMenuHeight: "inherit"
 	@Prop() order = false
-	/** @Prop options: is only needed if ig-options are inserted via slot */
+	@Prop() optionStyle: any
 	@Prop({ mutable: true, reflect: true }) options: OptionType[] = []
+	@Watch("options")
+	optionsChangeHandler(newOptions: OptionType[]) {
+		this.highlightIndex = 0
+	}
 	@Listen("optionHover")
 	optionHoverHandler(event: CustomEvent<{ value: any; name: string }>) {
 		if (event.detail.value)
@@ -102,6 +106,7 @@ export class SmoothlyMenuOptions {
 				{this.filteredOptions.length > 0 ? (
 					this.filteredOptions.map((option, index) => (
 						<smoothly-option
+							style={this.optionStyle}
 							ref={el => index == 0 && (this.firstOptionsElement = el ?? this.firstOptionsElement)}
 							value={option.value}
 							name={option.name}

--- a/src/components/option/style.scss
+++ b/src/components/option/style.scss
@@ -7,5 +7,14 @@
 }
 
 :host([data-highlight]) {
-	background-color: rgb(var(--smoothly-secondary-tint));
+	background-color: rgb(var(--smoothly-primary-color));
+	color: rgb(var(--smoothly-primary-contrast));
+	div:last-child {
+		color: rgba(var(--smoothly-primary-contrast), 0.8);
+	}
+}
+
+:host div:last-child {
+	color: rgba(var(--smoothly-default-contrast), 0.8);
+	font-style: italic;
 }

--- a/src/components/picker/index.tsx
+++ b/src/components/picker/index.tsx
@@ -14,6 +14,7 @@ export class SmoothlyPicker {
 	@State() isOpen: boolean
 	@Prop() maxMenuHeight: "inherit"
 	@Prop({ reflect: true }) multiple = false
+	@Prop() optionStyle: any
 	@Prop({ reflect: true }) options: OptionType[]
 	@Prop({ reflect: true }) label: string
 	@Prop({ mutable: true }) selections: { name: string; value: string }[] = []
@@ -152,6 +153,7 @@ export class SmoothlyPicker {
 				<smoothly-icon name="close" onClick={(e: MouseEvent) => this.onCrossClick(e)}></smoothly-icon>
 				<smoothly-menu-options
 					style={{ width: "100%" }}
+					optionStyle={this.optionStyle}
 					order={true}
 					max-menu-height={this.maxMenuHeight}
 					ref={(el: HTMLSmoothlyMenuOptionsElement) => (this.menuElement = el)}

--- a/src/model/OptionType.ts
+++ b/src/model/OptionType.ts
@@ -3,5 +3,4 @@ export type OptionType = {
 	name: string
 	aliases?: string[]
 	description?: HTMLElement | string
-	styles?: any
 }


### PR DESCRIPTION
- Native [autocomplete](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete) can be turned `off`, on smoothly input. Previously `smoothly-input` had unused Prop `autocomplete`.
- Style for `smoothly-option` can be set on `smoothly-menu-options` with Prop `option-style`
- Highlighted `smoothly-option` uses primary color for clarity.
- option with index 0 is automatically highlighted when `menu-options.options` are changed.