### PR TITLE
delete display: block.

### DIFF
--- a/src/components/button/style.css
+++ b/src/components/button/style.css
@@ -18,7 +18,6 @@
 }
 a,
 button {
-	display: block;
 	border-color: transparent;
 	background-color: transparent;
 	padding: 0.2em 0.3em;


### PR DESCRIPTION
when the type is link, we want it to display as inline. It displays block when the type is not link