### PR TITLE
fixes to various components

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smoothly",
-  "version": "0.1.122",
+  "version": "0.2.0",
   "description": "Web component library written in Stencil.",
   "author": "PayFunc",
   "license": "MIT",

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -785,9 +785,9 @@ declare namespace LocalJSX {
         "maxLength"?: number;
         "minLength"?: number;
         "name"?: string;
-        "onSmoothlyBlur"?: (event: CustomEvent<any>) => void;
-        "onSmoothlyChanged"?: (event: CustomEvent<{ name: string; value: any }>) => void;
-        "onSmoothlyDone"?: (event: CustomEvent<{ name: string; value: any }>) => void;
+        "onSmoothlyBlur"?: (event: CustomEvent<void>) => void;
+        "onSmoothlyChange"?: (event: CustomEvent<{ name: string; value: any }>) => void;
+        "onSmoothlyInput"?: (event: CustomEvent<{ name: string; value: any }>) => void;
         "pattern"?: RegExp | undefined;
         "placeholder"?: string | undefined;
         "readonly"?: boolean;
@@ -943,7 +943,7 @@ declare namespace LocalJSX {
     }
     interface SmoothlyTableExpandableCell {
         "align"?: "left" | "center" | "right";
-        "onExpansionLoaded"?: (event: CustomEvent<void>) => void;
+        "onExpansionLoad"?: (event: CustomEvent<void>) => void;
         "onExpansionOpen"?: (event: CustomEvent<HTMLElement>) => void;
         "open"?: boolean;
     }

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -105,6 +105,7 @@ export namespace Components {
         "name": string;
         "pattern": RegExp | undefined;
         "placeholder": string | undefined;
+        "readonly": boolean;
         "required": boolean;
         "setKeepFocusOnReRender": (keepFocus: boolean) => Promise<void>;
         "setSelectionRange": (start: number, end: number, direction?: Direction | undefined) => Promise<void>;
@@ -784,9 +785,12 @@ declare namespace LocalJSX {
         "maxLength"?: number;
         "minLength"?: number;
         "name"?: string;
+        "onSmoothlyBlur"?: (event: CustomEvent<any>) => void;
         "onSmoothlyChanged"?: (event: CustomEvent<{ name: string; value: any }>) => void;
+        "onSmoothlyDone"?: (event: CustomEvent<{ name: string; value: any }>) => void;
         "pattern"?: RegExp | undefined;
         "placeholder"?: string | undefined;
+        "readonly"?: boolean;
         "required"?: boolean;
         "showLabel"?: boolean;
         "type"?: string;

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -284,6 +284,106 @@ export namespace Components {
         "data": string;
     }
 }
+export interface SmoothlyAccordionItemCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLSmoothlyAccordionItemElement;
+}
+export interface SmoothlyCalendarCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLSmoothlyCalendarElement;
+}
+export interface SmoothlyCheckboxCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLSmoothlyCheckboxElement;
+}
+export interface SmoothlyDisplayDemoCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLSmoothlyDisplayDemoElement;
+}
+export interface SmoothlyFrameCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLSmoothlyFrameElement;
+}
+export interface SmoothlyInputCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLSmoothlyInputElement;
+}
+export interface SmoothlyInputDateCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLSmoothlyInputDateElement;
+}
+export interface SmoothlyInputDateRangeCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLSmoothlyInputDateRangeElement;
+}
+export interface SmoothlyInputMonthCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLSmoothlyInputMonthElement;
+}
+export interface SmoothlyItemCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLSmoothlyItemElement;
+}
+export interface SmoothlyNotificationCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLSmoothlyNotificationElement;
+}
+export interface SmoothlyOptionCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLSmoothlyOptionElement;
+}
+export interface SmoothlyPickerCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLSmoothlyPickerElement;
+}
+export interface SmoothlyPopupCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLSmoothlyPopupElement;
+}
+export interface SmoothlyRadioCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLSmoothlyRadioElement;
+}
+export interface SmoothlyReorderCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLSmoothlyReorderElement;
+}
+export interface SmoothlySelectCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLSmoothlySelectElement;
+}
+export interface SmoothlySelectorCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLSmoothlySelectorElement;
+}
+export interface SmoothlySubmitCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLSmoothlySubmitElement;
+}
+export interface SmoothlyTabCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLSmoothlyTabElement;
+}
+export interface SmoothlyTableCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLSmoothlyTableElement;
+}
+export interface SmoothlyTableExpandableCellCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLSmoothlyTableExpandableCellElement;
+}
+export interface SmoothlyTableExpandableRowCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLSmoothlyTableExpandableRowElement;
+}
+export interface SmoothlyTriggerCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLSmoothlyTriggerElement;
+}
+export interface SmoothlyTriggerSourceCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLSmoothlyTriggerSourceElement;
+}
 declare global {
     interface HTMLSmoothlyAccordionElement extends Components.SmoothlyAccordion, HTMLStencilElement {
     }
@@ -687,10 +787,10 @@ declare namespace LocalJSX {
     interface SmoothlyAccordionItem {
         "brand"?: string | string[];
         "name"?: string;
-        "onSmoothlyAccordionItemDidLoad"?: (event: CustomEvent<void>) => void;
-        "onSmoothlyAccordionItemDidUnload"?: (event: CustomEvent<void>) => void;
-        "onSmoothlyClose"?: (event: CustomEvent<{ name: string; open: boolean }>) => void;
-        "onSmoothlyOpen"?: (event: CustomEvent<{ name: string; open: boolean }>) => void;
+        "onSmoothlyAccordionItemDidLoad"?: (event: SmoothlyAccordionItemCustomEvent<void>) => void;
+        "onSmoothlyAccordionItemDidUnload"?: (event: SmoothlyAccordionItemCustomEvent<void>) => void;
+        "onSmoothlyClose"?: (event: SmoothlyAccordionItemCustomEvent<{ name: string; open: boolean }>) => void;
+        "onSmoothlyOpen"?: (event: SmoothlyAccordionItemCustomEvent<{ name: string; open: boolean }>) => void;
         "open"?: boolean;
     }
     interface SmoothlyApp {
@@ -719,18 +819,18 @@ declare namespace LocalJSX {
         "max"?: Date;
         "min"?: Date;
         "month"?: Date;
-        "onDateRangeSet"?: (event: CustomEvent<DateRange>) => void;
-        "onDateSet"?: (event: CustomEvent<Date>) => void;
-        "onEndChanged"?: (event: CustomEvent<Date>) => void;
-        "onStartChanged"?: (event: CustomEvent<Date>) => void;
-        "onValueChanged"?: (event: CustomEvent<Date>) => void;
+        "onDateRangeSet"?: (event: SmoothlyCalendarCustomEvent<DateRange>) => void;
+        "onDateSet"?: (event: SmoothlyCalendarCustomEvent<Date>) => void;
+        "onEndChanged"?: (event: SmoothlyCalendarCustomEvent<Date>) => void;
+        "onStartChanged"?: (event: SmoothlyCalendarCustomEvent<Date>) => void;
+        "onValueChanged"?: (event: SmoothlyCalendarCustomEvent<Date>) => void;
         "start"?: Date;
         "value"?: Date;
     }
     interface SmoothlyCheckbox {
         "disabled"?: boolean;
         "intermediate"?: boolean;
-        "onChecked"?: (event: CustomEvent<{ selected: boolean }>) => void;
+        "onChecked"?: (event: SmoothlyCheckboxCustomEvent<{ selected: boolean }>) => void;
         "selectAll"?: boolean;
         "selected"?: boolean;
         "size"?: "tiny" | "small" | "medium" | "large";
@@ -757,12 +857,12 @@ declare namespace LocalJSX {
         "datetime"?: DateTime;
     }
     interface SmoothlyDisplayDemo {
-        "onNotice"?: (event: CustomEvent<Notice>) => void;
+        "onNotice"?: (event: SmoothlyDisplayDemoCustomEvent<Notice>) => void;
     }
     interface SmoothlyFrame {
         "name"?: string;
-        "onMessage"?: (event: CustomEvent<Message<any>>) => void;
-        "onTrigger"?: (event: CustomEvent<Trigger>) => void;
+        "onMessage"?: (event: SmoothlyFrameCustomEvent<Message<any>>) => void;
+        "onTrigger"?: (event: SmoothlyFrameCustomEvent<Trigger>) => void;
         "origin"?: string | undefined;
         "url"?: string;
     }
@@ -785,9 +885,9 @@ declare namespace LocalJSX {
         "maxLength"?: number;
         "minLength"?: number;
         "name"?: string;
-        "onSmoothlyBlur"?: (event: CustomEvent<void>) => void;
-        "onSmoothlyChange"?: (event: CustomEvent<{ name: string; value: any }>) => void;
-        "onSmoothlyInput"?: (event: CustomEvent<{ name: string; value: any }>) => void;
+        "onSmoothlyBlur"?: (event: SmoothlyInputCustomEvent<void>) => void;
+        "onSmoothlyChange"?: (event: SmoothlyInputCustomEvent<{ name: string; value: any }>) => void;
+        "onSmoothlyInput"?: (event: SmoothlyInputCustomEvent<{ name: string; value: any }>) => void;
         "pattern"?: RegExp | undefined;
         "placeholder"?: string | undefined;
         "readonly"?: boolean;
@@ -800,7 +900,7 @@ declare namespace LocalJSX {
         "disabled"?: boolean;
         "max"?: Date;
         "min"?: Date;
-        "onValueChanged"?: (event: CustomEvent<Date>) => void;
+        "onValueChanged"?: (event: SmoothlyInputDateCustomEvent<Date>) => void;
         "open"?: boolean;
         "value"?: Date;
     }
@@ -808,8 +908,8 @@ declare namespace LocalJSX {
         "end"?: Date;
         "max"?: Date;
         "min"?: Date;
-        "onDateRangeSelected"?: (event: CustomEvent<{ start: Date; end: Date }>) => void;
-        "onValueChanged"?: (event: CustomEvent<Date>) => void;
+        "onDateRangeSelected"?: (event: SmoothlyInputDateRangeCustomEvent<{ start: Date; end: Date }>) => void;
+        "onValueChanged"?: (event: SmoothlyInputDateRangeCustomEvent<Date>) => void;
         "open"?: boolean;
         "showLabel"?: boolean;
         "start"?: Date;
@@ -818,11 +918,11 @@ declare namespace LocalJSX {
     interface SmoothlyInputDemo {
     }
     interface SmoothlyInputMonth {
-        "onValueChanged"?: (event: CustomEvent<Date>) => void;
+        "onValueChanged"?: (event: SmoothlyInputMonthCustomEvent<Date>) => void;
         "value"?: Date;
     }
     interface SmoothlyItem {
-        "onItemSelected"?: (event: CustomEvent<void>) => void;
+        "onItemSelected"?: (event: SmoothlyItemCustomEvent<void>) => void;
         "selected"?: boolean;
         "value"?: any;
     }
@@ -836,7 +936,7 @@ declare namespace LocalJSX {
     }
     interface SmoothlyNotification {
         "notice"?: Notice;
-        "onRemove"?: (event: CustomEvent<Notice>) => void;
+        "onRemove"?: (event: SmoothlyNotificationCustomEvent<Notice>) => void;
     }
     interface SmoothlyNotifier {
     }
@@ -845,8 +945,8 @@ declare namespace LocalJSX {
         "dataHighlight"?: boolean;
         "divider"?: boolean;
         "name"?: string;
-        "onOptionHover"?: (event: CustomEvent<{ value: any; name: string }>) => void;
-        "onOptionSelect"?: (event: CustomEvent<{ value: any; name: string }>) => void;
+        "onOptionHover"?: (event: SmoothlyOptionCustomEvent<{ value: any; name: string }>) => void;
+        "onOptionSelect"?: (event: SmoothlyOptionCustomEvent<{ value: any; name: string }>) => void;
         "value"?: string;
     }
     interface SmoothlyPicker {
@@ -856,7 +956,7 @@ declare namespace LocalJSX {
         "maxHeight"?: string;
         "maxMenuHeight"?: "inherit";
         "multiple"?: boolean;
-        "onMenuClose"?: (event: CustomEvent<OptionType[]>) => void;
+        "onMenuClose"?: (event: SmoothlyPickerCustomEvent<OptionType[]>) => void;
         "optionStyle"?: any;
         "options"?: OptionType[];
         "selectNoneName"?: string;
@@ -865,7 +965,7 @@ declare namespace LocalJSX {
     }
     interface SmoothlyPopup {
         "direction"?: "up" | "down";
-        "onPopup"?: (event: CustomEvent<boolean>) => void;
+        "onPopup"?: (event: SmoothlyPopupCustomEvent<boolean>) => void;
         "visible"?: boolean;
     }
     interface SmoothlyQuiet {
@@ -874,7 +974,7 @@ declare namespace LocalJSX {
     interface SmoothlyRadio {
         "checked"?: boolean;
         "name"?: string;
-        "onSmoothlySelected"?: (event: CustomEvent<{ name: string; value: string }>) => void;
+        "onSmoothlySelected"?: (event: SmoothlyRadioCustomEvent<{ name: string; value: string }>) => void;
         "tabIndex"?: number;
         "value"?: string;
     }
@@ -882,7 +982,7 @@ declare namespace LocalJSX {
         "orientation"?: "horizontal" | "vertical";
     }
     interface SmoothlyReorder {
-        "onReorder"?: (event: CustomEvent<[number, number]>) => void;
+        "onReorder"?: (event: SmoothlyReorderCustomEvent<[number, number]>) => void;
     }
     interface SmoothlyRoom {
         "icon"?: string;
@@ -893,13 +993,13 @@ declare namespace LocalJSX {
     interface SmoothlySelect {
         "background"?: string;
         "identifier"?: string;
-        "onSelectionChanged"?: (event: CustomEvent<{ identifier: string; value: string }>) => void;
+        "onSelectionChanged"?: (event: SmoothlySelectCustomEvent<{ identifier: string; value: string }>) => void;
         "value"?: string;
     }
     interface SmoothlySelectDemo {
     }
     interface SmoothlySelector {
-        "onSelected"?: (event: CustomEvent<any>) => void;
+        "onSelected"?: (event: SmoothlySelectorCustomEvent<any>) => void;
     }
     interface SmoothlySkeleton {
         "align"?: "left" | "center" | "right";
@@ -918,7 +1018,7 @@ declare namespace LocalJSX {
         "disabled"?: boolean;
         "expand"?: Expand;
         "fill"?: Fill;
-        "onSubmit"?: (event: CustomEvent<{ [key: string]: string }>) => void;
+        "onSubmit"?: (event: SmoothlySubmitCustomEvent<{ [key: string]: string }>) => void;
         "prevent"?: boolean;
         "processing"?: boolean;
     }
@@ -929,13 +1029,13 @@ declare namespace LocalJSX {
     }
     interface SmoothlyTab {
         "label"?: string;
-        "onExpansionOpen"?: (event: CustomEvent<HTMLElement>) => void;
+        "onExpansionOpen"?: (event: SmoothlyTabCustomEvent<HTMLElement>) => void;
         "open"?: boolean;
     }
     interface SmoothlyTabSwitch {
     }
     interface SmoothlyTable {
-        "onLoadMore"?: (event: CustomEvent<void>) => void;
+        "onLoadMore"?: (event: SmoothlyTableCustomEvent<void>) => void;
     }
     interface SmoothlyTableCell {
     }
@@ -943,13 +1043,13 @@ declare namespace LocalJSX {
     }
     interface SmoothlyTableExpandableCell {
         "align"?: "left" | "center" | "right";
-        "onExpansionLoad"?: (event: CustomEvent<void>) => void;
-        "onExpansionOpen"?: (event: CustomEvent<HTMLElement>) => void;
+        "onExpansionLoad"?: (event: SmoothlyTableExpandableCellCustomEvent<void>) => void;
+        "onExpansionOpen"?: (event: SmoothlyTableExpandableCellCustomEvent<HTMLElement>) => void;
         "open"?: boolean;
     }
     interface SmoothlyTableExpandableRow {
         "align"?: "left" | "center" | "right";
-        "onExpansionOpen"?: (event: CustomEvent<HTMLElement>) => void;
+        "onExpansionOpen"?: (event: SmoothlyTableExpandableRowCustomEvent<HTMLElement>) => void;
         "open"?: boolean;
     }
     interface SmoothlyTableHeader {
@@ -963,7 +1063,7 @@ declare namespace LocalJSX {
         "expand"?: Expand;
         "fill"?: Fill;
         "name"?: string;
-        "onTrigger"?: (event: CustomEvent<Trigger>) => void;
+        "onTrigger"?: (event: SmoothlyTriggerCustomEvent<Trigger>) => void;
         "type"?: "link" | "button";
         "value"?: any;
     }
@@ -974,8 +1074,8 @@ declare namespace LocalJSX {
     }
     interface SmoothlyTriggerSource {
         "listen"?: string;
-        "onMessage"?: (event: CustomEvent<Message<any>>) => void;
-        "onTrigger"?: (event: CustomEvent<Trigger>) => void;
+        "onMessage"?: (event: SmoothlyTriggerSourceCustomEvent<Message<any>>) => void;
+        "onTrigger"?: (event: SmoothlyTriggerSourceCustomEvent<Trigger>) => void;
     }
     interface SmoothlyTuple {
         "tuple"?: [string, string];

--- a/src/components/button/style.css
+++ b/src/components/button/style.css
@@ -18,6 +18,7 @@
 }
 a,
 button {
+	display: block;
 	border-color: transparent;
 	background-color: transparent;
 	padding: 0.2em 0.3em;

--- a/src/components/input-date-range/index.tsx
+++ b/src/components/input-date-range/index.tsx
@@ -43,7 +43,7 @@ export class InputDateRange {
 					type="date"
 					value={this.start}
 					showLabel={this.showLabel}
-					onSmoothlyChanged={e => (this.start = e.detail.value)}>
+					onSmoothlyInput={e => (this.start = e.detail.value)}>
 					from
 				</smoothly-input>
 				<span>–</span>
@@ -51,7 +51,7 @@ export class InputDateRange {
 					type="date"
 					showLabel={this.showLabel}
 					value={this.end}
-					onSmoothlyChanged={e => (this.end = e.detail.value)}>
+					onSmoothlyInput={e => (this.end = e.detail.value)}>
 					to
 				</smoothly-input>
 			</section>,

--- a/src/components/input-date/index.tsx
+++ b/src/components/input-date/index.tsx
@@ -29,7 +29,7 @@ export class InputDate {
 				disabled={this.disabled}
 				type="date"
 				value={this.value}
-				onSmoothlyChanged={e => (this.value = e.detail.value)}>
+				onSmoothlyInput={e => (this.value = e.detail.value)}>
 				<slot></slot>
 			</smoothly-input>,
 			this.open && !this.disabled

--- a/src/components/input-demo/index.tsx
+++ b/src/components/input-demo/index.tsx
@@ -18,7 +18,7 @@ export class SmoothlyInputDemo {
 						onSmoothlyBlur={() => console.log("smoothly blur")}>
 						Readonly
 					</smoothly-input>
-					<smoothly-input type="text" name="name" onSmoothlyDone={e => console.log("smoothly done event")}>
+					<smoothly-input type="text" name="name" onSmoothlyChange={e => console.log("smoothly change event")}>
 						Name
 					</smoothly-input>
 					<smoothly-input type="date" name="date">

--- a/src/components/input-demo/index.tsx
+++ b/src/components/input-demo/index.tsx
@@ -10,7 +10,15 @@ export class SmoothlyInputDemo {
 					<h5>Address</h5>
 				</header>
 				<main>
-					<smoothly-input type="text" name="name">
+					<smoothly-input
+						type="text"
+						name="name"
+						readonly={true}
+						value={"Readonly"}
+						onSmoothlyBlur={() => console.log("smoothly blur")}>
+						Readonly
+					</smoothly-input>
+					<smoothly-input type="text" name="name" onSmoothlyDone={e => console.log("smoothly done event")}>
 						Name
 					</smoothly-input>
 					<smoothly-input type="date" name="date">

--- a/src/components/input/index.tsx
+++ b/src/components/input/index.tsx
@@ -44,9 +44,9 @@ export class SmoothlyInput {
 		const formatter = this.formatter
 		return formatter.format(StateEditor.copy(formatter.unformat(StateEditor.copy(state))))
 	}
-	@Event() smoothlyBlur: EventEmitter
-	@Event() smoothlyDone: EventEmitter<{ name: string; value: any }>
-	@Event() smoothlyChanged: EventEmitter<{ name: string; value: any }>
+	@Event() smoothlyBlur: EventEmitter<void>
+	@Event() smoothlyChange: EventEmitter<{ name: string; value: any }>
+	@Event() smoothlyInput: EventEmitter<{ name: string; value: any }>
 	@Watch("value")
 	valueWatcher(value: any, before: any) {
 		if (this.lastValue != value) {
@@ -59,7 +59,7 @@ export class SmoothlyInput {
 		if (value != before) {
 			if (typeof value == "string")
 				value = value.trim()
-			this.smoothlyChanged.emit({ name: this.name, value })
+			this.smoothlyInput.emit({ name: this.name, value })
 		}
 	}
 	@Watch("currency")
@@ -127,7 +127,7 @@ export class SmoothlyInput {
 	onBlur(event: FocusEvent) {
 		this.smoothlyBlur.emit()
 		if (this.initialValue != this.value)
-			this.smoothlyDone.emit({ name: this.name, value: this.value })
+			this.smoothlyChange.emit({ name: this.name, value: this.value })
 		this.initialValue = undefined
 	}
 	onFocus(event: FocusEvent) {

--- a/src/components/input/index.tsx
+++ b/src/components/input/index.tsx
@@ -1,6 +1,7 @@
-import { Component, Event, EventEmitter, h, Host, Method, Prop, Watch } from "@stencil/core"
+import { Component, Event, EventEmitter, h, Host, Method, Prop, State, Watch } from "@stencil/core"
 import { Currency, Language, Locale } from "isoly"
-import { Action, Converter, Direction, Formatter, get, Settings, State, StateEditor, Type } from "tidily"
+import { Action, Converter, Direction, Formatter, get, Settings, State as TidilyState, StateEditor, Type } from "tidily"
+
 @Component({
 	tag: "smoothly-input",
 	styleUrl: "style.css",
@@ -11,7 +12,7 @@ export class SmoothlyInput {
 	/** On re-render the input will blur. This boolean is meant to keep track of if input should keep its focus. */
 	private keepFocusOnReRender = false
 	private lastValue: any
-	private state: Readonly<State> & Readonly<Settings>
+	private state: Readonly<TidilyState> & Readonly<Settings>
 	@Prop({ reflect: true }) name: string
 	@Prop({ mutable: true }) value: any
 	@Prop({ reflect: true }) type = "text"
@@ -23,7 +24,9 @@ export class SmoothlyInput {
 	@Prop({ mutable: true }) pattern: RegExp | undefined
 	@Prop({ mutable: true }) placeholder: string | undefined
 	@Prop({ mutable: true }) disabled = false
+	@Prop({ mutable: true }) readonly = false
 	@Prop({ reflect: true }) currency?: Currency
+	@State() initialValue?: any
 	get formatter(): Formatter & Converter<any> {
 		let result: (Formatter & Converter<any>) | undefined
 		switch (this.type) {
@@ -37,10 +40,12 @@ export class SmoothlyInput {
 		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 		return result || get("text")!
 	}
-	private newState(state: State) {
+	private newState(state: TidilyState) {
 		const formatter = this.formatter
 		return formatter.format(StateEditor.copy(formatter.unformat(StateEditor.copy(state))))
 	}
+	@Event() smoothlyBlur: EventEmitter
+	@Event() smoothlyDone: EventEmitter<{ name: string; value: any }>
 	@Event() smoothlyChanged: EventEmitter<{ name: string; value: any }>
 	@Watch("value")
 	valueWatcher(value: any, before: any) {
@@ -119,9 +124,14 @@ export class SmoothlyInput {
 		const after = this.formatter.format(StateEditor.copy(this.formatter.unformat(StateEditor.copy({ ...this.state }))))
 		this.updateBackend(after, this.inputElement)
 	}
-	// eslint-disable-next-line @typescript-eslint/no-empty-function
-	onBlur(event: FocusEvent) {}
+	onBlur(event: FocusEvent) {
+		this.smoothlyBlur.emit()
+		if (this.initialValue != this.value)
+			this.smoothlyDone.emit({ name: this.name, value: this.value })
+		this.initialValue = undefined
+	}
 	onFocus(event: FocusEvent) {
+		this.initialValue = this.value
 		const after = this.formatter.format(StateEditor.copy(this.formatter.unformat(StateEditor.copy({ ...this.state }))))
 		if (event.target)
 			this.updateBackend(after, event.target as HTMLInputElement)
@@ -203,10 +213,12 @@ export class SmoothlyInput {
 		return value
 	}
 	private processKey(event: Action, backend: HTMLInputElement) {
-		const after = Action.apply(this.formatter, this.state, event)
-		this.updateBackend(after, backend)
+		if (!this.readonly) {
+			const after = Action.apply(this.formatter, this.state, event)
+			this.updateBackend(after, backend)
+		}
 	}
-	updateBackend(after: Readonly<State> & Readonly<Settings>, backend: HTMLInputElement) {
+	updateBackend(after: Readonly<TidilyState> & Readonly<Settings>, backend: HTMLInputElement) {
 		if (after.value != backend.value)
 			backend.value = after.value
 		if (backend.selectionStart != undefined && after.selection.start != backend.selectionStart)
@@ -232,6 +244,7 @@ export class SmoothlyInput {
 						required={this.required}
 						autocomplete={this.autocomplete ? this.state?.autocomplete : "off"}
 						disabled={this.disabled}
+						readOnly={this.readonly}
 						pattern={this.state?.pattern && this.state?.pattern.source}
 						value={this.state?.value}
 						onInput={(e: InputEvent) => this.onInput(e)}

--- a/src/components/tab-switch/index.tsx
+++ b/src/components/tab-switch/index.tsx
@@ -10,6 +10,7 @@ export class SmoothlyTabSwitch {
 	@State() selectedElement: HTMLSmoothlyTabElement
 	@Listen("expansionOpen")
 	openChanged(event: CustomEvent) {
+		event.stopPropagation()
 		this.selectedElement = event.target as HTMLSmoothlyTabElement
 		this.selectedElement.open = true
 		this.element.after(event.detail)

--- a/src/components/table/demo/index.tsx
+++ b/src/components/table/demo/index.tsx
@@ -1,4 +1,4 @@
-import { Component, h } from "@stencil/core"
+import { Component, h, Host } from "@stencil/core"
 
 @Component({
 	tag: "smoothly-table-demo",
@@ -7,55 +7,81 @@ import { Component, h } from "@stencil/core"
 })
 export class TableDemo {
 	render() {
-		return [
-			<smoothly-table>
-				<smoothly-table-row>
-					<smoothly-table-header>Header A</smoothly-table-header>
-					<smoothly-table-header>Header B</smoothly-table-header>
-					<smoothly-table-header>Header C</smoothly-table-header>
-					<smoothly-table-header>Header D</smoothly-table-header>
-					<smoothly-table-header></smoothly-table-header>
-				</smoothly-table-row>
-				<smoothly-table-row>
-					<smoothly-table-expandable-cell>
-						normal row (exp.cell)
-						<div slot="detail">expandable cell 1 content</div>
-					</smoothly-table-expandable-cell>
-					<smoothly-table-expandable-cell>
-						expandable cell
-						<div slot="detail">expandable cell 2 content</div>
-					</smoothly-table-expandable-cell>
-					<smoothly-table-expandable-cell>
-						expandable cell
-						<div slot="detail">expandable cell 3 content</div>
-					</smoothly-table-expandable-cell>
-					<smoothly-table-expandable-cell>
-						expandable cell
-						<div slot="detail">expandable cell 4 content</div>
-					</smoothly-table-expandable-cell>
-				</smoothly-table-row>
+		return (
+			<Host>
+				<smoothly-table>
+					<smoothly-table-row>
+						<smoothly-table-header>Header A</smoothly-table-header>
+						<smoothly-table-header>Header B</smoothly-table-header>
+						<smoothly-table-header>Header C</smoothly-table-header>
+						<smoothly-table-header>Header D</smoothly-table-header>
+						<smoothly-table-header></smoothly-table-header>
+					</smoothly-table-row>
+					<smoothly-table-row>
+						<smoothly-table-expandable-cell>
+							normal row (exp.cell)
+							<div slot="detail">expandable cell 1 content</div>
+						</smoothly-table-expandable-cell>
+						<smoothly-table-expandable-cell>
+							expandable cell
+							<div slot="detail">expandable cell 2 content</div>
+						</smoothly-table-expandable-cell>
+						<smoothly-table-expandable-cell>
+							expandable cell
+							<div slot="detail">expandable cell 3 content</div>
+						</smoothly-table-expandable-cell>
+						<smoothly-table-expandable-cell>
+							expandable cell
+							<div slot="detail">expandable cell 4 content</div>
+						</smoothly-table-expandable-cell>
+					</smoothly-table-row>
 
-				<smoothly-table-row>
-					<smoothly-table-cell>normal row (nor.cell)"</smoothly-table-cell>
-					<smoothly-table-cell>normal cell</smoothly-table-cell>
-					<smoothly-table-expandable-cell>
-						expandable cell
-						<div slot="detail">expandable cell details.</div>
-					</smoothly-table-expandable-cell>
-					<smoothly-table-expandable-cell>
-						expandable cell
-						<div slot="detail">expandable cell details.</div>
-					</smoothly-table-expandable-cell>
-				</smoothly-table-row>
+					<smoothly-table-row>
+						<smoothly-table-cell>normal row (nor.cell)"</smoothly-table-cell>
+						<smoothly-table-cell>normal cell</smoothly-table-cell>
+						<smoothly-table-expandable-cell>
+							expandable cell
+							<div slot="detail">expandable cell details.</div>
+						</smoothly-table-expandable-cell>
+						<smoothly-table-expandable-cell>
+							expandable cell
+							<div slot="detail">expandable cell details.</div>
+						</smoothly-table-expandable-cell>
+					</smoothly-table-row>
 
-				<smoothly-table-expandable-row>
-					<smoothly-table-cell>expandable row (nor.cell)</smoothly-table-cell>
-					<smoothly-table-cell>Normal cell</smoothly-table-cell>
-					<smoothly-table-cell>normal cell</smoothly-table-cell>
-					<smoothly-table-cell>Normal cell</smoothly-table-cell>
-					<div slot="detail">expandable row content</div>
-				</smoothly-table-expandable-row>
-			</smoothly-table>,
-		]
+					<smoothly-table-expandable-row>
+						<smoothly-table-cell>expandable row (nor.cell)</smoothly-table-cell>
+						<smoothly-table-cell>Normal cell</smoothly-table-cell>
+						<smoothly-table-cell>normal cell</smoothly-table-cell>
+						<smoothly-table-cell>Normal cell</smoothly-table-cell>
+						<div slot="detail">expandable row content</div>
+					</smoothly-table-expandable-row>
+				</smoothly-table>
+				<smoothly-table>
+					<smoothly-table-row>
+						<smoothly-table-header>Header A</smoothly-table-header>
+						<smoothly-table-header></smoothly-table-header>
+					</smoothly-table-row>
+					<smoothly-table-expandable-row>
+						A Content
+						<div slot="detail">
+							<smoothly-tab-switch>
+								<smoothly-tab label="1" open={true}>
+									<smoothly-table>
+										<smoothly-table-row>
+											<smoothly-table-header>Header B</smoothly-table-header>
+											<smoothly-table-header></smoothly-table-header>
+										</smoothly-table-row>
+										<smoothly-table-expandable-row>
+											<smoothly-table-cell>B Content</smoothly-table-cell>
+										</smoothly-table-expandable-row>
+									</smoothly-table>
+								</smoothly-tab>
+							</smoothly-tab-switch>
+						</div>
+					</smoothly-table-expandable-row>
+				</smoothly-table>
+			</Host>
+		)
 	}
 }

--- a/src/components/table/demo/index.tsx
+++ b/src/components/table/demo/index.tsx
@@ -1,4 +1,4 @@
-import { Component, h, Host } from "@stencil/core"
+import { Component, h } from "@stencil/core"
 
 @Component({
 	tag: "smoothly-table-demo",
@@ -7,81 +7,79 @@ import { Component, h, Host } from "@stencil/core"
 })
 export class TableDemo {
 	render() {
-		return (
-			<Host>
-				<smoothly-table>
-					<smoothly-table-row>
-						<smoothly-table-header>Header A</smoothly-table-header>
-						<smoothly-table-header>Header B</smoothly-table-header>
-						<smoothly-table-header>Header C</smoothly-table-header>
-						<smoothly-table-header>Header D</smoothly-table-header>
-						<smoothly-table-header></smoothly-table-header>
-					</smoothly-table-row>
-					<smoothly-table-row>
-						<smoothly-table-expandable-cell>
-							normal row (exp.cell)
-							<div slot="detail">expandable cell 1 content</div>
-						</smoothly-table-expandable-cell>
-						<smoothly-table-expandable-cell>
-							expandable cell
-							<div slot="detail">expandable cell 2 content</div>
-						</smoothly-table-expandable-cell>
-						<smoothly-table-expandable-cell>
-							expandable cell
-							<div slot="detail">expandable cell 3 content</div>
-						</smoothly-table-expandable-cell>
-						<smoothly-table-expandable-cell>
-							expandable cell
-							<div slot="detail">expandable cell 4 content</div>
-						</smoothly-table-expandable-cell>
-					</smoothly-table-row>
+		return [
+			<smoothly-table>
+				<smoothly-table-row>
+					<smoothly-table-header>Header A</smoothly-table-header>
+					<smoothly-table-header>Header B</smoothly-table-header>
+					<smoothly-table-header>Header C</smoothly-table-header>
+					<smoothly-table-header>Header D</smoothly-table-header>
+					<smoothly-table-header></smoothly-table-header>
+				</smoothly-table-row>
+				<smoothly-table-row>
+					<smoothly-table-expandable-cell>
+						normal row (exp.cell)
+						<div slot="detail">expandable cell 1 content</div>
+					</smoothly-table-expandable-cell>
+					<smoothly-table-expandable-cell>
+						expandable cell
+						<div slot="detail">expandable cell 2 content</div>
+					</smoothly-table-expandable-cell>
+					<smoothly-table-expandable-cell>
+						expandable cell
+						<div slot="detail">expandable cell 3 content</div>
+					</smoothly-table-expandable-cell>
+					<smoothly-table-expandable-cell>
+						expandable cell
+						<div slot="detail">expandable cell 4 content</div>
+					</smoothly-table-expandable-cell>
+				</smoothly-table-row>
 
-					<smoothly-table-row>
-						<smoothly-table-cell>normal row (nor.cell)"</smoothly-table-cell>
-						<smoothly-table-cell>normal cell</smoothly-table-cell>
-						<smoothly-table-expandable-cell>
-							expandable cell
-							<div slot="detail">expandable cell details.</div>
-						</smoothly-table-expandable-cell>
-						<smoothly-table-expandable-cell>
-							expandable cell
-							<div slot="detail">expandable cell details.</div>
-						</smoothly-table-expandable-cell>
-					</smoothly-table-row>
+				<smoothly-table-row>
+					<smoothly-table-cell>normal row (nor.cell)"</smoothly-table-cell>
+					<smoothly-table-cell>normal cell</smoothly-table-cell>
+					<smoothly-table-expandable-cell>
+						expandable cell
+						<div slot="detail">expandable cell details.</div>
+					</smoothly-table-expandable-cell>
+					<smoothly-table-expandable-cell>
+						expandable cell
+						<div slot="detail">expandable cell details.</div>
+					</smoothly-table-expandable-cell>
+				</smoothly-table-row>
 
-					<smoothly-table-expandable-row>
-						<smoothly-table-cell>expandable row (nor.cell)</smoothly-table-cell>
-						<smoothly-table-cell>Normal cell</smoothly-table-cell>
-						<smoothly-table-cell>normal cell</smoothly-table-cell>
-						<smoothly-table-cell>Normal cell</smoothly-table-cell>
-						<div slot="detail">expandable row content</div>
-					</smoothly-table-expandable-row>
-				</smoothly-table>
-				<smoothly-table>
-					<smoothly-table-row>
-						<smoothly-table-header>Header A</smoothly-table-header>
-						<smoothly-table-header></smoothly-table-header>
-					</smoothly-table-row>
-					<smoothly-table-expandable-row>
-						A Content
-						<div slot="detail">
-							<smoothly-tab-switch>
-								<smoothly-tab label="1" open={true}>
-									<smoothly-table>
-										<smoothly-table-row>
-											<smoothly-table-header>Header B</smoothly-table-header>
-											<smoothly-table-header></smoothly-table-header>
-										</smoothly-table-row>
-										<smoothly-table-expandable-row>
-											<smoothly-table-cell>B Content</smoothly-table-cell>
-										</smoothly-table-expandable-row>
-									</smoothly-table>
-								</smoothly-tab>
-							</smoothly-tab-switch>
-						</div>
-					</smoothly-table-expandable-row>
-				</smoothly-table>
-			</Host>
-		)
+				<smoothly-table-expandable-row>
+					<smoothly-table-cell>expandable row (nor.cell)</smoothly-table-cell>
+					<smoothly-table-cell>Normal cell</smoothly-table-cell>
+					<smoothly-table-cell>normal cell</smoothly-table-cell>
+					<smoothly-table-cell>Normal cell</smoothly-table-cell>
+					<div slot="detail">expandable row content</div>
+				</smoothly-table-expandable-row>
+			</smoothly-table>,
+			<smoothly-table>
+				<smoothly-table-row>
+					<smoothly-table-header>Header A</smoothly-table-header>
+					<smoothly-table-header></smoothly-table-header>
+				</smoothly-table-row>
+				<smoothly-table-expandable-row>
+					A Content
+					<div slot="detail">
+						<smoothly-tab-switch>
+							<smoothly-tab label="1" open={true}>
+								<smoothly-table>
+									<smoothly-table-row>
+										<smoothly-table-header>Header B</smoothly-table-header>
+										<smoothly-table-header></smoothly-table-header>
+									</smoothly-table-row>
+									<smoothly-table-expandable-row>
+										<smoothly-table-cell>B Content</smoothly-table-cell>
+									</smoothly-table-expandable-row>
+								</smoothly-table>
+							</smoothly-tab>
+						</smoothly-tab-switch>
+					</div>
+				</smoothly-table-expandable-row>
+			</smoothly-table>,
+		]
 	}
 }

--- a/src/components/table/expandable/cell/index.tsx
+++ b/src/components/table/expandable/cell/index.tsx
@@ -9,7 +9,7 @@ export class TableExpandableCell implements ComponentDidLoad {
 	@Element() element: HTMLSmoothlyTableExpandableCellElement
 	expansionElement?: HTMLTableRowElement
 	@Event() expansionOpen: EventEmitter<HTMLElement>
-	@Event() expansionLoaded: EventEmitter<void>
+	@Event() expansionLoad: EventEmitter<void>
 	@Prop() align: "left" | "center" | "right" = "left"
 	@Prop({ mutable: true, reflect: true }) open: boolean
 	private beginOpen: boolean
@@ -26,7 +26,7 @@ export class TableExpandableCell implements ComponentDidLoad {
 		this.open = !this.open
 	}
 	componentDidLoad(): void {
-		this.expansionLoaded.emit()
+		this.expansionLoad.emit()
 	}
 	componentDidRender(): void {
 		if (this.beginOpen) {

--- a/src/components/table/expandable/cell/index.tsx
+++ b/src/components/table/expandable/cell/index.tsx
@@ -1,16 +1,4 @@
-import {
-	Component,
-	ComponentDidLoad,
-	Element,
-	Event,
-	EventEmitter,
-	h,
-	Host,
-	Listen,
-	Prop,
-	State,
-	Watch,
-} from "@stencil/core"
+import { Component, ComponentDidLoad, Element, Event, EventEmitter, h, Host, Listen, Prop, Watch } from "@stencil/core"
 
 @Component({
 	tag: "smoothly-table-expandable-cell",
@@ -24,7 +12,7 @@ export class TableExpandableCell implements ComponentDidLoad {
 	@Event() expansionLoaded: EventEmitter<void>
 	@Prop() align: "left" | "center" | "right" = "left"
 	@Prop({ mutable: true, reflect: true }) open: boolean
-	@State() beginOpen: boolean
+	private beginOpen: boolean
 	@Watch("open")
 	openChanged(value: boolean) {
 		if (this.expansionElement)
@@ -52,7 +40,7 @@ export class TableExpandableCell implements ComponentDidLoad {
 				<slot></slot>
 				<smoothly-icon name="chevron-forward" size="tiny"></smoothly-icon>
 				<tr ref={e => (this.expansionElement = e)}>
-					<td colSpan={500} class={!this.open ? "hide" : ""}>
+					<td colSpan={999} class={!this.open ? "hide" : ""}>
 						<div class="slot-detail">
 							<slot name="detail"></slot>
 						</div>

--- a/src/components/table/expandable/row/index.tsx
+++ b/src/components/table/expandable/row/index.tsx
@@ -1,4 +1,4 @@
-import { Component, Element, Event, EventEmitter, h, Host, Listen, Prop, State, Watch } from "@stencil/core"
+import { Component, Element, Event, EventEmitter, h, Host, Listen, Prop, Watch } from "@stencil/core"
 
 @Component({
 	tag: "smoothly-table-expandable-row",
@@ -11,7 +11,6 @@ export class TableExpandableRow {
 	@Event() expansionOpen: EventEmitter<HTMLElement>
 	@Prop() align: "left" | "center" | "right" = "left"
 	@Prop({ mutable: true, reflect: true }) open: boolean
-	@State() beginOpen: boolean
 	@Watch("open")
 	openChanged(value: boolean) {
 		if (this.expansionElement)
@@ -37,7 +36,7 @@ export class TableExpandableRow {
 					<smoothly-icon name="chevron-forward" size="tiny"></smoothly-icon>
 				</smoothly-table-cell>
 				<tr ref={e => (this.expansionElement = e)}>
-					<td colSpan={500} class={!this.open ? "hide" : ""}>
+					<td colSpan={999} class={!this.open ? "hide" : ""}>
 						<div class="slot-detail">
 							<slot name="detail"></slot>
 						</div>

--- a/src/components/table/index.tsx
+++ b/src/components/table/index.tsx
@@ -1,4 +1,4 @@
-import { Component, Element, Event, EventEmitter, h } from "@stencil/core"
+import { Component, Element, Event, EventEmitter, h, Listen } from "@stencil/core"
 
 @Component({
 	tag: "smoothly-table",
@@ -8,6 +8,11 @@ import { Component, Element, Event, EventEmitter, h } from "@stencil/core"
 export class Table {
 	@Element() element: HTMLSmoothlyTableElement
 	@Event() loadMore: EventEmitter<void>
+	@Listen("expansionLoaded")
+	@Listen("expansionOpen")
+	handleEvents(event: Event) {
+		event.stopPropagation()
+	}
 	render() {
 		return [<slot></slot>]
 	}

--- a/src/components/table/index.tsx
+++ b/src/components/table/index.tsx
@@ -8,7 +8,7 @@ import { Component, Element, Event, EventEmitter, h, Listen } from "@stencil/cor
 export class Table {
 	@Element() element: HTMLSmoothlyTableElement
 	@Event() loadMore: EventEmitter<void>
-	@Listen("expansionLoaded")
+	@Listen("expansionLoad")
 	@Listen("expansionOpen")
 	handleEvents(event: Event) {
 		event.stopPropagation()


### PR DESCRIPTION
* button fix to removed the bottom "margin" from inline-block element
* added readonly property to input as disabled inputs does not propagate events to parents in firefox.
* added `smoothlyDone` event to input to mimic the HTML standard `change` event but named it `smoothlyDone` as smoothly already have a `smoothlyChange` event that mimics the HTML standard `input` event.
* added stopPropagation to `tabSwitch` and `table` as it prevented them from being nested in eachother.
* removed warnings by removing a State.