### PR TITLE
support for active icons on non-clear buttons

### DIFF
--- a/src/components/button-demo/index.tsx
+++ b/src/components/button-demo/index.tsx
@@ -73,12 +73,15 @@ export class SmoothlyButtonDemo {
 				<h4>Fill examples</h4>
 				<div>
 					<smoothly-button shape="rounded" color="primary" fill="solid">
+						<smoothly-icon name="checkmark-circle" slot="start"></smoothly-icon>
 						Fill Solid
 					</smoothly-button>
 					<smoothly-button shape="rounded" color="secondary" fill="outline">
+						<smoothly-icon name="checkmark-circle" slot="start" fill="clear"></smoothly-icon>
 						Fill Outline
 					</smoothly-button>
 					<smoothly-button shape="rounded" color="tertiary" fill="clear">
+						<smoothly-icon name="checkmark-circle" slot="start" fill="clear"></smoothly-icon>
 						Fill Clear
 					</smoothly-button>
 					<smoothly-button size="icon" shape="rounded" color="success" fill="solid">

--- a/src/components/button/style.css
+++ b/src/components/button/style.css
@@ -55,11 +55,9 @@ button {
 :host([size=large]) > button{
 	font-size: 130%;
 }
-
 :host(:not([size=icon])){
 	min-width: 8em;
 }
-
 :host([size=flexible]) {
 	min-width: unset;
 	padding: 0;
@@ -69,7 +67,6 @@ button {
 	align-items: center;
 	border: none;
 }
-
 :host([size=flexible]) > button {
 	min-width: unset;
 	padding: 0;
@@ -95,7 +92,10 @@ button {
 }
 :host(:not([fill=clear]):hover) > button,
 :host(:not([fill=clear]):focus) > button,
-:host(:not([fill=clear]):active) > button{
+:host(:not([fill=clear]):active) > button,
+:host(:not([fill=clear]):hover) ::slotted(smoothly-icon),
+:host(:not([fill=clear]):focus) ::slotted(smoothly-icon),
+:host(:not([fill=clear]):active) ::slotted(smoothly-icon){
 	color: rgb(var(--smoothly-color-contrast)) !important;
 	stroke: rgb(var(--smoothly-color-contrast)) !important;
 	fill: rgb(var(--smoothly-color-contrast)) !important;
@@ -113,37 +113,32 @@ button {
 }
 :host(:not([fill])),
 :host([fill=default]) {
-	color: rgb(var(--smoothly-color-contrast));
-	stroke: rgb(var(--smoothly-color-contrast));
-	fill: rgb(var(--smoothly-color-contrast));
 	background: rgb(var(--smoothly-color));
 	border-color: transparent;
 }
 :host([fill=solid]) {
-	stroke: rgb(var(--smoothly-color-contrast));
-	fill: rgb(var(--smoothly-color-contrast));
 	background: rgb(var(--smoothly-color));
 	border-color: rgb(var(--smoothly-color-shade));
 }
 :host([fill=solid]) > button,
 :host([fill=default]) > button{
+	stroke: rgb(var(--smoothly-color-contrast));
+	fill: rgb(var(--smoothly-color-contrast));
 	color: rgb(var(--smoothly-color-contrast));
 }
-:host([fill=outline]) {
+:host([fill=outline]) > button,
+:host([fill=clear]) > button{
 	stroke: rgb(var(--smoothly-color));
 	fill: rgb(var(--smoothly-color));
+	color: rgb(var(--smoothly-color));
+}
+:host([fill=outline]) {
 	background: transparent;
 	border-color: rgb(var(--smoothly-color));
 }
 :host([fill=clear]) {
-	stroke: rgb(var(--smoothly-color));
-	fill: rgb(var(--smoothly-color));
 	background: transparent;
 	border-color: transparent;
-}
-:host([fill=outline]) > button,
-:host([fill=clear]) > button{
-	color: rgb(var(--smoothly-color));
 }
 ::slotted(smoothly-icon[slot=start]),
 ::slotted(smoothly-icon[slot=end]){


### PR DESCRIPTION
Default fill icons were not visible on hover/active/or focus. Now works with icon fill=clear. Added to button demo.