### PR TITLE
expandable row styling does not break with display contents

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -116,7 +116,7 @@ export namespace Components {
         "readonly": boolean;
         "required": boolean;
         "setKeepFocusOnReRender": (keepFocus: boolean) => Promise<void>;
-        "setSelectionRange": (start: number, end: number, direction?: Direction) => Promise<void>;
+        "setSelectionRange": (start: number, end: number, direction?: Direction | undefined) => Promise<void>;
         "showLabel": boolean;
         "type": string;
         "value": any;

--- a/src/components/table/demo/index.tsx
+++ b/src/components/table/demo/index.tsx
@@ -175,6 +175,19 @@ export class TableDemo {
 					</smoothly-table-expandable-cell>
 				</smoothly-table-row>
 			</smoothly-table>,
+			<smoothly-table>
+				<smoothly-table-row>
+					<smoothly-table-header>display</smoothly-table-header>
+					<smoothly-table-header>contents</smoothly-table-header>
+				</smoothly-table-row>
+				<smoothly-table-expandable-row>
+					<div class={"content"}>
+						<smoothly-table-cell>A</smoothly-table-cell>
+						<smoothly-table-cell>B</smoothly-table-cell>
+					</div>
+					<div slot="detail">expansion</div>
+				</smoothly-table-expandable-row>
+			</smoothly-table>,
 		]
 	}
 }

--- a/src/components/table/demo/style.css
+++ b/src/components/table/demo/style.css
@@ -5,3 +5,6 @@
 	gap: 3rem;
 	padding-bottom: 10rem;
 }
+.content {
+	display: contents;
+}

--- a/src/components/table/expandable/row/style.css
+++ b/src/components/table/expandable/row/style.css
@@ -10,6 +10,7 @@
 	box-shadow: -1px 0 0 0 rgb(var(--smoothly-dark-color)) inset, 
 		1px 0 0 0 rgb(var(--smoothly-dark-color)) inset;
 }
+:host[open]::slotted(*) smoothly-table-cell,
 :host[open]::slotted(smoothly-table-cell) {
 	border-bottom: none;
 }
@@ -57,9 +58,11 @@ td::slotted(*)::after {
 	width: calc(var(--expansion-width) -1px);
 	border-top: 1px solid rgb(var(--smoothly-dark-color));
 }
+:host::slotted(*) smoothly-table-cell:last-of-type > div > smoothly-icon:last-of-type,
 :host::slotted(smoothly-table-cell:last-of-type) > div > smoothly-icon:last-of-type {
 	display: flex;
 }
+:host[open]::slotted(*) smoothly-table-cell:last-of-type > div > smoothly-icon:last-of-type,
 :host[open]::slotted(smoothly-table-cell:last-of-type) > div > smoothly-icon:last-of-type {
 	transform: rotate(90deg);
 }


### PR DESCRIPTION
Expandable row styling broke if an element with `display: contents` containing table cell was provided instead of a table cell directly. This styling makes it possible for the row to contain elements with `display: contents` inbetween the `expandable-row` and `table-cell` and styling is still working.