### PR TITLE
Lint fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "eslint-plugin-simple-import-sort": "^7.0.0",
         "jest": "^27.0.3",
         "jest-cli": "^27.4.5",
-        "prettier": "^2.6.2",
+        "prettier": "^1.7.0",
         "prettier-stylelint": "^0.4.2",
         "prettierx": "github:utily/eslint-plugin-prettierx#utily-20220323",
         "puppeteer": "^14.1.0",
@@ -9951,18 +9951,15 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz",
-      "integrity": "sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==",
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
+      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
       "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
       "engines": {
-        "node": ">=10.13.0"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
+        "node": ">=4"
       }
     },
     "node_modules/prettier-linter-helpers": {
@@ -10691,18 +10688,6 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
       "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
       "dev": true
-    },
-    "node_modules/prettier-stylelint/node_modules/prettier": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
-      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
-      "dev": true,
-      "bin": {
-        "prettier": "bin-prettier.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
     },
     "node_modules/prettier-stylelint/node_modules/quick-lru": {
       "version": "1.1.0",
@@ -22178,9 +22163,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz",
-      "integrity": "sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==",
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
+      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
       "dev": true
     },
     "prettier-linter-helpers": {
@@ -22746,12 +22731,6 @@
           "version": "3.3.1",
           "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
           "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
-          "dev": true
-        },
-        "prettier": {
-          "version": "1.19.1",
-          "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
-          "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
           "dev": true
         },
         "quick-lru": {

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "eslint-plugin-simple-import-sort": "^7.0.0",
     "jest": "^27.0.3",
     "jest-cli": "^27.4.5",
-    "prettier": "^2.6.2",
+    "prettier": "^1.7.0",
     "prettier-stylelint": "^0.4.2",
     "prettierx": "github:utily/eslint-plugin-prettierx#utily-20220323",
     "puppeteer": "^14.1.0",

--- a/src/components/app/style.css
+++ b/src/components/app/style.css
@@ -37,7 +37,7 @@ smoothly-app[color=danger] {
 	--smoothly-app-hover-color: var(--smoothly-default-contrast);
 	--smoothly-app-shadow: var(--smoothly-color-shadow);
 }
-smoothly-app>smoothly-notifier>header {
+smoothly-app > smoothly-notifier > header {
 	position: fixed;
 	top: 0;
 	left: 0;
@@ -52,29 +52,29 @@ smoothly-app>smoothly-notifier>header {
 	justify-content: space-between;
 	align-items: center;
 	box-shadow: 0 2px 5px 0 rgba(var(--smoothly-app-shadow));
-	border-bottom: 1px solid rgba(var(--smoothly-dark-color))
+	border-bottom: 1px solid rgba(var(--smoothly-dark-color));
 }
-smoothly-app>smoothly-notifier>header a {
+smoothly-app > smoothly-notifier > header a {
 	color: inherit;
 	text-decoration: inherit;
 }
-smoothly-app>smoothly-notifier>header>nav {
+smoothly-app > smoothly-notifier > header > nav {
 	width: 100%;
 	flex-shrink: 2;
 }
-smoothly-app>smoothly-notifier>header>h1,
-smoothly-app>smoothly-notifier>header>nav,
-smoothly-app>smoothly-notifier>header>nav>ul,
-smoothly-app>smoothly-notifier>header>nav>ul>li,
-smoothly-app>smoothly-notifier>header>nav>ul>li>*:not(a) {
+smoothly-app > smoothly-notifier > header > h1,
+smoothly-app > smoothly-notifier > header > nav,
+smoothly-app > smoothly-notifier > header > nav > ul,
+smoothly-app > smoothly-notifier > header > nav > ul > li,
+smoothly-app > smoothly-notifier > header > nav > ul > li > *:not(a) {
 	display: flex;
 	height: 100%;
 	margin: 0;
 }
-smoothly-app>smoothly-notifier>header>h1 {
+smoothly-app > smoothly-notifier > header > h1 {
 	margin-left: 3.8rem;
 }
-smoothly-app>smoothly-notifier>header>h1>a {
+smoothly-app > smoothly-notifier > header > h1 > a {
 	overflow: hidden;
 	user-select: none;
 	height: 200%;
@@ -83,62 +83,62 @@ smoothly-app>smoothly-notifier>header>h1>a {
 	size: 100%;
 	background-position-y: center;
 }
-smoothly-app>smoothly-notifier>header>nav>ul>li a {
+smoothly-app > smoothly-notifier > header > nav > ul > li a {
 	line-height: 1.6cm;
 }
-smoothly-app>smoothly-notifier>header>nav>ul {
+smoothly-app > smoothly-notifier > header > nav > ul {
 	width: 100%;
 }
-smoothly-app>smoothly-notifier>header>[slot=header] {
+smoothly-app > smoothly-notifier > header > [slot=header] {
 	display: flex;
 	margin-right: 2.1rem;
 	justify-content: flex-end;
 	border: 0;
 }
-smoothly-app>smoothly-notifier>header>[slot=header]>a {
+smoothly-app > smoothly-notifier > header > [slot=header] > a {
 	display: flex;
 	align-self: center;
 	border-width: 0;
 	align-items: center;
 	margin-right: 3.9rem;
 }
-smoothly-app>smoothly-notifier>header>[slot=header]>a>smoothly-icon {
+smoothly-app > smoothly-notifier > header > [slot=header] > a > smoothly-icon {
 	fill: rgb(var(--smoothly-primary-shade));
 	stroke: rgb(var(--smoothly-primary-shade));
 	color: rgb(var(--smoothly-primary-shade));
 }
-smoothly-app>smoothly-notifier>header>nav>ul>li a {
+smoothly-app > smoothly-notifier > header > nav > ul > li a {
 	display: flex;
 	height: 2.3rem;
 	margin: 0 0.4cm;
 	text-decoration: none;
 }
-smoothly-app>smoothly-notifier>header>nav>ul>li>a {
+smoothly-app > smoothly-notifier > header > nav > ul > li > a {
 	display: flex;
 	align-items: center;
 	align-self: center;
 	margin-bottom: 2px;
 }
-smoothly-app>smoothly-notifier>header>nav>ul>li smoothly-trigger.sc-smoothly-trigger-h {
+smoothly-app > smoothly-notifier > header > nav > ul > li smoothly-trigger.sc-smoothly-trigger-h {
 	border: 0;
 }
-smoothly-app>smoothly-notifier>header>nav>ul>li>a>smoothly-icon>svg {
+smoothly-app > smoothly-notifier > header > nav > ul > li > a > smoothly-icon > svg {
 	fill: rgb(var(--smoothly-medium-color));
 	stroke: rgb(var(--smoothly-medium-color));
 	color: rgb(var(--smoothly-medium-color));
 	align-items: center;
 	display: flex;
 }
-smoothly-app>smoothly-notifier>header>nav>ul>li>a:hover>smoothly-icon>svg,
-smoothly-app>smoothly-notifier>header>nav>ul>li>a.active>smoothly-icon>svg {
+smoothly-app > smoothly-notifier > header > nav > ul > li > a:hover > smoothly-icon > svg,
+smoothly-app > smoothly-notifier > header > nav > ul > li > a.active > smoothly-icon > svg {
 	color: rgb(var(--smoothly-app-color));
 	stroke: rgb(var(--smoothly-app-color));
 	fill: rgb(var(--smoothly-app-color));
 }
-smoothly-app>smoothly-notifier>header>nav>ul>li>smoothly-trigger.active a>smoothly-icon,
-smoothly-app>smoothly-notifier>header>nav>ul>li>smoothly-trigger:hover a>smoothly-icon,
-smoothly-app>smoothly-notifier>header>nav>ul>li a:hover,
-smoothly-app>smoothly-notifier>header>nav>ul>li a.active {
+smoothly-app > smoothly-notifier > header > nav > ul > li > smoothly-trigger.active a > smoothly-icon,
+smoothly-app > smoothly-notifier > header > nav > ul > li > smoothly-trigger:hover a > smoothly-icon,
+smoothly-app > smoothly-notifier > header > nav > ul > li a:hover,
+smoothly-app > smoothly-notifier > header > nav > ul > li a.active {
 	border-bottom: 2px solid rgb(var(--smoothly-app-color));
 	margin-bottom: 0px;
 	border-bottom-width: 2px;
@@ -146,7 +146,7 @@ smoothly-app>smoothly-notifier>header>nav>ul>li a.active {
 	stroke: rgb(var(--smoothly-app-color));
 	fill: rgb(var(--smoothly-app-color));
 }
-smoothly-app>smoothly-notifier>main {
+smoothly-app > smoothly-notifier > main {
 	position: relative;
 	top: 5.6rem;
 }

--- a/src/components/button/style.css
+++ b/src/components/button/style.css
@@ -24,7 +24,6 @@ button {
 	font-size: 110%;
 	font-weight: 400;
 }
-
 :host:not([disabled]):hover,
 :host:not([disabled]):focus,
 :host:not([disabled]):active {
@@ -35,7 +34,6 @@ button {
 	text-align: center;
 	text-decoration: inherit;
 }
-
 :host[type=button] > a {
 	width: calc(100% - 0.6em);
 }

--- a/src/components/calendar/style.css
+++ b/src/components/calendar/style.css
@@ -35,7 +35,7 @@ td:nth-child(6):not(.currentMonth),
 td:nth-child(7):not(.currentMonth) {
 	color: rgba(var(--smoothly-danger-tint), var(--other-month-opacity));
 }
-td:not(.selected,.disable):hover {
+td:not(.selected, .disable):hover {
 	color: rgb(var(--smoothly-primary-contrast));
 	background: rgb(var(--smoothly-primary-tint));
 }
@@ -43,7 +43,7 @@ td.selected {
 	color: rgb(var(--smoothly-primary-contrast));
 	background: rgb(var(--smoothly-primary-color));
 }
-td:not(.selected,.dateRange):not(:hover).today {
+td:not(.selected, .dateRange):not(:hover).today {
 	background: rgb(var(--smoothly-dark-tint));
 	color: rgb(var(--smoothly-dark-contrast));
 }
@@ -56,4 +56,3 @@ td.disable {
 	background-color: rgb(var(--smoothly-default-tint), 0.5);
 	color: rgb(var(--smoothly-default-contrast), 0.5);
 }
-

--- a/src/components/input-date-range/style.scss
+++ b/src/components/input-date-range/style.scss
@@ -3,16 +3,14 @@
 	display: block;
 	width: fit-content;
 }
-
-:host>nav {
+:host > nav {
 	position: absolute;
 	z-index: 10;
 	top: 3.5em;
 	background-color: rgb(var(--smoothly-default-shade));
 	max-width: 22em;
 }
-
-:host>div {
+:host > div {
 	position: fixed;
 	top: 0px;
 	left: 0px;
@@ -22,8 +20,7 @@
 	height: 100vh;
 	z-index: 2;
 }
-
-:host>nav>.arrow {
+:host > nav > .arrow {
 	position: absolute;
 	z-index: 9;
 	transform: translate(10em, -0.55em) rotate(45deg);
@@ -31,20 +28,17 @@
 	height: 1em;
 	background-color: rgb(var(--smoothly-default-shade));
 }
-
-:host>section {
+:host > section {
 	display: flex;
 	background-color: var(--background, transparent);
 	border-radius: 0.25rem;
 	cursor: pointer;
 }
-
 smoothly-input {
 	border-radius: var(--border-radius, none);
 	background-color: transparent;
 	width: var(--input-width);
 }
-
 span {
 	padding: 0.5em 0.2em 0.5em 0.2em;
 	align-self: center;

--- a/src/components/input-date/style.css
+++ b/src/components/input-date/style.css
@@ -1,14 +1,13 @@
 :host {
 	position: relative;
 }
-
 nav {
 	position: absolute;
 	z-index: 10;
 	top: 3.5em;
 	background-color: rgb(var(--smoothly-default-shade));
 	max-width: 22em;
-} 
+}
 :host > div {
 	position: fixed;
 	top: 0px;
@@ -22,7 +21,7 @@ nav {
 :host > nav > .arrow {
 	position: absolute;
 	z-index: 9;
-	transform: translate(2em, -.55em) rotate(45deg);
+	transform: translate(2em, -0.55em) rotate(45deg);
 	width: 1em;
 	height: 1em;
 	background-color: rgb(var(--smoothly-default-shade));

--- a/src/components/item/style.css
+++ b/src/components/item/style.css
@@ -3,14 +3,13 @@
 	color: rgb(var(--smoothly-primary-contrast));
 }
 :host {
-	padding: .5em;
+	padding: 0.5em;
 	cursor: pointer;
 	background-color: rgb(var(--smoothly-default-shade));
 	color: rgb(var(--smoothly-default-contrast));
-	border: rgb(var(--smoothly-default-shade) solid 1px)
+	border: rgb(var(--smoothly-default-shade) solid 1px);
 }
 :host:hover {
 	background-color: rgb(var(--smoothly-primary-color));
 	color: rgb(var(--smoothly-primary-contrast));
 }
-

--- a/src/components/menu-options/style.scss
+++ b/src/components/menu-options/style.scss
@@ -12,7 +12,6 @@
 	overflow-y: auto;
 	cursor: pointer;
 }
-
 :host:first-child {
 	margin: 10em;
 }

--- a/src/components/option/style.scss
+++ b/src/components/option/style.scss
@@ -9,26 +9,21 @@
 	background-color: transparent;
 	position: relative;
 }
-
 :host([data-highlight]) {
 	background-color: rgb(var(--smoothly-default-shade));
 }
-
-:host>div.middle {
+:host > div.middle {
 	padding-left: 0.5em;
 	flex-shrink: 1;
 	width: 100%;
 }
-
 :host([divider]) {
 	margin-bottom: 0.5em;
 }
-
 ::slotted([slot=right]) {
 	font-style: italic;
 	white-space: nowrap;
 }
-
 :host([divider])::after {
 	position: absolute;
 	height: 1px;

--- a/src/components/picker/style.scss
+++ b/src/components/picker/style.scss
@@ -26,7 +26,7 @@
 	border-width: 2px;
 	margin: 0px;
 }
-:host>div {
+:host > div {
 	display: flex;
 	background-color: transparent;
 	min-height: 2.5rem;
@@ -34,7 +34,7 @@
 	align-self: center;
 	border: none;
 	max-height: var(--max-height);
-	.icons>smoothly-icon {
+	.icons > smoothly-icon {
 		flex-shrink: 0;
 		padding-left: 0.6em;
 		stroke: rgba(var(--color), 0.4);
@@ -57,17 +57,16 @@
 		padding: 0 0.6rem;
 		font-family: var(--smoothly-font-family);
 		font-size: 1.05rem;
-
 		&::placeholder {
 			opacity: 1;
 			text-overflow: ellipsis;
 		}
 	}
 }
-:host([is-open])>div input {
+:host([is-open]) > div input {
 	color: rgb(var(--smoothly-medium-color));
 }
-:host(:not(:focus-within)[multiple]) ul>li:last-child {
+:host(:not(:focus-within)[multiple]) ul > li:last-child {
 	/* Remove Input out of the CSS flow Layout. This way input takes up no extra space */
 	position: absolute;
 	pointer-events: none;
@@ -131,7 +130,7 @@ smoothly-icon.down {
 	position: absolute;
 	z-index: 1;
 }
-:host(:not([is-open]))>smoothly-menu-options {
+:host(:not([is-open])) > smoothly-menu-options {
 	/* hide options by default */
 	display: none;
 }

--- a/src/components/select-demo/style.css
+++ b/src/components/select-demo/style.css
@@ -8,5 +8,5 @@ button:focus {
 	outline: none;
 }
 smoothly-selector {
-	outline: none
+	outline: none;
 }

--- a/src/components/selector/style.css
+++ b/src/components/selector/style.css
@@ -1,4 +1,3 @@
-
 :host {
 	position: relative;
 	height: 100%;
@@ -9,7 +8,6 @@
 	display: flex;
 	align-items: center;
 }
-
 :host > div > nav {
 	display: flex;
 	flex-direction: column;

--- a/src/components/spinner/style.scss
+++ b/src/components/spinner/style.scss
@@ -27,7 +27,6 @@ $time: 1.4s;
 		}
 	}
 }
-
 @keyframes SPIN-SVG {
 	0% {
 		transform: rotate(0deg);
@@ -36,7 +35,6 @@ $time: 1.4s;
 		transform: rotate(270deg);
 	}
 }
-
 @keyframes SPIN-CIRCLE {
 	0% {
 		stroke-dashoffset: 187;

--- a/src/components/tab-switch/style.css
+++ b/src/components/tab-switch/style.css
@@ -1,5 +1,5 @@
 :host {
 	display: flex;
 	flex-direction: row;
-	margin: 1em 1em 0em 0em
+	margin: 1em 1em 0em 0em;
 }

--- a/src/components/tab/style.css
+++ b/src/components/tab/style.css
@@ -6,14 +6,13 @@
 }
 label {
 	display: block;
-  padding: 1em;
+	padding: 1em;
 	background-color: rgb(var(--smoothly-default-shade));
 	border-top-left-radius: 0.3rem;
 	border-top-right-radius: 0.3rem;
 	width: 6.25rem;
-
 }
 div {
-  background-color: rgb(var(--smoothly-default-shade));
-  padding: 1em;
+	background-color: rgb(var(--smoothly-default-shade));
+	padding: 1em;
 }

--- a/src/components/table/expandable/row/style.css
+++ b/src/components/table/expandable/row/style.css
@@ -9,4 +9,3 @@
 :host:hover {
 	background-color: rgb(var(--smoothly-default-color));
 }
-

--- a/src/components/table/row/style.css
+++ b/src/components/table/row/style.css
@@ -9,6 +9,6 @@
 :host:hover {
 	background-color: rgb(var(--smoothly-default-color));
 }
-.hide{
+.hide {
 	display: none;
 }


### PR DESCRIPTION
prettier-stylelint appears to be incompatible with prettier ^2.0.0 due to some changes in how [postcss is accessed](https://github.com/prettier/prettier/issues/7999#issuecomment-611517738).

downgrade prettier version to ^1.7.0 appears solve the problem.

prettier-stylint havent been updated in 5 years so it might be a good idea to eventually replace it.