### PR TITLE
Remove extra flex on smoothly app

### DIFF
--- a/src/components/app/style.css
+++ b/src/components/app/style.css
@@ -90,14 +90,11 @@ smoothly-app > smoothly-notifier > header > nav > ul {
 	width: 100%;
 }
 smoothly-app > smoothly-notifier > header > [slot=header] {
-	display: flex;
 	margin-right: 2.1rem;
-	justify-content: flex-end;
 	border: 0;
 }
 smoothly-app > smoothly-notifier > header > [slot=header] > a {
 	display: flex;
-	align-self: center;
 	border-width: 0;
 	align-items: center;
 	margin-right: 3.9rem;


### PR DESCRIPTION
This styling changes elements with `slot=header` to flex, which might not be what is needed in the header-slot element. It also has a high specificity, which makes it difficult to override without `!important`.