### PR TITLE
disabled + readonly picker

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -167,6 +167,7 @@ export namespace Components {
         "value": string;
     }
     interface SmoothlyPicker {
+        "disabled": boolean;
         "emptyMenuLabel": string;
         "label": string;
         "labelSetting": "hide" | "default";
@@ -177,6 +178,7 @@ export namespace Components {
         "newOptionLabel": string;
         "optionStyle": any;
         "options": OptionType[];
+        "readonly": boolean;
         "selectAllName": string;
         "selectNoneName": string;
         "selectionName": string;
@@ -862,6 +864,7 @@ declare namespace LocalJSX {
         "value"?: string;
     }
     interface SmoothlyPicker {
+        "disabled"?: boolean;
         "emptyMenuLabel"?: string;
         "label"?: string;
         "labelSetting"?: "hide" | "default";
@@ -874,6 +877,7 @@ declare namespace LocalJSX {
         "onNotice"?: (event: CustomEvent<Notice>) => void;
         "optionStyle"?: any;
         "options"?: OptionType[];
+        "readonly"?: boolean;
         "selectAllName"?: string;
         "selectNoneName"?: string;
         "selectionName"?: string;

--- a/src/components/picker/index.tsx
+++ b/src/components/picker/index.tsx
@@ -32,7 +32,6 @@ export class SmoothlyPicker {
 	@Prop() valueValidator: (value: any) => [boolean, Notice | undefined] = _ => [true, undefined]
 	@Event() menuClose: EventEmitter<OptionType[]>
 	@Event() notice: EventEmitter<Notice>
-	@Watch("selections")
 	@Watch("isOpen")
 	isOpenChangeHandler() {
 		if (this.isOpen == false) {

--- a/src/components/picker/index.tsx
+++ b/src/components/picker/index.tsx
@@ -13,6 +13,8 @@ export class SmoothlyPicker {
 	@Element() element: HTMLElement
 	@State() isOpen: boolean
 	@State() empty: boolean
+	@Prop({ reflect: true, attribute: "data-disabled" }) disabled = false
+	@Prop({ reflect: true, attribute: "data-readonly" }) readonly = false
 	@Prop() maxMenuHeight: "inherit"
 	@Prop() maxHeight: string
 	@Prop({ mutable: true }) emptyMenuLabel = "No Options"
@@ -140,10 +142,12 @@ export class SmoothlyPicker {
 		}
 	}
 	onClick() {
-		this.isOpen = !this.isOpen
-		this.inputElement.focus()
-		this.highlightDefault()
-		this.filterOptions()
+		if (!(this.readonly || this.disabled)) {
+			this.isOpen = !this.isOpen
+			this.inputElement.focus()
+			this.highlightDefault()
+			this.filterOptions()
+		}
 	}
 	onBlur() {
 		this.inputElement.value = ""
@@ -187,9 +191,11 @@ export class SmoothlyPicker {
 				onMouseDown={(e: MouseEvent) => e.preventDefault()}
 				onClick={() => this.onClick()}>
 				<div>
-					<smoothly-icon class="search" name="search-outline" size="tiny"></smoothly-icon>
+					<smoothly-icon part="search-icon" class="search" name="search-outline" size="tiny"></smoothly-icon>
 					<label>{this.label}</label>
 					<input
+						disabled={this.disabled}
+						readonly={this.readonly}
 						type="text"
 						ref={(el: HTMLInputElement) => (this.inputElement = el ? el : this.inputElement)}
 						onFocus={() => this.highlightDefault()}
@@ -201,8 +207,8 @@ export class SmoothlyPicker {
 						}
 						onKeyDown={e => this.onKeyDown(e)}
 						onInput={(e: UIEvent) => this.onInput(e)}></input>
-					<smoothly-icon class="down" name="chevron-down" size="tiny"></smoothly-icon>
-					<smoothly-icon class="up" name="chevron-up" size="tiny"></smoothly-icon>
+					<smoothly-icon part="chevron-icon" class="down" name="chevron-down" size="tiny"></smoothly-icon>
+					<smoothly-icon part="chevron-icon" class="up" name="chevron-up" size="tiny"></smoothly-icon>
 				</div>
 				<smoothly-menu-options
 					style={{ width: "100%" }}

--- a/src/components/picker/index.tsx
+++ b/src/components/picker/index.tsx
@@ -191,9 +191,10 @@ export class SmoothlyPicker {
 				onMouseDown={(e: MouseEvent) => e.preventDefault()}
 				onClick={() => this.onClick()}>
 				<div>
-					<smoothly-icon part="search-icon" class="search" name="search-outline" size="tiny"></smoothly-icon>
-					<label>{this.label}</label>
+					<smoothly-icon part="search" class="search" name="search-outline" size="tiny"></smoothly-icon>
+					<label part="label-element">{this.label}</label>
 					<input
+						part="input"
 						disabled={this.disabled}
 						readonly={this.readonly}
 						type="text"
@@ -207,10 +208,11 @@ export class SmoothlyPicker {
 						}
 						onKeyDown={e => this.onKeyDown(e)}
 						onInput={(e: UIEvent) => this.onInput(e)}></input>
-					<smoothly-icon part="chevron-icon" class="down" name="chevron-down" size="tiny"></smoothly-icon>
-					<smoothly-icon part="chevron-icon" class="up" name="chevron-up" size="tiny"></smoothly-icon>
+					<smoothly-icon part="chevron" class="down" name="chevron-down" size="tiny"></smoothly-icon>
+					<smoothly-icon part="chevron" class="up" name="chevron-up" size="tiny"></smoothly-icon>
 				</div>
 				<smoothly-menu-options
+					part="menu-options"
 					style={{ width: "100%" }}
 					optionStyle={{ ...this.optionStyle }}
 					order={false}

--- a/src/components/picker/index.tsx
+++ b/src/components/picker/index.tsx
@@ -13,8 +13,8 @@ export class SmoothlyPicker {
 	@Element() element: HTMLElement
 	@State() isOpen: boolean
 	@State() empty: boolean
-	@Prop({ reflect: true, attribute: "data-disabled" }) disabled = false
-	@Prop({ reflect: true, attribute: "data-readonly" }) readonly = false
+	@Prop({ reflect: true }) disabled = false
+	@Prop({ reflect: true }) readonly = false
 	@Prop() maxMenuHeight: "inherit"
 	@Prop() maxHeight: string
 	@Prop({ mutable: true }) emptyMenuLabel = "No Options"

--- a/src/components/select-demo/index.tsx
+++ b/src/components/select-demo/index.tsx
@@ -158,6 +158,12 @@ export class SmoothlySelectDemo {
 					{ name: "Dragon", value: "dragon" },
 					{ name: "Kraken", value: "kraken" },
 				]}></smoothly-picker>,
+			<br />,
+			<smoothly-picker
+				label="readonly"
+				readonly={true}
+				options={[{ name: "readonly", value: "readonly" }]}></smoothly-picker>,
+			<br />,
 			<smoothly-tab-switch>
 				<smoothly-tab label="test1" open>
 					Hello world!


### PR DESCRIPTION
* added reflected properties disabled and readonly.
* added `part` on the icons to allow CSS targeting outside shadow DOM.
* removed watcher on `selections`. Could cause infinite loops if selections are given and the selections given are linked with a Listen on the `menuClosed` event.