### PR TITLE
Support for nested tables

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -116,7 +116,7 @@ export namespace Components {
         "readonly": boolean;
         "required": boolean;
         "setKeepFocusOnReRender": (keepFocus: boolean) => Promise<void>;
-        "setSelectionRange": (start: number, end: number, direction?: Direction) => Promise<void>;
+        "setSelectionRange": (start: number, end: number, direction?: Direction | undefined) => Promise<void>;
         "showLabel": boolean;
         "type": string;
         "value": any;
@@ -275,6 +275,7 @@ export namespace Components {
     interface SmoothlyTabSwitch {
     }
     interface SmoothlyTable {
+        "root": boolean;
     }
     interface SmoothlyTableCell {
     }
@@ -1138,7 +1139,10 @@ declare namespace LocalJSX {
     interface SmoothlyTabSwitch {
     }
     interface SmoothlyTable {
-        "onLoadMore"?: (event: SmoothlyTableCustomEvent<void>) => void;
+        "onSmoothlyNestedTable"?: (event: SmoothlyTableCustomEvent<() => void>) => void;
+        "onSpotlightChange"?: (event: SmoothlyTableCustomEvent<{ allowSpotlight: boolean; owner?: EventTarget }>) => void;
+        "onTableLoad"?: (event: SmoothlyTableCustomEvent<(owner: EventTarget) => void>) => void;
+        "root"?: boolean;
     }
     interface SmoothlyTableCell {
     }
@@ -1146,12 +1150,16 @@ declare namespace LocalJSX {
     }
     interface SmoothlyTableExpandableCell {
         "align"?: "left" | "center" | "right";
+        "onExpandableChange"?: (event: SmoothlyTableExpandableCellCustomEvent<boolean>) => void;
+        "onExpandableLoad"?: (event: SmoothlyTableExpandableCellCustomEvent<{ allowSpotlight: (allowed: boolean) => void }>) => void;
         "onExpansionLoad"?: (event: SmoothlyTableExpandableCellCustomEvent<void>) => void;
         "onExpansionOpen"?: (event: SmoothlyTableExpandableCellCustomEvent<HTMLElement>) => void;
         "open"?: boolean;
     }
     interface SmoothlyTableExpandableRow {
         "align"?: "left" | "center" | "right";
+        "onExpandableChange"?: (event: SmoothlyTableExpandableRowCustomEvent<boolean>) => void;
+        "onExpandableLoad"?: (event: SmoothlyTableExpandableRowCustomEvent<{ allowSpotlight: (allowed: boolean) => void }>) => void;
         "onExpansionOpen"?: (event: SmoothlyTableExpandableRowCustomEvent<HTMLElement>) => void;
         "open"?: boolean;
     }

--- a/src/components/table/cell/style.css
+++ b/src/components/table/cell/style.css
@@ -3,4 +3,5 @@
 	line-height: 1.5rem;
 	white-space: nowrap;
 	padding: 0.3rem 0 0.3rem 1rem;
+	border-bottom: 1px solid rgb(var(--smoothly-dark-color));
 }

--- a/src/components/table/demo/index.tsx
+++ b/src/components/table/demo/index.tsx
@@ -85,6 +85,62 @@ export class TableDemo {
 					</div>
 				</smoothly-table-expandable-row>
 			</smoothly-table>,
+			<smoothly-table>
+				<smoothly-table-row>
+					<smoothly-table-header>A</smoothly-table-header>
+					<smoothly-table-header>B</smoothly-table-header>
+				</smoothly-table-row>
+				<smoothly-table-expandable-row>
+					<smoothly-table-cell>a row</smoothly-table-cell>
+					<smoothly-table-cell>b row</smoothly-table-cell>
+					<div slot="detail">
+						<smoothly-table>
+							<smoothly-table-row>
+								<smoothly-table-header>C</smoothly-table-header>
+								<smoothly-table-header>D</smoothly-table-header>
+							</smoothly-table-row>
+							<smoothly-table-expandable-row>
+								<smoothly-table-cell>c</smoothly-table-cell>
+								<smoothly-table-cell>d</smoothly-table-cell>
+								<div slot="detail">
+									<smoothly-table>
+										<smoothly-table-row>
+											<smoothly-table-header>E</smoothly-table-header>
+											<smoothly-table-header>F</smoothly-table-header>
+										</smoothly-table-row>
+										<smoothly-table-expandable-row>
+											<smoothly-table-cell>e row</smoothly-table-cell>
+											<smoothly-table-cell>f row</smoothly-table-cell>
+											<div slot="detail">nested expandable rows</div>
+										</smoothly-table-expandable-row>
+									</smoothly-table>
+								</div>
+							</smoothly-table-expandable-row>
+						</smoothly-table>
+					</div>
+				</smoothly-table-expandable-row>
+				<smoothly-table-row>
+					<smoothly-table-cell>a cell</smoothly-table-cell>
+					<smoothly-table-expandable-cell>
+						b cell
+						<div slot="detail">
+							<smoothly-table>
+								<smoothly-table-row>
+									<smoothly-table-header>C</smoothly-table-header>
+									<smoothly-table-header>D</smoothly-table-header>
+								</smoothly-table-row>
+								<smoothly-table-row>
+									<smoothly-table-cell>c cell</smoothly-table-cell>
+									<smoothly-table-expandable-cell>
+										d cell
+										<div slot="detail">nested expandable cell</div>
+									</smoothly-table-expandable-cell>
+								</smoothly-table-row>
+							</smoothly-table>
+						</div>
+					</smoothly-table-expandable-cell>
+				</smoothly-table-row>
+			</smoothly-table>,
 		]
 	}
 }

