### PR TITLE
cell slotted content 100%

### DIFF
--- a/src/components/table/cell/style.css
+++ b/src/components/table/cell/style.css
@@ -13,9 +13,10 @@
 :host > div {
 	display: flex;
 	align-items: center;
-	justify-content: space-between;
 }
-
+:host > div > div {
+	width: 100%;
+}
 :host smoothly-icon {
 	width: 0.6rem;
 	height: 0.6rem;


### PR DESCRIPTION
the slotted contents div is now 100% width instead of having a space between the icon.