### PR TITLE
Cell icon

### DIFF
--- a/src/components/table/cell/index.tsx
+++ b/src/components/table/cell/index.tsx
@@ -10,7 +10,9 @@ export class TableCell {
 		return (
 			<Host>
 				<div>
-					<slot></slot>
+					<div>
+						<slot></slot>
+					</div>
 					<smoothly-icon name="chevron-forward" size="tiny" />
 				</div>
 			</Host>

--- a/src/components/table/demo/index.tsx
+++ b/src/components/table/demo/index.tsx
@@ -121,9 +121,9 @@ export class TableDemo {
 				</smoothly-table-expandable-row>
 				<smoothly-table-expandable-row>
 					<smoothly-table-cell>
-						<div>one</div>
-						<div>two</div>
-						<div>three</div>
+						<span>one</span>
+						<span>two</span>
+						<span>three</span>
 					</smoothly-table-cell>
 					<smoothly-table-cell>
 						five<smoothly-icon name="paper-plane-sharp" size="small"></smoothly-icon>

--- a/src/components/table/demo/index.tsx
+++ b/src/components/table/demo/index.tsx
@@ -119,6 +119,17 @@ export class TableDemo {
 						</smoothly-table>
 					</div>
 				</smoothly-table-expandable-row>
+				<smoothly-table-expandable-row>
+					<smoothly-table-cell>
+						<div>one</div>
+						<div>two</div>
+						<div>three</div>
+					</smoothly-table-cell>
+					<smoothly-table-cell>
+						five<smoothly-icon name="paper-plane-sharp" size="small"></smoothly-icon>
+					</smoothly-table-cell>
+					<div slot="detail">four</div>
+				</smoothly-table-expandable-row>
 				<smoothly-table-row>
 					<smoothly-table-expandable-cell>
 						a cell

--- a/src/components/table/expandable/row/style.css
+++ b/src/components/table/expandable/row/style.css
@@ -57,9 +57,9 @@ td::slotted(*)::after {
 	width: calc(var(--expansion-width) -1px);
 	border-top: 1px solid rgb(var(--smoothly-dark-color));
 }
-:host::slotted(smoothly-table-cell:last-of-type) smoothly-icon {
+:host::slotted(smoothly-table-cell:last-of-type) > div > smoothly-icon:last-of-type {
 	display: flex;
 }
-:host[open]::slotted(smoothly-table-cell:last-of-type) smoothly-icon {
+:host[open]::slotted(smoothly-table-cell:last-of-type) > div > smoothly-icon:last-of-type {
 	transform: rotate(90deg);
 }


### PR DESCRIPTION
Forgot to account for the `<smoothly-table-cell>` to slot multiple elements when making the changes to the chevron. The slotted content is now separated from the icon.

The icon CSS selector was too broad and could hit icons slotted into the cell. This more precise selector only hits the cells icon.
