### PR TITLE
fix nav mobile bug

### DIFF
--- a/src/components/app/index.tsx
+++ b/src/components/app/index.tsx
@@ -71,8 +71,8 @@ export class SmoothlyApp {
 						<a href={""}>{this.label}</a>
 					</h1>
 					<slot name="header"></slot>
-					<nav>
-						<ul class={this.menuOpen.toString()}>
+					<nav class={this.menuOpen.toString()}>
+						<ul>
 							<slot name="nav-start"></slot>
 							<slot> </slot>
 							<slot name="nav-end"></slot>

--- a/src/components/app/style.css
+++ b/src/components/app/style.css
@@ -114,6 +114,6 @@ smoothly-app > smoothly-notifier > main {
 		background-color: rgba(var(--smoothly-color));
 	}
 }
-.true:not([menuOpen]) > * {
+.true:not([menuOpen])  {
 	display: none;
 }


### PR DESCRIPTION
Fixing a small bug in where the `<nav>` element would overflow too much causing elements under it to not be interactive. 
This fix doesn't affect performance, but makes it so that the space `<nav>` takes up (when the hamburger is closed) is removed. 

