### PR TITLE
table-chevron-fix

### DIFF
--- a/src/components/table/cell/index.tsx
+++ b/src/components/table/cell/index.tsx
@@ -9,7 +9,10 @@ export class TableCell {
 	render() {
 		return (
 			<Host>
-				<slot></slot>
+				<div>
+					<slot></slot>
+					<smoothly-icon name="chevron-forward" size="tiny" />
+				</div>
 			</Host>
 		)
 	}

--- a/src/components/table/cell/style.css
+++ b/src/components/table/cell/style.css
@@ -5,3 +5,20 @@
 	padding: 0.3rem 0 0.3rem 1rem;
 	border-bottom: 1px solid rgb(var(--smoothly-dark-color));
 }
+
+:host smoothly-icon {
+	display: none;
+}
+
+:host > div {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+}
+
+:host smoothly-icon {
+	width: 0.6rem;
+	height: 0.6rem;
+	margin: 0 0.3rem;
+	transition: transform 0.2s;
+}

--- a/src/components/table/expandable/row/index.tsx
+++ b/src/components/table/expandable/row/index.tsx
@@ -62,7 +62,6 @@ export class TableExpandableRow implements ComponentWillLoad {
 		return (
 			<Host style={{ textAlign: this.align }}>
 				<slot></slot>
-				<smoothly-icon name="chevron-forward" size="tiny"></smoothly-icon>
 				<tr class={this.spotlight ? "spotlight" : ""} ref={e => (this.expansionElement = e)}>
 					<td colSpan={999} class={!this.open ? "hide" : ""}>
 						<slot name="detail"></slot>

--- a/src/components/table/expandable/row/style.css
+++ b/src/components/table/expandable/row/style.css
@@ -2,6 +2,7 @@
 	display: table-row;
 	cursor: pointer;
 	line-height: 1.5rem;
+	position: relative;
 }
 :host[open] {
 	position: relative;
@@ -15,10 +16,11 @@
 }
 :host smoothly-icon {
 	width: 0.6rem;
-	height: 1rem;
-	margin-top: -1rem;
 	margin-left: -1rem;
 	transition: transform 0.2s;
+	position: absolute;
+	top: 0;
+	align-items: center;
 	display: flex;
 	height: 100%;
 }

--- a/src/components/table/expandable/row/style.css
+++ b/src/components/table/expandable/row/style.css
@@ -2,7 +2,6 @@
 	display: table-row;
 	cursor: pointer;
 	line-height: 1.5rem;
-	position: relative;
 }
 :host[open] {
 	position: relative;
@@ -13,19 +12,6 @@
 }
 :host[open]::slotted(smoothly-table-cell) {
 	border-bottom: none;
-}
-:host smoothly-icon {
-	width: 0.6rem;
-	margin-left: -1rem;
-	transition: transform 0.2s;
-	position: absolute;
-	top: 0;
-	align-items: center;
-	display: flex;
-	height: 100%;
-}
-:host[open] smoothly-icon {
-	transform: rotate(90deg);
 }
 
 .hide {
@@ -70,4 +56,10 @@ td::slotted(*)::after {
 	right: 0;
 	width: calc(var(--expansion-width) -1px);
 	border-top: 1px solid rgb(var(--smoothly-dark-color));
+}
+:host::slotted(smoothly-table-cell:last-of-type) smoothly-icon {
+	display: flex;
+}
+:host[open]::slotted(smoothly-table-cell:last-of-type) smoothly-icon {
+	transform: rotate(90deg);
 }


### PR DESCRIPTION
The chevron on expandable row acted different in our project compared to the demo app. These changes places a chevron in all cells and a expandable row then shows the last cell in the row. This allows the chevron to have its own space and it does not have any weird behavior anymore with negative margins.