### PR TITLE
Fixed deselectable sending null when deselecting.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "smoothly",
       "version": "0.3.9",
       "license": "MIT",
       "dependencies": {

--- a/src/components/radio-button/index.tsx
+++ b/src/components/radio-button/index.tsx
@@ -18,7 +18,7 @@ export class SmoothlyRadioButton {
 		if (this.deselectable || this.active?.value != event.detail.value) {
 			this.active?.select(false)
 			this.active = event.detail
-			this.radioButtonSelected.emit((this.value = this.active.selected ? this.active.value : undefined))
+			this.radioButtonSelected.emit((this.value = this.active.value))
 			this.active.select(this.active.selected)
 		}
 	}


### PR DESCRIPTION
When radio-button has property deselectable, it will always send back the item which is clicked. 