### PR TITLE
Fix text overflow on logo.

### DIFF
--- a/src/components/app/style.css
+++ b/src/components/app/style.css
@@ -69,10 +69,16 @@ smoothly-app > smoothly-notifier > header > nav > ul > li > *:not(a) {
 	height: 100%;
 	margin: 0;
 }
+smoothly-app > smoothly-notifier > header > h1 a {
+	overflow: hidden;
+	user-select: none;
+}
+smoothly-app > smoothly-notifier > header > nav > ul > li a {
+	line-height: 1.6cm;
+}
 smoothly-app > smoothly-notifier > header > h1 a,
 smoothly-app > smoothly-notifier > header > nav > ul > li a {
 	display: inline-block;
-	line-height: 1.6cm;
 	height: 100%;
 	padding: 0 0.4cm;
 	text-decoration: none;


### PR DESCRIPTION
- [x] Merge https://github.com/payfunc/smoothly/pull/241 first

Text made red in the picture to show the difference.
![logo-text-overflow-fix](https://user-images.githubusercontent.com/14332757/135984646-69bb9d5b-219d-4a87-aa7c-a3ea73396c83.png)
