### PR TITLE
Style smoothly-dialog for better contrast

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -34,6 +34,8 @@ export namespace Components {
         "header": string | undefined;
         "open": boolean;
     }
+    interface SmoothlyDialogDemo {
+    }
     interface SmoothlyDisplay {
         "country"?: CountryCode.Alpha2;
         "currency"?: Currency;
@@ -232,6 +234,12 @@ declare global {
     var HTMLSmoothlyDialogElement: {
         prototype: HTMLSmoothlyDialogElement;
         new (): HTMLSmoothlyDialogElement;
+    };
+    interface HTMLSmoothlyDialogDemoElement extends Components.SmoothlyDialogDemo, HTMLStencilElement {
+    }
+    var HTMLSmoothlyDialogDemoElement: {
+        prototype: HTMLSmoothlyDialogDemoElement;
+        new (): HTMLSmoothlyDialogDemoElement;
     };
     interface HTMLSmoothlyDisplayElement extends Components.SmoothlyDisplay, HTMLStencilElement {
     }
@@ -450,6 +458,7 @@ declare global {
         "smoothly-app-demo": HTMLSmoothlyAppDemoElement;
         "smoothly-checkbox": HTMLSmoothlyCheckboxElement;
         "smoothly-dialog": HTMLSmoothlyDialogElement;
+        "smoothly-dialog-demo": HTMLSmoothlyDialogDemoElement;
         "smoothly-display": HTMLSmoothlyDisplayElement;
         "smoothly-display-amount": HTMLSmoothlyDisplayAmountElement;
         "smoothly-display-date-time": HTMLSmoothlyDisplayDateTimeElement;
@@ -517,6 +526,8 @@ declare namespace LocalJSX {
         "color"?: Color | undefined;
         "header"?: string | undefined;
         "open"?: boolean;
+    }
+    interface SmoothlyDialogDemo {
     }
     interface SmoothlyDisplay {
         "country"?: CountryCode.Alpha2;
@@ -698,6 +709,7 @@ declare namespace LocalJSX {
         "smoothly-app-demo": SmoothlyAppDemo;
         "smoothly-checkbox": SmoothlyCheckbox;
         "smoothly-dialog": SmoothlyDialog;
+        "smoothly-dialog-demo": SmoothlyDialogDemo;
         "smoothly-display": SmoothlyDisplay;
         "smoothly-display-amount": SmoothlyDisplayAmount;
         "smoothly-display-date-time": SmoothlyDisplayDateTime;
@@ -745,6 +757,7 @@ declare module "@stencil/core" {
             "smoothly-app-demo": LocalJSX.SmoothlyAppDemo & JSXBase.HTMLAttributes<HTMLSmoothlyAppDemoElement>;
             "smoothly-checkbox": LocalJSX.SmoothlyCheckbox & JSXBase.HTMLAttributes<HTMLSmoothlyCheckboxElement>;
             "smoothly-dialog": LocalJSX.SmoothlyDialog & JSXBase.HTMLAttributes<HTMLSmoothlyDialogElement>;
+            "smoothly-dialog-demo": LocalJSX.SmoothlyDialogDemo & JSXBase.HTMLAttributes<HTMLSmoothlyDialogDemoElement>;
             "smoothly-display": LocalJSX.SmoothlyDisplay & JSXBase.HTMLAttributes<HTMLSmoothlyDisplayElement>;
             "smoothly-display-amount": LocalJSX.SmoothlyDisplayAmount & JSXBase.HTMLAttributes<HTMLSmoothlyDisplayAmountElement>;
             "smoothly-display-date-time": LocalJSX.SmoothlyDisplayDateTime & JSXBase.HTMLAttributes<HTMLSmoothlyDisplayDateTimeElement>;

--- a/src/components/app-demo/index.tsx
+++ b/src/components/app-demo/index.tsx
@@ -47,10 +47,10 @@ export class SmoothlyAppDemo {
 				<smoothly-room path="input" label="Input">
 					<smoothly-input-demo />
 				</smoothly-room>
-				<smoothly-room path="dialog" label="Dialog" reactive>
+				<smoothly-room path="dialog" label="Dialog">
 					<smoothly-dialog-demo />
 				</smoothly-room>
-				<smoothly-room path="display" label="Display" icon="eye-outline" reactive>
+				<smoothly-room path="display" label="Display" icon="eye-outline">
 					<smoothly-display-demo />
 				</smoothly-room>
 				<smoothly-room path="table" label="Table">

--- a/src/components/app-demo/index.tsx
+++ b/src/components/app-demo/index.tsx
@@ -47,7 +47,10 @@ export class SmoothlyAppDemo {
 				<smoothly-room path="input" label="Input">
 					<smoothly-input-demo />
 				</smoothly-room>
-				<smoothly-room path="display" label="Display" icon="eye-outline">
+				<smoothly-room path="dialog" label="Dialog" reactive>
+					<smoothly-dialog-demo />
+				</smoothly-room>
+				<smoothly-room path="display" label="Display" icon="eye-outline" reactive>
 					<smoothly-display-demo />
 				</smoothly-room>
 				<smoothly-room path="table" label="Table">

--- a/src/components/dialog-demo/index.tsx
+++ b/src/components/dialog-demo/index.tsx
@@ -1,0 +1,14 @@
+import { Component, h } from "@stencil/core"
+
+@Component({
+	tag: "smoothly-dialog-demo",
+})
+export class SmoothlyDialogDemo {
+	render() {
+		return (
+			<smoothly-dialog color="default" style={{ "margin-top": "6vh" }} closable>
+				<smoothly-frame url="https://www.wikipedia.org/" name="parent" style={{ height: "80vh" }}></smoothly-frame>
+			</smoothly-dialog>
+		)
+	}
+}

--- a/src/components/dialog/index.tsx
+++ b/src/components/dialog/index.tsx
@@ -10,7 +10,7 @@ export class SmoothlyDialog {
 	@Prop({ reflect: true }) color: Color | undefined
 	@Prop({ mutable: true, reflect: true }) open = true
 	@Prop({ reflect: true }) closable = false
-	@Prop() header: string | undefined
+	@Prop({ reflect: true }) header: string | undefined
 	@Listen("trigger")
 	TriggerListener(event: CustomEvent<Trigger>) {
 		if (Trigger.is(event.detail) && event.detail.name == "close")

--- a/src/components/dialog/style.css
+++ b/src/components/dialog/style.css
@@ -17,6 +17,10 @@
 	margin-top: 2em;
 	color: rgb(var(--smoothly-primary-contrast));
 	background: rgb(var(--smoothly-primary-color));
+	border-color: rgb(var(--smoothly-primary-color));
+}
+:host:not([header]) header {
+	border: none;
 }
 :host > * {
 	position: relative;
@@ -37,12 +41,25 @@
 	border-bottom-left-radius: 8px;
 	border-bottom-right-radius: 8px;
 	margin-bottom: 2em;
+	border: 1px solid rgb(var(--smoothly-default-contrast));
+	box-sizing: border-box;
+	overflow: hidden;
+}
+:host:not([header]) main {
+	border-radius: 8px;
 }
 :host > * > smoothly-trigger {
 	position: absolute;
 	right: -2em;
 	top: -2em;
 	z-index: 1;
+}
+:host > * > smoothly-trigger:hover {
+	border-color: transparent;
+}
+:host smoothly-icon {
+	background-color: rgb(var(--smoothly-color)); 
+	border-radius: 50%;
 }
 :host > * > * {
 	margin: 10px;

--- a/src/components/icon/style.css
+++ b/src/components/icon/style.css
@@ -1,6 +1,8 @@
+:host[size] {
+	background: none;
+}
 :host {
-	display: block;
-	background: none !important;
+	display:block;
 }
 :host[hidden] {
 	display: none;


### PR DESCRIPTION
- Added dialog-demo room
- Add border around `smoothly-dialog`.
- Dialog border adapts to if the `header` attribute is set.
- Styled close button to have contrasting background.
- Colors of close button can be set with the `color` attribute on `smoothly-dialog`

![dialog-close-colors](https://user-images.githubusercontent.com/14332757/127123847-5ff7ee1f-5390-4142-8de0-81efe3a5ef88.png)
