### PR TITLE
make the key up and down work with the scroll.

### DIFF
--- a/src/components/item/index.tsx
+++ b/src/components/item/index.tsx
@@ -1,4 +1,4 @@
-import { Component, Element, Event, EventEmitter, h, Listen, Method, Prop, Watch } from "@stencil/core"
+import { Component, Element, Event, EventEmitter, h, Host, Listen, Method, Prop, Watch } from "@stencil/core"
 
 @Component({
 	tag: "smoothly-item",
@@ -36,6 +36,10 @@ export class Item {
 		return result
 	}
 	render() {
-		return <slot />
+		return (
+			<Host tabIndex={-1}>
+				<slot />
+			</Host>
+		)
 	}
 }

--- a/src/components/selector/index.tsx
+++ b/src/components/selector/index.tsx
@@ -107,6 +107,7 @@ export class Selector {
 				markedIndex = (markedIndex + direction + this.items.length) % this.items.length
 			} while (this.items[markedIndex].hidden)
 			this.items[markedIndex].marked = true
+			this.items[markedIndex].focus()
 		}
 	}
 	render() {

--- a/src/components/selector/style.css
+++ b/src/components/selector/style.css
@@ -13,6 +13,8 @@
 	flex-direction: column;
 	position: absolute;
 	z-index: 10;
+	height:  var(--menu-height, unset);
+	overflow-y: scroll;
 }
 :host > aside {
 	position: absolute;


### PR DESCRIPTION
if `overflow-y: scroll`, when we use down arrow on keyboard to select items, the scroll doesn't go down