--- a/src/components/table/demo/index.tsx
+++ b/src/components/table/demo/index.tsx
@@ -111,7 +111,7 @@ export class TableDemo {
 										<smoothly-table-expandable-row>
 											<smoothly-table-cell>e row</smoothly-table-cell>
 											<smoothly-table-cell>f row</smoothly-table-cell>
-											<div slot="detail">nested expandable rows</div>
+											<div slot="detail">nested expandable row expansion e f</div>
 										</smoothly-table-expandable-row>
 									</smoothly-table>
 								</div>
@@ -120,7 +120,27 @@ export class TableDemo {
 					</div>
 				</smoothly-table-expandable-row>
 				<smoothly-table-row>
-					<smoothly-table-cell>a cell</smoothly-table-cell>
+					<smoothly-table-expandable-cell>
+						a cell
+						<div slot="detail">
+							<smoothly-table>
+								<smoothly-table-row>
+									<smoothly-table-header>E</smoothly-table-header>
+									<smoothly-table-header>F</smoothly-table-header>
+								</smoothly-table-row>
+								<smoothly-table-row>
+									<smoothly-table-expandable-cell>
+										e cell
+										<div slot="detail">nested expandable cell expansion e</div>
+									</smoothly-table-expandable-cell>
+									<smoothly-table-expandable-cell>
+										f cell
+										<div slot="detail">nested expandable cell expansion f</div>
+									</smoothly-table-expandable-cell>
+								</smoothly-table-row>
+							</smoothly-table>
+						</div>
+					</smoothly-table-expandable-cell>
 					<smoothly-table-expandable-cell>
 						b cell
 						<div slot="detail">
@@ -130,10 +150,13 @@ export class TableDemo {
 									<smoothly-table-header>D</smoothly-table-header>
 								</smoothly-table-row>
 								<smoothly-table-row>
-									<smoothly-table-cell>c cell</smoothly-table-cell>
+									<smoothly-table-expandable-cell>
+										c cell
+										<div slot="detail">nested expandable cell expansion c</div>
+									</smoothly-table-expandable-cell>
 									<smoothly-table-expandable-cell>
 										d cell
-										<div slot="detail">nested expandable cell</div>
+										<div slot="detail">nested expandable cell expansion d</div>
 									</smoothly-table-expandable-cell>
 								</smoothly-table-row>
 							</smoothly-table>

--- a/src/components/table/demo/style.css
+++ b/src/components/table/demo/style.css
@@ -1,0 +1,7 @@
+:host {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: 3rem;
+	padding-bottom: 10rem;
+}

--- a/src/components/table/expandable/cell/index.tsx
+++ b/src/components/table/expandable/cell/index.tsx
@@ -1,18 +1,34 @@
-import { Component, ComponentDidLoad, Element, Event, EventEmitter, h, Host, Listen, Prop, Watch } from "@stencil/core"
+import {
+	Component,
+	ComponentWillLoad,
+	Element,
+	Event,
+	EventEmitter,
+	h,
+	Host,
+	Listen,
+	Prop,
+	State,
+	Watch,
+} from "@stencil/core"
 
 @Component({
 	tag: "smoothly-table-expandable-cell",
 	styleUrl: "style.css",
 	scoped: true,
 })
-export class TableExpandableCell implements ComponentDidLoad {
+export class TableExpandableCell implements ComponentWillLoad {
+	private expansionElement?: HTMLTableRowElement
+	private beginOpen: boolean
 	@Element() element: HTMLSmoothlyTableExpandableCellElement
-	expansionElement?: HTMLTableRowElement
-	@Event() expansionOpen: EventEmitter<HTMLElement>
-	@Event() expansionLoad: EventEmitter<void>
+	@State() allowSpotlight = true
+	@State() spotlight = true
 	@Prop() align: "left" | "center" | "right" = "left"
 	@Prop({ mutable: true, reflect: true }) open: boolean
-	private beginOpen: boolean
+	@Event() expansionOpen: EventEmitter<HTMLElement>
+	@Event() expansionLoad: EventEmitter<void>
+	@Event() expandableChange: EventEmitter<boolean>
+	@Event() expandableLoad: EventEmitter<{ allowSpotlight: (allowed: boolean) => void }>
 	@Watch("open")
 	openChanged(value: boolean) {
 		if (this.expansionElement)
@@ -20,19 +36,33 @@ export class TableExpandableCell implements ComponentDidLoad {
 				this.beginOpen = true
 			else
 				this.element.append(this.expansionElement)
+		this.expandableChange.emit(this.open)
 	}
-	@Listen("click")
-	onClick() {
-		this.open = !this.open
+	@Watch("open")
+	@Watch("allowSpotlight")
+	handleSpotlight() {
+		this.spotlight = this.open && this.allowSpotlight
 	}
-	componentDidLoad(): void {
+	componentWillLoad(): void {
 		this.expansionLoad.emit()
+		this.expandableLoad.emit({
+			allowSpotlight: (allowed: boolean) => (this.allowSpotlight = allowed),
+		})
 	}
 	componentDidRender(): void {
 		if (this.beginOpen) {
 			this.beginOpen = false
 			this.expansionOpen.emit(this.expansionElement)
 		}
+	}
+	@Listen("click")
+	onClick() {
+		this.open = !this.open
+	}
+	@Listen("tableLoad")
+	handleTableLoaded(event: CustomEvent<(owner: EventTarget) => void>) {
+		event.stopPropagation()
+		event.detail(this.element)
 	}
 	render() {
 		return (
@@ -41,11 +71,9 @@ export class TableExpandableCell implements ComponentDidLoad {
 					<smoothly-icon name="chevron-forward" size="tiny"></smoothly-icon>
 					<slot></slot>
 				</aside>
-				<tr ref={e => (this.expansionElement = e)}>
+				<tr class={this.spotlight ? "spotlight" : ""} ref={e => (this.expansionElement = e)}>
 					<td colSpan={999} class={!this.open ? "hide" : ""}>
-						<div class="slot-detail">
-							<slot name="detail"></slot>
-						</div>
+						<slot name="detail"></slot>
 					</td>
 				</tr>
 			</Host>

--- a/src/components/table/expandable/cell/style.css
+++ b/src/components/table/expandable/cell/style.css
@@ -3,12 +3,14 @@
 	padding: 0.3rem 0 0.3rem 0;
 	cursor: pointer;
 	line-height: 1.5rem;
+	border-bottom: 1px solid rgb(var(--smoothly-dark-color));
 }
 :host[open] {
 	position: relative;
 	z-index: 3;
 	background-color: rgb(var(--smoothly-default-color));
-	border: 2px solid rgb(var(--smoothly-dark-color));
+	box-shadow: -1px 0 0 rgb(var(--smoothly-dark-color)) inset, 
+		1px 0 0 rgb(var(--smoothly-dark-color)) inset;
 	border-bottom: none;
 }
 :host smoothly-icon {
@@ -29,15 +31,41 @@ aside {
 .hide {
 	display: none;
 }
-
-.slot-detail {
+td::slotted(*) {
+	--expansion-width: 1.5rem;
+	--expansion-border-width: 3px;
 	position: relative;
 	background-color: rgb(var(--smoothly-default-color));
-	width: 104%;
-	left: -2%;
-	border-left: 2px solid rgb(var(--smoothly-tertiary-color));
-	box-shadow: 0px 0px 5px 4px rgb(var(--smoothly-dark-color), 0.5);
+	width: calc(100% + 3rem - var(--expansion-border-width));
+	left: calc(-1 * var(--expansion-width));
+	border-left: var(--expansion-border-width) solid rgb(0, 0, 0, 0);
+	box-shadow: 0px 0px 4px 2px rgb(var(--smoothly-dark-color));
 	box-sizing: border-box;
-	padding: 0.5rem 2%;
+	padding: 0.5rem calc(var(--expansion-width) - var(--expansion-border-width));
+	border-bottom: 1px solid rgb(var(--smoothly-dark-color));
+	border-left-width: 3px;
+}
+tr.spotlight > td::slotted(*) {
+	border-left-color: rgb(var(--smoothly-tertiary-color));
+}
+td::slotted(*)::before {
+	content: "";
+	position: absolute;
+	display: flex;
+	top: -1px;
+	bottom: 0;
+	left: -3px;
+	width: calc(var(--expansion-width) + 1px);
+	border-top: 1px solid rgb(var(--smoothly-dark-color));
+}
+td::slotted(*)::after {
+	content: "";
+	position: absolute;
+	display: flex;
+	top: -1px;
+	bottom: 0;
+	right: 0;
+	width: calc(var(--expansion-width) -1px);
+	border-top: 1px solid rgb(var(--smoothly-dark-color));
 }
 

--- a/src/components/table/expandable/row/style.css
+++ b/src/components/table/expandable/row/style.css
@@ -7,7 +7,10 @@
 	position: relative;
 	z-index: 3;
 	background-color: rgb(var(--smoothly-default-color));
-	border: 2px solid rgb(var(--smoothly-dark-color));
+	box-shadow: -1px 0 0 0 rgb(var(--smoothly-dark-color)) inset, 
+		1px 0 0 0 rgb(var(--smoothly-dark-color)) inset;
+}
+:host[open]::slotted(smoothly-table-cell) {
 	border-bottom: none;
 }
 :host smoothly-icon {
@@ -26,14 +29,43 @@
 .hide {
 	display: none;
 }
-.slot-detail {
+:host > tr > td {
+	position: relative;
+}
+td::slotted(*) {
+	--expansion-width: 1.5rem;
+	--expansion-border-width: 3px;
 	position: relative;
 	background-color: rgb(var(--smoothly-default-color));
-	width: 104%;
-	left: -2%;
-	border-left-style: solid;
-	border-left-color: rgb(var(--smoothly-tertiary-color));
+	width: calc(100% + 3rem - var(--expansion-border-width));
+	left: calc(-1 * var(--expansion-width));
+	border-left: var(--expansion-border-width) solid rgb(0, 0, 0, 0);
 	box-shadow: 0px 0px 4px 2px rgb(var(--smoothly-dark-color));
 	box-sizing: border-box;
-	padding: 0.5rem 2%;
+	padding: 0.5rem calc(var(--expansion-width) - var(--expansion-border-width));
+	border-bottom: 1px solid rgb(var(--smoothly-dark-color));
+	border-left-width: 3px;
+}
+tr.spotlight > td::slotted(*) {
+	border-left-color: rgb(var(--smoothly-tertiary-color));
+}
+td::slotted(*)::before {
+	content: "";
+	position: absolute;
+	display: flex;
+	top: 0;
+	bottom: 0;
+	left: -3px;
+	width: calc(var(--expansion-width) + 1px);
+	border-top: 1px solid rgb(var(--smoothly-dark-color));
+}
+td::slotted(*)::after {
+	content: "";
+	position: absolute;
+	display: flex;
+	top: 0;
+	bottom: 0;
+	right: 0;
+	width: calc(var(--expansion-width) -1px);
+	border-top: 1px solid rgb(var(--smoothly-dark-color));
 }

--- a/src/components/table/header/style.css
+++ b/src/components/table/header/style.css
@@ -1,8 +1,8 @@
 :host {
 	display: table-cell;
 	line-height: 2.5rem;
-	background-color: rgb(var(--smoothly-color-shade));
 	border-bottom: 1px solid rgb(var(--smoothly-dark-color));
+	border-top: 1px solid rgb(var(--smoothly-dark-color));
 	padding-left: 1rem;
 	font-weight: bold;
 }

--- a/src/components/table/index.tsx
+++ b/src/components/table/index.tsx
@@ -1,13 +1,44 @@
-import { Component, Element, Event, EventEmitter, h, Listen } from "@stencil/core"
+import { Component, ComponentWillLoad, Element, Event, EventEmitter, h, Listen, Prop } from "@stencil/core"
 
 @Component({
 	tag: "smoothly-table",
 	styleUrl: "style.css",
 	scoped: true,
 })
-export class Table {
+export class Table implements ComponentWillLoad {
+	private owner?: EventTarget
+	private expandable: Map<EventTarget, { allowSpotlight: (allowed: boolean) => void } | undefined> = new Map()
+	private expanded: Set<EventTarget> = new Set()
 	@Element() element: HTMLSmoothlyTableElement
-	@Event() loadMore: EventEmitter<void>
+	@Prop({ mutable: true, reflect: true }) root = true
+	@Event() smoothlyNestedTable: EventEmitter<() => void>
+	@Event() spotlightChange: EventEmitter<{ allowSpotlight: boolean; owner?: EventTarget }>
+	@Event() tableLoad: EventEmitter<(owner: EventTarget) => void>
+	componentWillLoad() {
+		this.smoothlyNestedTable.emit(() => (this.root = false))
+		this.tableLoad.emit((owner: EventTarget) => (this.owner = owner))
+	}
+	@Listen("expandableLoad")
+	handleExpandableLoaded(event: CustomEvent<{ allowSpotlight: (allowed: boolean) => void }>) {
+		event.stopPropagation()
+		event.target && this.expandable.set(event.target, event.detail)
+	}
+	@Listen("expandableChange")
+	handleExpandableState(event: CustomEvent<boolean>) {
+		event.stopPropagation()
+		event.target && (event.detail ? this.expanded.add(event.target) : this.expanded.delete(event.target))
+		this.spotlightChange.emit({ allowSpotlight: !this.expanded.size, owner: this.owner })
+	}
+	@Listen("spotlightChange")
+	handleSpotlightState(event: CustomEvent<{ allowSpotlight: boolean; owner?: EventTarget }>) {
+		event.target != this.element &&
+			(event.stopPropagation(),
+			event.detail.owner && this.expandable.get(event.detail.owner)?.allowSpotlight(event.detail.allowSpotlight))
+	}
+	@Listen("smoothlyNestedTable")
+	handleNestedTable(event: CustomEvent<() => void>) {
+		event.target != this.element && (event.stopPropagation(), event.detail())
+	}
 	@Listen("expansionLoad")
 	@Listen("expansionOpen")
 	handleEvents(event: Event) {

--- a/src/components/table/style.css
+++ b/src/components/table/style.css
@@ -1,9 +1,16 @@
 :host {
 	display: table;
-	border-collapse: collapse;
-	border: 1px solid rgb(var(--smoothly-dark-color));
 	width: var(--table-width, 80%);
 	box-sizing: border-box;
 	background-color: rgb(var(--smoothly-default-color));
-	margin: auto;
+}
+:host[root] {
+	margin-left: auto;
+	margin-right: auto;
+	margin-left: 1.5rem;
+	margin-right: 1.5rem;
+}
+:host:not([root]) {
+	margin: 0;
+	width: 100%;
 }


### PR DESCRIPTION
* expansions no longer measured in %
* removed the `<div>` inside `<td>` in expandable cell/row as it was unnecessary
* expansions keep the expansion with no matter the depth but the left border shrinks to the height of the deepest leaves.
* removed `border-collapse: collapse` from the table as it caused small twitching when expanding.
* replaced some borders to shadows as the borders caused some twitching when expanding.
