### PR TITLE
Possible fix, locale key bug in chrome for input

### DIFF
--- a/src/components/input/index.tsx
+++ b/src/components/input/index.tsx
@@ -113,7 +113,7 @@ export class SmoothlyInput {
 		const after = this.formatter.format(StateEditor.copy(this.formatter.unformat(StateEditor.copy({ ...this.state }))))
 		this.updateBackend(after, backend)
 	}
-	onKeyDown(event: KeyboardEvent) {
+	onKeyPress(event: KeyboardEvent) {
 		if (event.key && !(event.key == "Unidentified")) {
 			const backend = event.target as HTMLInputElement
 			this.state = {
@@ -208,7 +208,7 @@ export class SmoothlyInput {
 					onFocus={e => this.onFocus(e)}
 					onClick={e => this.onClick(e)}
 					onBlur={e => this.onBlur(e)}
-					onKeyDown={e => this.onKeyDown(e)}
+					onKeyPress={e => this.onKeyPress(e)}
 					ref={(el: HTMLInputElement) => (this.inputElement = el)}
 					onPaste={e => this.onPaste(e)}></input>
 				<smoothly-icon name="alert-circle" color="danger" fill="clear" size="small"></smoothly-icon>


### PR DESCRIPTION
- [ ] Must check that this works


This is a possible fix to the key locale problem in chrome. For example it makes it difficult to write `@` on swedish keyboard.

However I could not reproduce the bug on my laptop (maybe my Chrome Version 94.0.4606.81 is too new).
I will try this branch with the NUC to see if it solves anything. Also @nilssonemma feel free to try on your computer (if you ever get time).

Also, this website is helpful to see what keyboard events are triggered in the browser.
https://w3c.github.io/uievents/tools/key-event-viewer.html
