### PR TITLE
Routing

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -209,7 +209,7 @@ export namespace Components {
     interface SmoothlyRoom {
         "icon"?: string;
         "label"?: string;
-        "path": string;
+        "path": string | RegExp;
         "to"?: string;
     }
     interface SmoothlySelect {
@@ -1017,7 +1017,7 @@ declare namespace LocalJSX {
     interface SmoothlyRoom {
         "icon"?: string;
         "label"?: string;
-        "path"?: string;
+        "path"?: string | RegExp;
         "to"?: string;
     }
     interface SmoothlySelect {

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -95,26 +95,17 @@ export const App: FunctionalComponent<{ label: string }> = (attributes, nodes, u
 				<Router.Switch>
 					{children
 						.filter(child => child.vattrs?.path != undefined)
-						.map(child =>
-							child.vattrs?.to ? (
-								<Route
-									path={
-										typeof child.vattrs?.path == "string"
-											? resolve(child.vattrs?.path)
-											: child.vattrs?.path ?? child.vattrs?.path
-									}
-									to={child.vattrs?.to}></Route>
+						.map(child => {
+							const path =
+								typeof child.vattrs?.path == "string"
+									? resolve(child.vattrs?.path)
+									: child.vattrs?.path ?? child.vattrs?.path
+							return child.vattrs?.to ? (
+								<Route path={path} to={child.vattrs?.to}></Route>
 							) : (
-								<Route
-									path={
-										typeof child.vattrs?.path == "string"
-											? resolve(child.vattrs?.path)
-											: child.vattrs?.path ?? child.vattrs?.path
-									}>
-									{child.node}
-								</Route>
+								<Route path={path}>{child.node}</Route>
 							)
-						)}
+						})}
 				</Router.Switch>
 			</main>
 		</smoothly-app>

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -96,10 +96,7 @@ export const App: FunctionalComponent<{ label: string }> = (attributes, nodes, u
 					{children
 						.filter(child => child.vattrs?.path != undefined)
 						.map(child => {
-							const path =
-								typeof child.vattrs?.path == "string"
-									? resolve(child.vattrs?.path)
-									: child.vattrs?.path ?? child.vattrs?.path
+							const path = typeof child.vattrs?.path == "string" ? resolve(child.vattrs?.path) : child.vattrs?.path
 							return child.vattrs?.to ? (
 								<Route path={path} to={child.vattrs?.to}></Route>
 							) : (

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -19,7 +19,7 @@ export const App: FunctionalComponent<{ label: string }> = (attributes, nodes, u
 	function childToNode(child: ChildNode): VNode {
 		return utils.map([emptyNode], c => ({ ...c, ...child }))[0]
 	}
-	const children = nodes.map((node, index) => ({ ...nodeToChild(node), node }))
+	const children = nodes.map(node => ({ ...nodeToChild(node), node }))
 	return (
 		<smoothly-app>
 			<header>
@@ -32,7 +32,9 @@ export const App: FunctionalComponent<{ label: string }> = (attributes, nodes, u
 							.map(
 								[
 									...children.filter(child => child.vattrs?.slot == "nav-start"),
-									...children.filter(child => child.vattrs?.label && child.vattrs?.path),
+									...children.filter(
+										child => child.vattrs?.label && child.vattrs?.path && typeof child.vattrs?.path == "string"
+									),
 									...children.filter(child => child.vattrs?.slot == "nav-end"),
 								].map(child => child.node),
 								child => {
@@ -92,9 +94,22 @@ export const App: FunctionalComponent<{ label: string }> = (attributes, nodes, u
 						.filter(child => child.vattrs?.path != undefined)
 						.map(child =>
 							child.vattrs?.to ? (
-								<Route path={resolve(child.vattrs?.path) ?? child.vattrs?.path} to={child.vattrs?.to}></Route>
+								<Route
+									path={
+										typeof child.vattrs?.path == "string"
+											? resolve(child.vattrs?.path)
+											: child.vattrs?.path ?? child.vattrs?.path
+									}
+									to={child.vattrs?.to}></Route>
 							) : (
-								<Route path={resolve(child.vattrs?.path) ?? child.vattrs?.path}>{child.node}</Route>
+								<Route
+									path={
+										typeof child.vattrs?.path == "string"
+											? resolve(child.vattrs?.path)
+											: child.vattrs?.path ?? child.vattrs?.path
+									}>
+									{child.node}
+								</Route>
 							)
 						)}
 				</Router.Switch>

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -4,7 +4,10 @@ import { createRouter, href, Route } from "stencil-router-v2"
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const Router = createRouter()
-
+export function redirect(url: string) {
+	const destination = resolve(url)
+	destination ? Router.push(destination) : (window.location.href = url)
+}
 export const App: FunctionalComponent<{ label: string }> = (attributes, nodes, utils) => {
 	const emptyNode = Object.entries(nodes[0]).reduce<{ [property: string]: any }>((r, entry) => {
 		r[entry[0]] = null

--- a/src/components/app-demo/index.tsx
+++ b/src/components/app-demo/index.tsx
@@ -1,6 +1,7 @@
 import { Component, h, Prop } from "@stencil/core"
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { App } from "../App"
+import { redirect } from "../App"
 
 @Component({
 	tag: "smoothly-app-demo",
@@ -54,6 +55,25 @@ export class SmoothlyAppDemo {
 				</smoothly-room>
 				<smoothly-room path="icon" label="Icon">
 					<smoothly-icon-demo />
+				</smoothly-room>
+				<smoothly-room path="/redirect" label="Redirect">
+					<smoothly-button
+						style={{ "max-width": "300px" }}
+						onClick={() => {
+							redirect("/routing/pathParameter1")
+						}}>
+						Internal
+					</smoothly-button>
+					<smoothly-button
+						style={{ "max-width": "300px" }}
+						onClick={() => {
+							redirect("https://google.com")
+						}}>
+						External
+					</smoothly-button>
+				</smoothly-room>
+				<smoothly-room path={/^\/routing\/\w+\/?/} label="No effect">
+					<h2>Regex routing</h2>
 				</smoothly-room>
 				<smoothly-room path="old" label="Old" to="select"></smoothly-room>
 				<span slot="header" style={{ width: "100%", maxWidth: "500px" }}>

--- a/src/components/room/index.tsx
+++ b/src/components/room/index.tsx
@@ -6,7 +6,7 @@ import { Component, h, Prop } from "@stencil/core"
 export class SmoothlyRoom {
 	@Prop() label?: string
 	@Prop() icon?: string
-	@Prop() path: string
+	@Prop() path: string | RegExp
 	@Prop() to?: string
 	render() {
 		return <slot></slot>


### PR DESCRIPTION
Allows `<smoothly-room>`s to accept a regex as the `path`. If a path is a regex the provided `label` is unused and no link is generated in the `<header>`s `<nav>`. This allows routing with url parameters and probably other things.

Implemented `redirect(url)` to be able to redirect internally without page reloads.