### PR TITLE
select None name fix

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -172,6 +172,7 @@ export namespace Components {
         "multiple": boolean;
         "optionStyle": any;
         "options": OptionType[];
+        "selectAllName": string;
         "selectNoneName": string;
         "selectionName": string;
         "selections": OptionType[];
@@ -283,106 +284,6 @@ export namespace Components {
     interface SmoothlyUrlencoded {
         "data": string;
     }
-}
-export interface SmoothlyAccordionItemCustomEvent<T> extends CustomEvent<T> {
-    detail: T;
-    target: HTMLSmoothlyAccordionItemElement;
-}
-export interface SmoothlyCalendarCustomEvent<T> extends CustomEvent<T> {
-    detail: T;
-    target: HTMLSmoothlyCalendarElement;
-}
-export interface SmoothlyCheckboxCustomEvent<T> extends CustomEvent<T> {
-    detail: T;
-    target: HTMLSmoothlyCheckboxElement;
-}
-export interface SmoothlyDisplayDemoCustomEvent<T> extends CustomEvent<T> {
-    detail: T;
-    target: HTMLSmoothlyDisplayDemoElement;
-}
-export interface SmoothlyFrameCustomEvent<T> extends CustomEvent<T> {
-    detail: T;
-    target: HTMLSmoothlyFrameElement;
-}
-export interface SmoothlyInputCustomEvent<T> extends CustomEvent<T> {
-    detail: T;
-    target: HTMLSmoothlyInputElement;
-}
-export interface SmoothlyInputDateCustomEvent<T> extends CustomEvent<T> {
-    detail: T;
-    target: HTMLSmoothlyInputDateElement;
-}
-export interface SmoothlyInputDateRangeCustomEvent<T> extends CustomEvent<T> {
-    detail: T;
-    target: HTMLSmoothlyInputDateRangeElement;
-}
-export interface SmoothlyInputMonthCustomEvent<T> extends CustomEvent<T> {
-    detail: T;
-    target: HTMLSmoothlyInputMonthElement;
-}
-export interface SmoothlyItemCustomEvent<T> extends CustomEvent<T> {
-    detail: T;
-    target: HTMLSmoothlyItemElement;
-}
-export interface SmoothlyNotificationCustomEvent<T> extends CustomEvent<T> {
-    detail: T;
-    target: HTMLSmoothlyNotificationElement;
-}
-export interface SmoothlyOptionCustomEvent<T> extends CustomEvent<T> {
-    detail: T;
-    target: HTMLSmoothlyOptionElement;
-}
-export interface SmoothlyPickerCustomEvent<T> extends CustomEvent<T> {
-    detail: T;
-    target: HTMLSmoothlyPickerElement;
-}
-export interface SmoothlyPopupCustomEvent<T> extends CustomEvent<T> {
-    detail: T;
-    target: HTMLSmoothlyPopupElement;
-}
-export interface SmoothlyRadioCustomEvent<T> extends CustomEvent<T> {
-    detail: T;
-    target: HTMLSmoothlyRadioElement;
-}
-export interface SmoothlyReorderCustomEvent<T> extends CustomEvent<T> {
-    detail: T;
-    target: HTMLSmoothlyReorderElement;
-}
-export interface SmoothlySelectCustomEvent<T> extends CustomEvent<T> {
-    detail: T;
-    target: HTMLSmoothlySelectElement;
-}
-export interface SmoothlySelectorCustomEvent<T> extends CustomEvent<T> {
-    detail: T;
-    target: HTMLSmoothlySelectorElement;
-}
-export interface SmoothlySubmitCustomEvent<T> extends CustomEvent<T> {
-    detail: T;
-    target: HTMLSmoothlySubmitElement;
-}
-export interface SmoothlyTabCustomEvent<T> extends CustomEvent<T> {
-    detail: T;
-    target: HTMLSmoothlyTabElement;
-}
-export interface SmoothlyTableCustomEvent<T> extends CustomEvent<T> {
-    detail: T;
-    target: HTMLSmoothlyTableElement;
-}
-export interface SmoothlyTableExpandableCellCustomEvent<T> extends CustomEvent<T> {
-    detail: T;
-    target: HTMLSmoothlyTableExpandableCellElement;
-}
-export interface SmoothlyTableExpandableRowCustomEvent<T> extends CustomEvent<T> {
-    detail: T;
-    target: HTMLSmoothlyTableExpandableRowElement;
-}
-export interface SmoothlyTriggerCustomEvent<T> extends CustomEvent<T> {
-    detail: T;
-    target: HTMLSmoothlyTriggerElement;
-}
-export interface SmoothlyTriggerSourceCustomEvent<T> extends CustomEvent<T> {
-    detail: T;
-    target: HTMLSmoothlyTriggerSourceElement;
 }
 declare global {
     interface HTMLSmoothlyAccordionElement extends Components.SmoothlyAccordion, HTMLStencilElement {
@@ -787,10 +688,10 @@ declare namespace LocalJSX {
     interface SmoothlyAccordionItem {
         "brand"?: string | string[];
         "name"?: string;
-        "onSmoothlyAccordionItemDidLoad"?: (event: SmoothlyAccordionItemCustomEvent<void>) => void;
-        "onSmoothlyAccordionItemDidUnload"?: (event: SmoothlyAccordionItemCustomEvent<void>) => void;
-        "onSmoothlyClose"?: (event: SmoothlyAccordionItemCustomEvent<{ name: string; open: boolean }>) => void;
-        "onSmoothlyOpen"?: (event: SmoothlyAccordionItemCustomEvent<{ name: string; open: boolean }>) => void;
+        "onSmoothlyAccordionItemDidLoad"?: (event: CustomEvent<void>) => void;
+        "onSmoothlyAccordionItemDidUnload"?: (event: CustomEvent<void>) => void;
+        "onSmoothlyClose"?: (event: CustomEvent<{ name: string; open: boolean }>) => void;
+        "onSmoothlyOpen"?: (event: CustomEvent<{ name: string; open: boolean }>) => void;
         "open"?: boolean;
     }
     interface SmoothlyApp {
@@ -819,18 +720,18 @@ declare namespace LocalJSX {
         "max"?: Date;
         "min"?: Date;
         "month"?: Date;
-        "onDateRangeSet"?: (event: SmoothlyCalendarCustomEvent<DateRange>) => void;
-        "onDateSet"?: (event: SmoothlyCalendarCustomEvent<Date>) => void;
-        "onEndChanged"?: (event: SmoothlyCalendarCustomEvent<Date>) => void;
-        "onStartChanged"?: (event: SmoothlyCalendarCustomEvent<Date>) => void;
-        "onValueChanged"?: (event: SmoothlyCalendarCustomEvent<Date>) => void;
+        "onDateRangeSet"?: (event: CustomEvent<DateRange>) => void;
+        "onDateSet"?: (event: CustomEvent<Date>) => void;
+        "onEndChanged"?: (event: CustomEvent<Date>) => void;
+        "onStartChanged"?: (event: CustomEvent<Date>) => void;
+        "onValueChanged"?: (event: CustomEvent<Date>) => void;
         "start"?: Date;
         "value"?: Date;
     }
     interface SmoothlyCheckbox {
         "disabled"?: boolean;
         "intermediate"?: boolean;
-        "onChecked"?: (event: SmoothlyCheckboxCustomEvent<{ selected: boolean }>) => void;
+        "onChecked"?: (event: CustomEvent<{ selected: boolean }>) => void;
         "selectAll"?: boolean;
         "selected"?: boolean;
         "size"?: "tiny" | "small" | "medium" | "large";
@@ -857,12 +758,12 @@ declare namespace LocalJSX {
         "datetime"?: DateTime;
     }
     interface SmoothlyDisplayDemo {
-        "onNotice"?: (event: SmoothlyDisplayDemoCustomEvent<Notice>) => void;
+        "onNotice"?: (event: CustomEvent<Notice>) => void;
     }
     interface SmoothlyFrame {
         "name"?: string;
-        "onMessage"?: (event: SmoothlyFrameCustomEvent<Message<any>>) => void;
-        "onTrigger"?: (event: SmoothlyFrameCustomEvent<Trigger>) => void;
+        "onMessage"?: (event: CustomEvent<Message<any>>) => void;
+        "onTrigger"?: (event: CustomEvent<Trigger>) => void;
         "origin"?: string | undefined;
         "url"?: string;
     }
@@ -885,9 +786,9 @@ declare namespace LocalJSX {
         "maxLength"?: number;
         "minLength"?: number;
         "name"?: string;
-        "onSmoothlyBlur"?: (event: SmoothlyInputCustomEvent<void>) => void;
-        "onSmoothlyChange"?: (event: SmoothlyInputCustomEvent<{ name: string; value: any }>) => void;
-        "onSmoothlyInput"?: (event: SmoothlyInputCustomEvent<{ name: string; value: any }>) => void;
+        "onSmoothlyBlur"?: (event: CustomEvent<void>) => void;
+        "onSmoothlyChange"?: (event: CustomEvent<{ name: string; value: any }>) => void;
+        "onSmoothlyInput"?: (event: CustomEvent<{ name: string; value: any }>) => void;
         "pattern"?: RegExp | undefined;
         "placeholder"?: string | undefined;
         "readonly"?: boolean;
@@ -900,7 +801,7 @@ declare namespace LocalJSX {
         "disabled"?: boolean;
         "max"?: Date;
         "min"?: Date;
-        "onValueChanged"?: (event: SmoothlyInputDateCustomEvent<Date>) => void;
+        "onValueChanged"?: (event: CustomEvent<Date>) => void;
         "open"?: boolean;
         "value"?: Date;
     }
@@ -908,8 +809,8 @@ declare namespace LocalJSX {
         "end"?: Date;
         "max"?: Date;
         "min"?: Date;
-        "onDateRangeSelected"?: (event: SmoothlyInputDateRangeCustomEvent<{ start: Date; end: Date }>) => void;
-        "onValueChanged"?: (event: SmoothlyInputDateRangeCustomEvent<Date>) => void;
+        "onDateRangeSelected"?: (event: CustomEvent<{ start: Date; end: Date }>) => void;
+        "onValueChanged"?: (event: CustomEvent<Date>) => void;
         "open"?: boolean;
         "showLabel"?: boolean;
         "start"?: Date;
@@ -918,11 +819,11 @@ declare namespace LocalJSX {
     interface SmoothlyInputDemo {
     }
     interface SmoothlyInputMonth {
-        "onValueChanged"?: (event: SmoothlyInputMonthCustomEvent<Date>) => void;
+        "onValueChanged"?: (event: CustomEvent<Date>) => void;
         "value"?: Date;
     }
     interface SmoothlyItem {
-        "onItemSelected"?: (event: SmoothlyItemCustomEvent<void>) => void;
+        "onItemSelected"?: (event: CustomEvent<void>) => void;
         "selected"?: boolean;
         "value"?: any;
     }
@@ -936,7 +837,7 @@ declare namespace LocalJSX {
     }
     interface SmoothlyNotification {
         "notice"?: Notice;
-        "onRemove"?: (event: SmoothlyNotificationCustomEvent<Notice>) => void;
+        "onRemove"?: (event: CustomEvent<Notice>) => void;
     }
     interface SmoothlyNotifier {
     }
@@ -945,8 +846,8 @@ declare namespace LocalJSX {
         "dataHighlight"?: boolean;
         "divider"?: boolean;
         "name"?: string;
-        "onOptionHover"?: (event: SmoothlyOptionCustomEvent<{ value: any; name: string }>) => void;
-        "onOptionSelect"?: (event: SmoothlyOptionCustomEvent<{ value: any; name: string }>) => void;
+        "onOptionHover"?: (event: CustomEvent<{ value: any; name: string }>) => void;
+        "onOptionSelect"?: (event: CustomEvent<{ value: any; name: string }>) => void;
         "value"?: string;
     }
     interface SmoothlyPicker {
@@ -956,16 +857,17 @@ declare namespace LocalJSX {
         "maxHeight"?: string;
         "maxMenuHeight"?: "inherit";
         "multiple"?: boolean;
-        "onMenuClose"?: (event: SmoothlyPickerCustomEvent<OptionType[]>) => void;
+        "onMenuClose"?: (event: CustomEvent<OptionType[]>) => void;
         "optionStyle"?: any;
         "options"?: OptionType[];
+        "selectAllName"?: string;
         "selectNoneName"?: string;
         "selectionName"?: string;
         "selections"?: OptionType[];
     }
     interface SmoothlyPopup {
         "direction"?: "up" | "down";
-        "onPopup"?: (event: SmoothlyPopupCustomEvent<boolean>) => void;
+        "onPopup"?: (event: CustomEvent<boolean>) => void;
         "visible"?: boolean;
     }
     interface SmoothlyQuiet {
@@ -974,7 +876,7 @@ declare namespace LocalJSX {
     interface SmoothlyRadio {
         "checked"?: boolean;
         "name"?: string;
-        "onSmoothlySelected"?: (event: SmoothlyRadioCustomEvent<{ name: string; value: string }>) => void;
+        "onSmoothlySelected"?: (event: CustomEvent<{ name: string; value: string }>) => void;
         "tabIndex"?: number;
         "value"?: string;
     }
@@ -982,7 +884,7 @@ declare namespace LocalJSX {
         "orientation"?: "horizontal" | "vertical";
     }
     interface SmoothlyReorder {
-        "onReorder"?: (event: SmoothlyReorderCustomEvent<[number, number]>) => void;
+        "onReorder"?: (event: CustomEvent<[number, number]>) => void;
     }
     interface SmoothlyRoom {
         "icon"?: string;
@@ -993,13 +895,13 @@ declare namespace LocalJSX {
     interface SmoothlySelect {
         "background"?: string;
         "identifier"?: string;
-        "onSelectionChanged"?: (event: SmoothlySelectCustomEvent<{ identifier: string; value: string }>) => void;
+        "onSelectionChanged"?: (event: CustomEvent<{ identifier: string; value: string }>) => void;
         "value"?: string;
     }
     interface SmoothlySelectDemo {
     }
     interface SmoothlySelector {
-        "onSelected"?: (event: SmoothlySelectorCustomEvent<any>) => void;
+        "onSelected"?: (event: CustomEvent<any>) => void;
     }
     interface SmoothlySkeleton {
         "align"?: "left" | "center" | "right";
@@ -1018,7 +920,7 @@ declare namespace LocalJSX {
         "disabled"?: boolean;
         "expand"?: Expand;
         "fill"?: Fill;
-        "onSubmit"?: (event: SmoothlySubmitCustomEvent<{ [key: string]: string }>) => void;
+        "onSubmit"?: (event: CustomEvent<{ [key: string]: string }>) => void;
         "prevent"?: boolean;
         "processing"?: boolean;
     }
@@ -1029,13 +931,13 @@ declare namespace LocalJSX {
     }
     interface SmoothlyTab {
         "label"?: string;
-        "onExpansionOpen"?: (event: SmoothlyTabCustomEvent<HTMLElement>) => void;
+        "onExpansionOpen"?: (event: CustomEvent<HTMLElement>) => void;
         "open"?: boolean;
     }
     interface SmoothlyTabSwitch {
     }
     interface SmoothlyTable {
-        "onLoadMore"?: (event: SmoothlyTableCustomEvent<void>) => void;
+        "onLoadMore"?: (event: CustomEvent<void>) => void;
     }
     interface SmoothlyTableCell {
     }
@@ -1043,13 +945,13 @@ declare namespace LocalJSX {
     }
     interface SmoothlyTableExpandableCell {
         "align"?: "left" | "center" | "right";
-        "onExpansionLoad"?: (event: SmoothlyTableExpandableCellCustomEvent<void>) => void;
-        "onExpansionOpen"?: (event: SmoothlyTableExpandableCellCustomEvent<HTMLElement>) => void;
+        "onExpansionLoad"?: (event: CustomEvent<void>) => void;
+        "onExpansionOpen"?: (event: CustomEvent<HTMLElement>) => void;
         "open"?: boolean;
     }
     interface SmoothlyTableExpandableRow {
         "align"?: "left" | "center" | "right";
-        "onExpansionOpen"?: (event: SmoothlyTableExpandableRowCustomEvent<HTMLElement>) => void;
+        "onExpansionOpen"?: (event: CustomEvent<HTMLElement>) => void;
         "open"?: boolean;
     }
     interface SmoothlyTableHeader {
@@ -1063,7 +965,7 @@ declare namespace LocalJSX {
         "expand"?: Expand;
         "fill"?: Fill;
         "name"?: string;
-        "onTrigger"?: (event: SmoothlyTriggerCustomEvent<Trigger>) => void;
+        "onTrigger"?: (event: CustomEvent<Trigger>) => void;
         "type"?: "link" | "button";
         "value"?: any;
     }
@@ -1074,8 +976,8 @@ declare namespace LocalJSX {
     }
     interface SmoothlyTriggerSource {
         "listen"?: string;
-        "onMessage"?: (event: SmoothlyTriggerSourceCustomEvent<Message<any>>) => void;
-        "onTrigger"?: (event: SmoothlyTriggerSourceCustomEvent<Trigger>) => void;
+        "onMessage"?: (event: CustomEvent<Message<any>>) => void;
+        "onTrigger"?: (event: CustomEvent<Trigger>) => void;
     }
     interface SmoothlyTuple {
         "tuple"?: [string, string];

--- a/src/components/picker/index.tsx
+++ b/src/components/picker/index.tsx
@@ -128,8 +128,6 @@ export class SmoothlyPicker {
 	}
 
 	render() {
-		if (this.label == "")
-			console.log("rendered", this.selections)
 		const cssVariables = {
 			"--max-height": this.maxHeight ?? "inherit",
 			"--label-display": this.labelSetting == "hide" ? "none" : "absolute",

--- a/src/components/picker/index.tsx
+++ b/src/components/picker/index.tsx
@@ -51,7 +51,6 @@ export class SmoothlyPicker {
 			: this.selections.map(s => s.value).includes(option.value)
 			? this.unselect(option)
 			: this.select(option)
-		// this.selectNoneName = this.selections.length == this.options.length ? "Select None" : "Select All"
 	}
 	toggleAll() {
 		this.selections = this.selections.length == this.options?.length ? [] : this.options

--- a/src/components/picker/index.tsx
+++ b/src/components/picker/index.tsx
@@ -22,6 +22,7 @@ export class SmoothlyPicker {
 	@Prop({ reflect: true }) label: string
 	@Prop({ mutable: true }) selections: OptionType[] = []
 	@Prop({ mutable: true }) selectNoneName = "Select None"
+	@Prop({ mutable: true }) selectAllName = "Select All"
 	@Prop({ mutable: true }) selectionName = "items selected"
 	@Event() menuClose: EventEmitter<OptionType[]>
 
@@ -50,6 +51,7 @@ export class SmoothlyPicker {
 			: this.selections.map(s => s.value).includes(option.value)
 			? this.unselect(option)
 			: this.select(option)
+		// this.selectNoneName = this.selections.length == this.options.length ? "Select None" : "Select All"
 	}
 	toggleAll() {
 		this.selections = this.selections.length == this.options?.length ? [] : this.options
@@ -127,6 +129,8 @@ export class SmoothlyPicker {
 	}
 
 	render() {
+		if (this.label == "")
+			console.log("rendered", this.selections)
 		const cssVariables = {
 			"--max-height": this.maxHeight ?? "inherit",
 			"--label-display": this.labelSetting == "hide" ? "none" : "absolute",
@@ -139,7 +143,7 @@ export class SmoothlyPicker {
 				? [
 						{
 							value: "select-none",
-							name: this.selectNoneName,
+							name: this.selections.length == this.options.length ? this.selectNoneName : this.selectAllName,
 							left: this.getCheckHtml(this.selections.length == this.options?.length),
 							divider: true,
 						},


### PR DESCRIPTION
Picker always said "Select None" even if no options were selected. Changed to "Select All" by default when at least one element is missing and "Select None" when all options are selected. The exact text can be changed with a prop just like before.