### PR TITLE
replaced <content> with <slot name=content>

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -86,7 +86,7 @@ export const App: FunctionalComponent<{ label: string }> = (attributes, nodes, u
 				</nav>
 				{children.filter(child => child.vattrs?.slot == "header").map(child => child.node)}
 			</header>
-			<content>
+			<slot name="content">
 				<Router.Switch>
 					{children
 						.filter(child => child.vattrs?.path != undefined)
@@ -98,7 +98,7 @@ export const App: FunctionalComponent<{ label: string }> = (attributes, nodes, u
 							)
 						)}
 				</Router.Switch>
-			</content>
+			</slot>
 		</smoothly-app>
 	)
 }


### PR DESCRIPTION
The `<content>` element is [deprecated](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/content) and caused `<header>` to be under `<content>` in the HTML structure rendered by the browser. Changing `<content>` to a named `<slot>` results in expected HTML structure in the browser.