### PR TITLE
Table icon fix

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -284,6 +284,110 @@ export namespace Components {
         "data": string;
     }
 }
+export interface SmoothlyAccordionItemCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLSmoothlyAccordionItemElement;
+}
+export interface SmoothlyCalendarCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLSmoothlyCalendarElement;
+}
+export interface SmoothlyCheckboxCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLSmoothlyCheckboxElement;
+}
+export interface SmoothlyDisplayDemoCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLSmoothlyDisplayDemoElement;
+}
+export interface SmoothlyFrameCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLSmoothlyFrameElement;
+}
+export interface SmoothlyInputCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLSmoothlyInputElement;
+}
+export interface SmoothlyInputDateCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLSmoothlyInputDateElement;
+}
+export interface SmoothlyInputDateRangeCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLSmoothlyInputDateRangeElement;
+}
+export interface SmoothlyInputMonthCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLSmoothlyInputMonthElement;
+}
+export interface SmoothlyItemCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLSmoothlyItemElement;
+}
+export interface SmoothlyNotificationCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLSmoothlyNotificationElement;
+}
+export interface SmoothlyOptionCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLSmoothlyOptionElement;
+}
+export interface SmoothlyPickerCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLSmoothlyPickerElement;
+}
+export interface SmoothlyPopupCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLSmoothlyPopupElement;
+}
+export interface SmoothlyRadioCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLSmoothlyRadioElement;
+}
+export interface SmoothlyReorderCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLSmoothlyReorderElement;
+}
+export interface SmoothlySelectCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLSmoothlySelectElement;
+}
+export interface SmoothlySelectorCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLSmoothlySelectorElement;
+}
+export interface SmoothlySubmitCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLSmoothlySubmitElement;
+}
+export interface SmoothlyTabCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLSmoothlyTabElement;
+}
+export interface SmoothlyTableCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLSmoothlyTableElement;
+}
+export interface SmoothlyTableExpandableCellCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLSmoothlyTableExpandableCellElement;
+}
+export interface SmoothlyTableHeaderCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLSmoothlyTableHeaderElement;
+}
+export interface SmoothlyTableRowCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLSmoothlyTableRowElement;
+}
+export interface SmoothlyTriggerCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLSmoothlyTriggerElement;
+}
+export interface SmoothlyTriggerSourceCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLSmoothlyTriggerSourceElement;
+}
 declare global {
     interface HTMLSmoothlyAccordionElement extends Components.SmoothlyAccordion, HTMLStencilElement {
     }
@@ -687,10 +791,10 @@ declare namespace LocalJSX {
     interface SmoothlyAccordionItem {
         "brand"?: string | string[];
         "name"?: string;
-        "onSmoothlyAccordionItemDidLoad"?: (event: CustomEvent<void>) => void;
-        "onSmoothlyAccordionItemDidUnload"?: (event: CustomEvent<void>) => void;
-        "onSmoothlyClose"?: (event: CustomEvent<{ name: string; open: boolean }>) => void;
-        "onSmoothlyOpen"?: (event: CustomEvent<{ name: string; open: boolean }>) => void;
+        "onSmoothlyAccordionItemDidLoad"?: (event: SmoothlyAccordionItemCustomEvent<void>) => void;
+        "onSmoothlyAccordionItemDidUnload"?: (event: SmoothlyAccordionItemCustomEvent<void>) => void;
+        "onSmoothlyClose"?: (event: SmoothlyAccordionItemCustomEvent<{ name: string; open: boolean }>) => void;
+        "onSmoothlyOpen"?: (event: SmoothlyAccordionItemCustomEvent<{ name: string; open: boolean }>) => void;
         "open"?: boolean;
     }
     interface SmoothlyApp {
@@ -719,18 +823,18 @@ declare namespace LocalJSX {
         "max"?: Date;
         "min"?: Date;
         "month"?: Date;
-        "onDateRangeSet"?: (event: CustomEvent<DateRange>) => void;
-        "onDateSet"?: (event: CustomEvent<Date>) => void;
-        "onEndChanged"?: (event: CustomEvent<Date>) => void;
-        "onStartChanged"?: (event: CustomEvent<Date>) => void;
-        "onValueChanged"?: (event: CustomEvent<Date>) => void;
+        "onDateRangeSet"?: (event: SmoothlyCalendarCustomEvent<DateRange>) => void;
+        "onDateSet"?: (event: SmoothlyCalendarCustomEvent<Date>) => void;
+        "onEndChanged"?: (event: SmoothlyCalendarCustomEvent<Date>) => void;
+        "onStartChanged"?: (event: SmoothlyCalendarCustomEvent<Date>) => void;
+        "onValueChanged"?: (event: SmoothlyCalendarCustomEvent<Date>) => void;
         "start"?: Date;
         "value"?: Date;
     }
     interface SmoothlyCheckbox {
         "disabled"?: boolean;
         "intermediate"?: boolean;
-        "onChecked"?: (event: CustomEvent<{ selected: boolean }>) => void;
+        "onChecked"?: (event: SmoothlyCheckboxCustomEvent<{ selected: boolean }>) => void;
         "selectAll"?: boolean;
         "selected"?: boolean;
         "size"?: "tiny" | "small" | "medium" | "large";
@@ -757,12 +861,12 @@ declare namespace LocalJSX {
         "datetime"?: DateTime;
     }
     interface SmoothlyDisplayDemo {
-        "onNotice"?: (event: CustomEvent<Notice>) => void;
+        "onNotice"?: (event: SmoothlyDisplayDemoCustomEvent<Notice>) => void;
     }
     interface SmoothlyFrame {
         "name"?: string;
-        "onMessage"?: (event: CustomEvent<Message<any>>) => void;
-        "onTrigger"?: (event: CustomEvent<Trigger>) => void;
+        "onMessage"?: (event: SmoothlyFrameCustomEvent<Message<any>>) => void;
+        "onTrigger"?: (event: SmoothlyFrameCustomEvent<Trigger>) => void;
         "origin"?: string | undefined;
         "url"?: string;
     }
@@ -785,7 +889,7 @@ declare namespace LocalJSX {
         "maxLength"?: number;
         "minLength"?: number;
         "name"?: string;
-        "onSmoothlyChanged"?: (event: CustomEvent<{ name: string; value: any }>) => void;
+        "onSmoothlyChanged"?: (event: SmoothlyInputCustomEvent<{ name: string; value: any }>) => void;
         "pattern"?: RegExp | undefined;
         "placeholder"?: string | undefined;
         "required"?: boolean;
@@ -797,7 +901,7 @@ declare namespace LocalJSX {
         "disabled"?: boolean;
         "max"?: Date;
         "min"?: Date;
-        "onValueChanged"?: (event: CustomEvent<Date>) => void;
+        "onValueChanged"?: (event: SmoothlyInputDateCustomEvent<Date>) => void;
         "open"?: boolean;
         "value"?: Date;
     }
@@ -805,8 +909,8 @@ declare namespace LocalJSX {
         "end"?: Date;
         "max"?: Date;
         "min"?: Date;
-        "onDateRangeSelected"?: (event: CustomEvent<{ start: Date; end: Date }>) => void;
-        "onValueChanged"?: (event: CustomEvent<Date>) => void;
+        "onDateRangeSelected"?: (event: SmoothlyInputDateRangeCustomEvent<{ start: Date; end: Date }>) => void;
+        "onValueChanged"?: (event: SmoothlyInputDateRangeCustomEvent<Date>) => void;
         "open"?: boolean;
         "showLabel"?: boolean;
         "start"?: Date;
@@ -815,11 +919,11 @@ declare namespace LocalJSX {
     interface SmoothlyInputDemo {
     }
     interface SmoothlyInputMonth {
-        "onValueChanged"?: (event: CustomEvent<Date>) => void;
+        "onValueChanged"?: (event: SmoothlyInputMonthCustomEvent<Date>) => void;
         "value"?: Date;
     }
     interface SmoothlyItem {
-        "onItemSelected"?: (event: CustomEvent<void>) => void;
+        "onItemSelected"?: (event: SmoothlyItemCustomEvent<void>) => void;
         "selected"?: boolean;
         "value"?: any;
     }
@@ -833,7 +937,7 @@ declare namespace LocalJSX {
     }
     interface SmoothlyNotification {
         "notice"?: Notice;
-        "onRemove"?: (event: CustomEvent<Notice>) => void;
+        "onRemove"?: (event: SmoothlyNotificationCustomEvent<Notice>) => void;
     }
     interface SmoothlyNotifier {
     }
@@ -842,8 +946,8 @@ declare namespace LocalJSX {
         "dataHighlight"?: boolean;
         "divider"?: boolean;
         "name"?: string;
-        "onOptionHover"?: (event: CustomEvent<{ value: any; name: string }>) => void;
-        "onOptionSelect"?: (event: CustomEvent<{ value: any; name: string }>) => void;
+        "onOptionHover"?: (event: SmoothlyOptionCustomEvent<{ value: any; name: string }>) => void;
+        "onOptionSelect"?: (event: SmoothlyOptionCustomEvent<{ value: any; name: string }>) => void;
         "value"?: string;
     }
     interface SmoothlyPicker {
@@ -853,7 +957,7 @@ declare namespace LocalJSX {
         "maxHeight"?: string;
         "maxMenuHeight"?: "inherit";
         "multiple"?: boolean;
-        "onMenuClose"?: (event: CustomEvent<OptionType[]>) => void;
+        "onMenuClose"?: (event: SmoothlyPickerCustomEvent<OptionType[]>) => void;
         "optionStyle"?: any;
         "options"?: OptionType[];
         "selectNoneName"?: string;
@@ -862,7 +966,7 @@ declare namespace LocalJSX {
     }
     interface SmoothlyPopup {
         "direction"?: "up" | "down";
-        "onPopup"?: (event: CustomEvent<boolean>) => void;
+        "onPopup"?: (event: SmoothlyPopupCustomEvent<boolean>) => void;
         "visible"?: boolean;
     }
     interface SmoothlyQuiet {
@@ -871,7 +975,7 @@ declare namespace LocalJSX {
     interface SmoothlyRadio {
         "checked"?: boolean;
         "name"?: string;
-        "onSmoothlySelected"?: (event: CustomEvent<{ name: string; value: string }>) => void;
+        "onSmoothlySelected"?: (event: SmoothlyRadioCustomEvent<{ name: string; value: string }>) => void;
         "tabIndex"?: number;
         "value"?: string;
     }
@@ -879,7 +983,7 @@ declare namespace LocalJSX {
         "orientation"?: "horizontal" | "vertical";
     }
     interface SmoothlyReorder {
-        "onReorder"?: (event: CustomEvent<[number, number]>) => void;
+        "onReorder"?: (event: SmoothlyReorderCustomEvent<[number, number]>) => void;
     }
     interface SmoothlyRoom {
         "icon"?: string;
@@ -890,13 +994,13 @@ declare namespace LocalJSX {
     interface SmoothlySelect {
         "background"?: string;
         "identifier"?: string;
-        "onSelectionChanged"?: (event: CustomEvent<{ identifier: string; value: string }>) => void;
+        "onSelectionChanged"?: (event: SmoothlySelectCustomEvent<{ identifier: string; value: string }>) => void;
         "value"?: string;
     }
     interface SmoothlySelectDemo {
     }
     interface SmoothlySelector {
-        "onSelected"?: (event: CustomEvent<any>) => void;
+        "onSelected"?: (event: SmoothlySelectorCustomEvent<any>) => void;
     }
     interface SmoothlySkeleton {
         "align"?: "left" | "center" | "right";
@@ -915,7 +1019,7 @@ declare namespace LocalJSX {
         "disabled"?: boolean;
         "expand"?: Expand;
         "fill"?: Fill;
-        "onSubmit"?: (event: CustomEvent<{ [key: string]: string }>) => void;
+        "onSubmit"?: (event: SmoothlySubmitCustomEvent<{ [key: string]: string }>) => void;
         "prevent"?: boolean;
         "processing"?: boolean;
     }
@@ -926,13 +1030,13 @@ declare namespace LocalJSX {
     }
     interface SmoothlyTab {
         "label"?: string;
-        "onExpansionOpen"?: (event: CustomEvent<HTMLElement>) => void;
+        "onExpansionOpen"?: (event: SmoothlyTabCustomEvent<HTMLElement>) => void;
         "open"?: boolean;
     }
     interface SmoothlyTabSwitch {
     }
     interface SmoothlyTable {
-        "onLoadMore"?: (event: CustomEvent<void>) => void;
+        "onLoadMore"?: (event: SmoothlyTableCustomEvent<void>) => void;
     }
     interface SmoothlyTableCell {
     }
@@ -940,20 +1044,20 @@ declare namespace LocalJSX {
     }
     interface SmoothlyTableExpandableCell {
         "align"?: "left" | "center" | "right";
-        "onExpansionLoaded"?: (event: CustomEvent<void>) => void;
-        "onExpansionOpen"?: (event: CustomEvent<HTMLElement>) => void;
+        "onExpansionLoaded"?: (event: SmoothlyTableExpandableCellCustomEvent<void>) => void;
+        "onExpansionOpen"?: (event: SmoothlyTableExpandableCellCustomEvent<HTMLElement>) => void;
         "open"?: boolean;
     }
     interface SmoothlyTableExpandableRow {
     }
     interface SmoothlyTableHeader {
         "name"?: string;
-        "onSort"?: (event: CustomEvent<{ property: string; direction: "ascending" | "descending" }>) => void;
+        "onSort"?: (event: SmoothlyTableHeaderCustomEvent<{ property: string; direction: "ascending" | "descending" }>) => void;
         "sortDirection"?: "ascending" | "descending";
     }
     interface SmoothlyTableRow {
         "align"?: "left" | "center" | "right";
-        "onExpansionOpen"?: (event: CustomEvent<HTMLElement>) => void;
+        "onExpansionOpen"?: (event: SmoothlyTableRowCustomEvent<HTMLElement>) => void;
         "open"?: boolean;
     }
     interface SmoothlyTrigger {
@@ -962,7 +1066,7 @@ declare namespace LocalJSX {
         "expand"?: Expand;
         "fill"?: Fill;
         "name"?: string;
-        "onTrigger"?: (event: CustomEvent<Trigger>) => void;
+        "onTrigger"?: (event: SmoothlyTriggerCustomEvent<Trigger>) => void;
         "type"?: "link" | "button";
         "value"?: any;
     }
@@ -973,8 +1077,8 @@ declare namespace LocalJSX {
     }
     interface SmoothlyTriggerSource {
         "listen"?: string;
-        "onMessage"?: (event: CustomEvent<Message<any>>) => void;
-        "onTrigger"?: (event: CustomEvent<Trigger>) => void;
+        "onMessage"?: (event: SmoothlyTriggerSourceCustomEvent<Message<any>>) => void;
+        "onTrigger"?: (event: SmoothlyTriggerSourceCustomEvent<Trigger>) => void;
     }
     interface SmoothlyTuple {
         "tuple"?: [string, string];

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -254,7 +254,7 @@ export namespace Components {
     }
     interface SmoothlyTableHeader {
         "name": string;
-        "sortDirection"?: "ascending" | "descending";
+        "sortDirection": "ascending" | "descending";
     }
     interface SmoothlyTableRow {
         "align": "left" | "center" | "right";

--- a/src/components/table/header/index.tsx
+++ b/src/components/table/header/index.tsx
@@ -7,15 +7,14 @@ import { Component, Event, EventEmitter, h, Host, Listen, Prop } from "@stencil/
 })
 export class TableHeader {
 	@Prop() name: string
-	@Prop({ mutable: true }) sortDirection?: "ascending" | "descending"
+	@Prop({ mutable: true }) sortDirection?: "ascending" | "descending" = "ascending"
 	@Event() sort: EventEmitter<{ property: string; direction: "ascending" | "descending" }>
 	@Listen("click")
 	onClick(event: MouseEvent) {
 		this.sort.emit({
 			property: this.name,
-			direction: (this.sortDirection = this.sortDirection == "descending" ? "ascending" : "descending"),
+			direction: (this.sortDirection = this.sortDirection == "ascending" ? "descending" : "ascending"),
 		})
-		console.log("sort", this.name, this.sortDirection)
 		event.preventDefault()
 		event.stopPropagation()
 	}

--- a/src/components/table/header/index.tsx
+++ b/src/components/table/header/index.tsx
@@ -7,7 +7,7 @@ import { Component, Event, EventEmitter, h, Host, Listen, Prop } from "@stencil/
 })
 export class TableHeader {
 	@Prop() name: string
-	@Prop({ mutable: true }) sortDirection?: "ascending" | "descending" = "ascending"
+	@Prop({ mutable: true }) sortDirection: "ascending" | "descending" = "ascending"
 	@Event() sort: EventEmitter<{ property: string; direction: "ascending" | "descending" }>
 	@Listen("click")
 	onClick(event: MouseEvent) {
@@ -27,7 +27,7 @@ export class TableHeader {
 		)
 	}
 	private renderSortIcon(): any {
-		let result: any | undefined
+		let result: "ascending" | "descending"
 		switch (this.sortDirection) {
 			case "ascending":
 				result = <ion-icon name="chevron-up-outline" class="sort-icon"></ion-icon>

--- a/src/components/table/header/index.tsx
+++ b/src/components/table/header/index.tsx
@@ -13,7 +13,7 @@ export class TableHeader {
 	onClick(event: MouseEvent) {
 		this.sort.emit({
 			property: this.name,
-			direction: (this.sortDirection = this.sortDirection == "ascending" ? "descending" : "ascending"),
+			direction: (this.sortDirection = this.sortDirection == "descending" ? "ascending" : "descending"),
 		})
 		console.log("sort", this.name, this.sortDirection)
 		event.preventDefault()

--- a/src/components/table/index.tsx
+++ b/src/components/table/index.tsx
@@ -12,7 +12,7 @@ export class Table {
 	@Listen("sort")
 	onSort(event: CustomEvent<{ property: string; direction: "ascending" | "descending" }>) {
 		if (this.sortedOn && this.sortedOn != event.target)
-			this.sortedOn.sortDirection = undefined
+			this.sortedOn.sortDirection = "ascending"
 		this.sortedOn = event.target as HTMLSmoothlyTableHeaderElement
 	}
 	render() {

--- a/src/index.html
+++ b/src/index.html
@@ -8,6 +8,8 @@
 	<base href="/">
 	<script type="module" src="smoothly.esm.js"></script>
 	<script nomodule src="smoothly.js"></script>
+	<script type="module" src="https://unpkg.com/ionicons@5.5.2/dist/ionicons/ionicons.esm.js"></script>
+	<script nomodule src="https://unpkg.com/ionicons@5.5.2/dist/ionicons/ionicons.js"></script>
 	<link href="https://theme.payfunc.com/intergiro/index.css" rel="stylesheet">
 </head>
 


### PR DESCRIPTION
Added required scripts for `<ion-icon>` which is used by `smoothly-table-header`.
Fixed the initial state of the chevron icons for `smoothly-table-header`, now points up when not in focus