### PR TITLE
css improvement of expandable row, cell and tab-switch.

### DIFF
--- a/src/components/tab-switch/style.css
+++ b/src/components/tab-switch/style.css
@@ -1,5 +1,6 @@
 :host {
 	display: flex;
 	flex-direction: row;
-	margin: 1em 1em 0em 0em;
+	justify-content: space-around;
+	border-bottom: 3px solid rgb(var(--smoothly-default-shade));
 }

--- a/src/components/tab/style.css
+++ b/src/components/tab/style.css
@@ -1,18 +1,14 @@
-:host:not([open]) > label {
-	background-color: rgb(var(--smoothly-dark-shade));
+:host([open]) {
+	border-bottom: 3px solid rgb(var(--smoothly-primary-color));
+	box-sizing: border-box;
+	margin-bottom: -3px;
 }
 .hide {
 	display: none;
 }
 label {
 	display: block;
-	padding: 1em;
-	background-color: rgb(var(--smoothly-default-shade));
-	border-top-left-radius: 0.3rem;
-	border-top-right-radius: 0.3rem;
-	width: 6.25rem;
-}
-div {
-	background-color: rgb(var(--smoothly-default-shade));
-	padding: 1em;
+	padding: .5rem;
+	background-color: transparent;
+	width: auto;
 }

--- a/src/components/table/cell/style.css
+++ b/src/components/table/cell/style.css
@@ -1,5 +1,6 @@
 :host {
 	display: table-cell;
 	line-height: 1.5rem;
+	white-space: nowrap;
 	padding: 0.3rem 0 0.3rem 1rem;
 }

--- a/src/components/table/cell/style.css
+++ b/src/components/table/cell/style.css
@@ -1,6 +1,5 @@
 :host {
 	display: table-cell;
-	vertical-align: middle;
 	line-height: 1.5rem;
-	padding: 0.2rem 0 0.2rem 1rem;
+	padding: 0.3rem 0 0.3rem 1rem;
 }

--- a/src/components/table/demo/index.tsx
+++ b/src/components/table/demo/index.tsx
@@ -68,9 +68,7 @@ export class TableDemo {
 									<smoothly-table-row>
 										<smoothly-table-header>Header B</smoothly-table-header>
 									</smoothly-table-row>
-									<smoothly-table-expandable-row>
-										<smoothly-table-cell>B Content</smoothly-table-cell>
-									</smoothly-table-expandable-row>
+									<smoothly-table-expandable-row>B Content</smoothly-table-expandable-row>
 								</smoothly-table>
 							</smoothly-tab>
 							<smoothly-tab label="innertable 2">

--- a/src/components/table/demo/index.tsx
+++ b/src/components/table/demo/index.tsx
@@ -14,7 +14,6 @@ export class TableDemo {
 					<smoothly-table-header>Header B</smoothly-table-header>
 					<smoothly-table-header>Header C</smoothly-table-header>
 					<smoothly-table-header>Header D</smoothly-table-header>
-					<smoothly-table-header></smoothly-table-header>
 				</smoothly-table-row>
 				<smoothly-table-row>
 					<smoothly-table-expandable-cell>
@@ -59,20 +58,28 @@ export class TableDemo {
 			<smoothly-table>
 				<smoothly-table-row>
 					<smoothly-table-header>Header A</smoothly-table-header>
-					<smoothly-table-header></smoothly-table-header>
 				</smoothly-table-row>
 				<smoothly-table-expandable-row>
-					A Content
+					<smoothly-table-cell>A Content</smoothly-table-cell>
 					<div slot="detail">
 						<smoothly-tab-switch>
-							<smoothly-tab label="1" open={true}>
+							<smoothly-tab label="innertable 1" open={true}>
 								<smoothly-table>
 									<smoothly-table-row>
 										<smoothly-table-header>Header B</smoothly-table-header>
-										<smoothly-table-header></smoothly-table-header>
 									</smoothly-table-row>
 									<smoothly-table-expandable-row>
 										<smoothly-table-cell>B Content</smoothly-table-cell>
+									</smoothly-table-expandable-row>
+								</smoothly-table>
+							</smoothly-tab>
+							<smoothly-tab label="innertable 2">
+								<smoothly-table>
+									<smoothly-table-row>
+										<smoothly-table-header>Header C</smoothly-table-header>
+									</smoothly-table-row>
+									<smoothly-table-expandable-row>
+										<smoothly-table-cell>C Content</smoothly-table-cell>
 									</smoothly-table-expandable-row>
 								</smoothly-table>
 							</smoothly-tab>

--- a/src/components/table/expandable/cell/index.tsx
+++ b/src/components/table/expandable/cell/index.tsx
@@ -37,8 +37,10 @@ export class TableExpandableCell implements ComponentDidLoad {
 	render() {
 		return (
 			<Host style={{ textAlign: this.align }}>
-				<slot></slot>
-				<smoothly-icon name="chevron-forward" size="tiny"></smoothly-icon>
+				<aside>
+					<smoothly-icon name="chevron-forward" size="tiny"></smoothly-icon>
+					<slot></slot>
+				</aside>
 				<tr ref={e => (this.expansionElement = e)}>
 					<td colSpan={999} class={!this.open ? "hide" : ""}>
 						<div class="slot-detail">

--- a/src/components/table/expandable/cell/style.css
+++ b/src/components/table/expandable/cell/style.css
@@ -2,6 +2,7 @@
 	display: table-cell;
 	padding: 0.3rem 0 0.3rem 0;
 	cursor: pointer;
+	line-height: 1.5rem;
 }
 :host[open] {
 	position: relative;

--- a/src/components/table/expandable/cell/style.css
+++ b/src/components/table/expandable/cell/style.css
@@ -1,7 +1,6 @@
 :host {
 	display: table-cell;
-	min-width: 8rem;
-	padding: 0.3rem 0;
+	padding: 0.3rem 0 0.3rem 0;
 	cursor: pointer;
 }
 :host[open] {
@@ -9,12 +8,12 @@
 	z-index: 3;
 	background-color: rgb(var(--smoothly-default-color));
 	border: 2px solid rgb(var(--smoothly-dark-color));
-  border-bottom: none;
+	border-bottom: none;
 }
 :host smoothly-icon {
 	width: 0.6rem;
 	float: left;
-	padding: 0 0.3rem 0.5rem;
+	padding: 0 0.3rem;
 	transition: transform 0.2s;
 }
 :host[open] smoothly-icon {

--- a/src/components/table/expandable/cell/style.css
+++ b/src/components/table/expandable/cell/style.css
@@ -1,44 +1,40 @@
 :host {
 	display: table-cell;
-	vertical-align: middle;
-	line-height: 1.5em;
+	min-width: 8rem;
+	padding: 0.3rem 0;
 	cursor: pointer;
-	padding: 0.2em 0 0.2em;
-	border-style: solid solid none solid;
-	border-width: 2px;
-	border-color: rgb(var(--smoothly-default-color));
-}
-.hide {
-	display: none;
 }
 :host[open] {
 	position: relative;
 	z-index: 3;
 	background-color: rgb(var(--smoothly-default-color));
-	border-style: solid solid none solid;
-	border-width: 2px;
-	border-color: rgb(var(--smoothly-dark-color));
-}
-.slot-detail {
-	position: relative;
-	background-color: rgb(var(--smoothly-default-color));
-	width: 104%;
-	left: -2%;
-	border-left-style: solid;
-	border-left-color: rgb(var(--smoothly-tertiary-color));
-	box-shadow: 0px 0px 5px 4px rgb(var(--smoothly-dark-color), 0.5);
-	box-sizing: border-box;
-	padding: 0.5rem 2%;
+	border: 2px solid rgb(var(--smoothly-dark-color));
+  border-bottom: none;
 }
 :host smoothly-icon {
 	width: 0.6rem;
-	height: 1rem;
 	float: left;
-	padding-left: 0.2rem;
-	padding-right: 0.2rem;
-	padding-bottom: 0.5rem;
+	padding: 0 0.3rem 0.5rem;
 	transition: transform 0.2s;
 }
 :host[open] smoothly-icon {
 	transform: rotate(90deg);
 }
+aside {
+	display: flex;
+}
+.hide {
+	display: none;
+}
+
+.slot-detail {
+	position: relative;
+	background-color: rgb(var(--smoothly-default-color));
+	width: 104%;
+	left: -2%;
+	border-left: 2px solid rgb(var(--smoothly-tertiary-color));
+	box-shadow: 0px 0px 5px 4px rgb(var(--smoothly-dark-color), 0.5);
+	box-sizing: border-box;
+	padding: 0.5rem 2%;
+}
+

--- a/src/components/table/expandable/row/index.tsx
+++ b/src/components/table/expandable/row/index.tsx
@@ -32,9 +32,10 @@ export class TableExpandableRow {
 		return (
 			<Host style={{ textAlign: this.align }}>
 				<slot></slot>
-				<smoothly-table-cell>
+				<aside>
 					<smoothly-icon name="chevron-forward" size="tiny"></smoothly-icon>
-				</smoothly-table-cell>
+				</aside>
+
 				<tr ref={e => (this.expansionElement = e)}>
 					<td colSpan={999} class={!this.open ? "hide" : ""}>
 						<div class="slot-detail">

--- a/src/components/table/expandable/row/style.css
+++ b/src/components/table/expandable/row/style.css
@@ -12,9 +12,9 @@
 :host smoothly-icon {
 	width: 0.6rem;
 	height: 1rem;
-  position: absolute;
+	position: absolute;
 	right: 1rem;
-	top: -1rem;
+	top: -1.6rem;
 	transition: transform 0.2s;
 }
 :host[open] smoothly-icon {
@@ -22,6 +22,7 @@
 }
 
 aside {
+	display: table-row;
 	position: relative;
 }
 

--- a/src/components/table/expandable/row/style.css
+++ b/src/components/table/expandable/row/style.css
@@ -1,6 +1,7 @@
 :host {
 	display: table-row-group;
 	cursor: pointer;
+	line-height: 1.5rem;
 }
 :host[open] {
 	position: relative;
@@ -14,7 +15,7 @@
 	height: 1rem;
 	position: absolute;
 	right: 1rem;
-	top: -1.6rem;
+	top: -1.8rem;
 	transition: transform 0.2s;
 }
 :host[open] smoothly-icon {

--- a/src/components/table/expandable/row/style.css
+++ b/src/components/table/expandable/row/style.css
@@ -1,9 +1,29 @@
 :host {
 	display: table-row;
-	border: 1px solid rgb(var(--smoothly-default-color));
 	cursor: pointer;
-	box-sizing: border-box;
 }
+:host[open] {
+	position: relative;
+	z-index: 3;
+	background-color: rgb(var(--smoothly-default-color));
+	box-shadow: inset 2px 0px 0px 0px rgb(var(--smoothly-dark-color)), inset 0px 2px 0px 0px rgb(var(--smoothly-dark-color)), inset -2px 0px 0px 0px rgb(var(--smoothly-dark-color)), inset 0px 0px 0px 2px rgb(var(--smoothly-default-color));
+}
+:host smoothly-icon {
+	width: 0.6rem;
+	height: 1rem;
+  position: absolute;
+	right: 1rem;
+	top: -1rem;
+	transition: transform 0.2s;
+}
+:host[open] smoothly-icon {
+	transform: rotate(90deg);
+}
+
+aside {
+	position: relative;
+}
+
 .hide {
 	display: none;
 }
@@ -14,30 +34,7 @@
 	left: -2%;
 	border-left-style: solid;
 	border-left-color: rgb(var(--smoothly-tertiary-color));
-	box-shadow: 0px 0px 5px 2px rgb(var(--smoothly-dark-color), 0.5);
+	box-shadow: 0px 0px 4px 2px rgb(var(--smoothly-dark-color));
 	box-sizing: border-box;
 	padding: 0.5rem 2%;
-}
-:host smoothly-icon {
-	width: 0.6rem;
-	height: 1rem;
-	float: left;
-	padding-left: 0.2rem;
-	padding-right: 0.2rem;
-	padding-bottom: 0.5rem;
-	transition: transform 0.2s;
-}
-:host[open] smoothly-icon {
-	transform: rotate(90deg);
-}
-:host[open] smoothly-table-cell {
-	padding-bottom: 0.5rem;
-}
-:host[open] {
-	position: relative;
-	z-index: 3;
-	background-color: rgb(var(--smoothly-default-color));
-	border-style: solid;
-	border-width: 5px;
-	box-shadow: inset 2px 0px 0px 0px rgb(var(--smoothly-dark-color)), inset 0px 2px 0px 0px rgb(var(--smoothly-dark-color)), inset -2px 0px 0px 0px rgb(var(--smoothly-dark-color)), inset 0px 0px 0px 2px rgb(var(--smoothly-default-color));
 }

--- a/src/components/table/expandable/row/style.css
+++ b/src/components/table/expandable/row/style.css
@@ -1,12 +1,13 @@
 :host {
-	display: table-row;
+	display: table-row-group;
 	cursor: pointer;
 }
 :host[open] {
 	position: relative;
 	z-index: 3;
 	background-color: rgb(var(--smoothly-default-color));
-	box-shadow: inset 2px 0px 0px 0px rgb(var(--smoothly-dark-color)), inset 0px 2px 0px 0px rgb(var(--smoothly-dark-color)), inset -2px 0px 0px 0px rgb(var(--smoothly-dark-color)), inset 0px 0px 0px 2px rgb(var(--smoothly-default-color));
+	border: 2px solid rgb(var(--smoothly-dark-color));
+	border-bottom: none;
 }
 :host smoothly-icon {
 	width: 0.6rem;
@@ -38,3 +39,4 @@ aside {
 	box-sizing: border-box;
 	padding: 0.5rem 2%;
 }
+

--- a/src/components/table/header/style.css
+++ b/src/components/table/header/style.css
@@ -5,5 +5,4 @@
 	border-bottom: 1px solid rgb(var(--smoothly-dark-color));
 	padding-left: 1rem;
 	font-weight: bold;
-	margin-bottom: 5rem;
 }

--- a/src/components/table/row/style.css
+++ b/src/components/table/row/style.css
@@ -1,6 +1,5 @@
 :host {
 	display: table-row;
-	border: 1px solid rgb(var(--smoothly-dark-color), 0.5);
 	cursor: default;
 }
 .hide {

--- a/src/components/table/row/style.css
+++ b/src/components/table/row/style.css
@@ -1,6 +1,7 @@
 :host {
 	display: table-row;
 	cursor: default;
+	line-height: 1.5rem;
 }
 .hide {
 	display: none;

--- a/src/components/table/style.css
+++ b/src/components/table/style.css
@@ -2,13 +2,8 @@
 	display: table;
 	text-align: left;
 	border: 1px solid rgb(var(--smoothly-dark-color));
-	width: 80%;
+	width: var(--table-width, 80%);
 	box-sizing: border-box;
 	background-color: rgb(var(--smoothly-default-color));
-	margin: 1rem 9.5%;
-	padding-bottom: 0.5rem;
-}
-.slot-detail > div {
-	padding: 10rem 0;
-	margin-left: 10rem;
+	margin: auto;
 }

--- a/src/components/table/style.css
+++ b/src/components/table/style.css
@@ -1,6 +1,6 @@
 :host {
 	display: table;
-	text-align: left;
+	border-collapse: collapse;
 	border: 1px solid rgb(var(--smoothly-dark-color));
 	width: var(--table-width, 80%);
 	box-sizing: border-box;


### PR DESCRIPTION
Make chevron's position absolute, so it won't take extra space and no empty headers needed. 
Should only put table-cell or expandable-table-cell inside table-row. Otherwise tag like `p` will make the position of chevron unaligned


![Screenshot from 2022-08-15 10-30-38](https://user-images.githubusercontent.com/86956109/184602810-9932103d-4620-4c94-930b-962fd0580853.png)
