### PR TITLE
Export OptionType

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
 export { Components, JSX } from "./components"
 export { App } from "./components/App"
-export { Autocomplete, ClientIdentifier, Color, Expand, Fill, Message, Notice, Trigger } from "./model"
+export { Autocomplete, ClientIdentifier, Color, Expand, Fill, Message, Notice, Trigger, OptionType } from "./model"


### PR DESCRIPTION
OptionType was not properly exported before.
This export is necessery for autocomplete to import `OptionType` correctly