### PR TITLE
Remove border if button type is link

### DIFF
--- a/src/components/button/style.css
+++ b/src/components/button/style.css
@@ -1,5 +1,6 @@
 :host[type=link] {
 	display: inline;
+	border: none;
 }
 :host:not([type=link]) {
 	display: block;


### PR DESCRIPTION
![Screenshot from 2022-11-21 16-53-20](https://user-images.githubusercontent.com/14056988/203099482-0bd95d1b-48c1-4ec2-bae7-9a1a9b11d4df.png)
Those lines comes from the border and were not intended to be there