### PR TITLE
App header overflow

### DIFF
--- a/src/components/app-demo/index.tsx
+++ b/src/components/app-demo/index.tsx
@@ -16,10 +16,10 @@ export class SmoothlyAppDemo {
 				<a slot="nav-start" href="https://google.com">
 					External
 				</a>
-				<span slot="header">
+				<span slot="header" style={{ width: "100%", maxWidth: "500px" }}>
 					<smoothly-picker
 						label="All Animals Selected"
-						style={{ width: "500px" }}
+						style={{ minWidth: "100px" }}
 						labelSetting="hide"
 						empty-menu-label="Sorry, we're out of options."
 						max-height="58px"

--- a/src/components/app/style.css
+++ b/src/components/app/style.css
@@ -58,6 +58,10 @@ smoothly-app > smoothly-notifier > header a {
 	text-decoration: inherit;
 }
 
+smoothly-app > smoothly-notifier > header > nav {
+	flex-shrink: 0;
+}
+
 smoothly-app > smoothly-notifier > header > h1,
 smoothly-app > smoothly-notifier > header > nav,
 smoothly-app > smoothly-notifier > header > nav > ul,


### PR DESCRIPTION
- [x] https://github.com/payfunc/smoothly/pull/223

Nav bar does not wrap to next line when there width is to small.

![nav-flex-shrink](https://user-images.githubusercontent.com/14332757/128704017-faf864a1-45b0-4ca8-b260-c66a3dd4c86f.png)
