### PR TITLE
event names and borders

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -1356,8 +1356,8 @@ declare namespace LocalJSX {
     interface SmoothlyTable {
         "align"?: "middle" | "bottom" | "top";
         "onSmoothlyNestedTable"?: (event: SmoothlyTableCustomEvent<() => void>) => void;
-        "onSpotlightChange"?: (event: SmoothlyTableCustomEvent<{ allowSpotlight: boolean; owner?: EventTarget }>) => void;
-        "onTableLoad"?: (event: SmoothlyTableCustomEvent<(owner: EventTarget) => void>) => void;
+        "onSmoothlySpotlightChange"?: (event: SmoothlyTableCustomEvent<{ allowSpotlight: boolean; owner?: EventTarget }>) => void;
+        "onSmoothlyTableLoad"?: (event: SmoothlyTableCustomEvent<(owner: EventTarget) => void>) => void;
         "root"?: boolean;
     }
     interface SmoothlyTableCell {
@@ -1368,17 +1368,17 @@ declare namespace LocalJSX {
     }
     interface SmoothlyTableExpandableCell {
         "align"?: "left" | "center" | "right";
-        "onExpandableChange"?: (event: SmoothlyTableExpandableCellCustomEvent<boolean>) => void;
-        "onExpandableLoad"?: (event: SmoothlyTableExpandableCellCustomEvent<{ allowSpotlight: (allowed: boolean) => void }>) => void;
-        "onExpansionLoad"?: (event: SmoothlyTableExpandableCellCustomEvent<void>) => void;
-        "onExpansionOpen"?: (event: SmoothlyTableExpandableCellCustomEvent<HTMLElement>) => void;
+        "onSmoothlyExpandableChange"?: (event: SmoothlyTableExpandableCellCustomEvent<boolean>) => void;
+        "onSmoothlyExpandableLoad"?: (event: SmoothlyTableExpandableCellCustomEvent<{ allowSpotlight: (allowed: boolean) => void }>) => void;
+        "onSmoothlyExpansionLoad"?: (event: SmoothlyTableExpandableCellCustomEvent<void>) => void;
+        "onSmoothlyExpansionOpen"?: (event: SmoothlyTableExpandableCellCustomEvent<HTMLElement>) => void;
         "open"?: boolean;
     }
     interface SmoothlyTableExpandableRow {
         "align"?: "left" | "center" | "right";
-        "onExpandableChange"?: (event: SmoothlyTableExpandableRowCustomEvent<boolean>) => void;
-        "onExpandableLoad"?: (event: SmoothlyTableExpandableRowCustomEvent<{ allowSpotlight: (allowed: boolean) => void }>) => void;
-        "onExpansionOpen"?: (event: SmoothlyTableExpandableRowCustomEvent<HTMLElement>) => void;
+        "onSmoothlyExpandableChange"?: (event: SmoothlyTableExpandableRowCustomEvent<boolean>) => void;
+        "onSmoothlyExpandableLoad"?: (event: SmoothlyTableExpandableRowCustomEvent<{ allowSpotlight: (allowed: boolean) => void }>) => void;
+        "onSmoothlyExpansionOpen"?: (event: SmoothlyTableExpandableRowCustomEvent<HTMLElement>) => void;
         "open"?: boolean;
     }
     interface SmoothlyTableHeader {

--- a/src/components/table/demo/index.tsx
+++ b/src/components/table/demo/index.tsx
@@ -145,7 +145,24 @@ export class TableDemo {
 								<smoothly-table-row>
 									<smoothly-table-expandable-cell>
 										e cell
-										<div slot="detail">nested expandable cell expansion e</div>
+										<div slot="detail">
+											<smoothly-table>
+												<smoothly-table-row>
+													<smoothly-table-header>G</smoothly-table-header>
+													<smoothly-table-header>H</smoothly-table-header>
+												</smoothly-table-row>
+												<smoothly-table-row>
+													<smoothly-table-expandable-cell>
+														g cell
+														<div slot="detail">nested expandable cell expansion g</div>
+													</smoothly-table-expandable-cell>
+													<smoothly-table-expandable-cell>
+														h cell
+														<div slot="detail">nested expandable cell expansion h</div>
+													</smoothly-table-expandable-cell>
+												</smoothly-table-row>
+											</smoothly-table>
+										</div>
 									</smoothly-table-expandable-cell>
 									<smoothly-table-expandable-cell>
 										f cell

--- a/src/components/table/expandable/cell/index.tsx
+++ b/src/components/table/expandable/cell/index.tsx
@@ -25,10 +25,10 @@ export class TableExpandableCell implements ComponentWillLoad {
 	@State() spotlight = true
 	@Prop() align: "left" | "center" | "right" = "left"
 	@Prop({ mutable: true, reflect: true }) open: boolean
-	@Event() expansionOpen: EventEmitter<HTMLElement>
-	@Event() expansionLoad: EventEmitter<void>
-	@Event() expandableChange: EventEmitter<boolean>
-	@Event() expandableLoad: EventEmitter<{ allowSpotlight: (allowed: boolean) => void }>
+	@Event() smoothlyExpansionOpen: EventEmitter<HTMLElement>
+	@Event() smoothlyExpansionLoad: EventEmitter<void>
+	@Event() smoothlyExpandableChange: EventEmitter<boolean>
+	@Event() smoothlyExpandableLoad: EventEmitter<{ allowSpotlight: (allowed: boolean) => void }>
 	@Watch("open")
 	openChanged(value: boolean) {
 		if (this.expansionElement)
@@ -36,7 +36,7 @@ export class TableExpandableCell implements ComponentWillLoad {
 				this.beginOpen = true
 			else
 				this.element.append(this.expansionElement)
-		this.expandableChange.emit(this.open)
+		this.smoothlyExpandableChange.emit(this.open)
 	}
 	@Watch("open")
 	@Watch("allowSpotlight")
@@ -44,22 +44,22 @@ export class TableExpandableCell implements ComponentWillLoad {
 		this.spotlight = this.open && this.allowSpotlight
 	}
 	componentWillLoad(): void {
-		this.expansionLoad.emit()
-		this.expandableLoad.emit({
+		this.smoothlyExpansionLoad.emit()
+		this.smoothlyExpandableLoad.emit({
 			allowSpotlight: (allowed: boolean) => (this.allowSpotlight = allowed),
 		})
 	}
 	componentDidRender(): void {
 		if (this.beginOpen) {
 			this.beginOpen = false
-			this.expansionOpen.emit(this.expansionElement)
+			this.smoothlyExpansionOpen.emit(this.expansionElement)
 		}
 	}
 	@Listen("click")
 	onClick() {
 		this.open = !this.open
 	}
-	@Listen("tableLoad")
+	@Listen("smoothlyTableLoad")
 	handleTableLoaded(event: CustomEvent<(owner: EventTarget) => void>) {
 		event.stopPropagation()
 		event.detail(this.element)

--- a/src/components/table/expandable/cell/style.css
+++ b/src/components/table/expandable/cell/style.css
@@ -39,7 +39,7 @@ td::slotted(*) {
 	background-color: rgb(var(--smoothly-default-color));
 	width: calc(100% + 3rem - 1px);
 	top: 1px;
-	left: calc(-1 * var(--expansion-width));
+	left: calc(-1 * var(--expansion-width) + 1px);
 	box-sizing: border-box;
 	padding: 0.5rem calc(var(--expansion-width) - 1px);
 	border-bottom: 1px solid rgb(var(--smoothly-light-shade));
@@ -56,7 +56,7 @@ td::slotted(*)::before {
 	display: flex;
 	top: -1px;
 	bottom: 0;
-	left: 0;
+	left: -1px;
 	width: calc(var(--expansion-width) + 1px);
 	border-top: 1px solid rgb(var(--smoothly-light-shade));
 }

--- a/src/components/table/expandable/row/index.tsx
+++ b/src/components/table/expandable/row/index.tsx
@@ -24,14 +24,14 @@ export class TableExpandableRow implements ComponentWillLoad {
 	@State() spotlight = true
 	@Prop() align: "left" | "center" | "right" = "left"
 	@Prop({ mutable: true, reflect: true }) open: boolean
-	@Event() expansionOpen: EventEmitter<HTMLElement>
-	@Event() expandableChange: EventEmitter<boolean>
-	@Event() expandableLoad: EventEmitter<{ allowSpotlight: (allowed: boolean) => void }>
+	@Event() smoothlyExpansionOpen: EventEmitter<HTMLElement>
+	@Event() smoothlyExpandableChange: EventEmitter<boolean>
+	@Event() smoothlyExpandableLoad: EventEmitter<{ allowSpotlight: (allowed: boolean) => void }>
 	@Watch("open")
 	openChanged() {
 		if (this.expansionElement)
 			this.element.after(this.expansionElement)
-		this.expandableChange.emit(this.open)
+		this.smoothlyExpandableChange.emit(this.open)
 	}
 	@Watch("open")
 	@Watch("allowSpotlight")
@@ -39,12 +39,12 @@ export class TableExpandableRow implements ComponentWillLoad {
 		this.spotlight = this.open && this.allowSpotlight
 	}
 	componentWillLoad() {
-		this.expandableLoad.emit({
+		this.smoothlyExpandableLoad.emit({
 			allowSpotlight: (allowed: boolean) => (this.allowSpotlight = allowed),
 		})
 	}
 	componentDidRender(): void {
-		this.expansionOpen.emit(this.expansionElement)
+		this.smoothlyExpansionOpen.emit(this.expansionElement)
 		if (this.expansionElement && this.open)
 			this.element.after(this.expansionElement)
 	}
@@ -53,7 +53,7 @@ export class TableExpandableRow implements ComponentWillLoad {
 		event.stopPropagation()
 		this.open = !this.open
 	}
-	@Listen("tableLoad")
+	@Listen("smoothlyTableLoad")
 	handleTableLoaded(event: CustomEvent<(owner: EventTarget) => void>) {
 		event.stopPropagation()
 		event.detail(this.element)

--- a/src/components/table/expandable/row/style.css
+++ b/src/components/table/expandable/row/style.css
@@ -33,8 +33,8 @@ td::slotted(*) {
 	--expansion-border-width: 3px;
 	position: relative;
 	background-color: rgb(var(--smoothly-default-color));
-	width: calc(100% + 3rem - 1px);
-	left: calc(-1 * var(--expansion-width));
+	width: calc(100% + 3rem - 2px);
+	left: calc(-1 * var(--expansion-width) + 1px);
 	box-sizing: border-box;
 	padding: 0.5rem calc(var(--expansion-width) - 1px);
 	border-bottom: 1px solid rgb(var(--smoothly-light-shade));
@@ -42,13 +42,16 @@ td::slotted(*) {
 tr.spotlight > td::slotted(*) {
 	box-shadow: calc(var(--expansion-border-width)) 0px 0px 0px rgb(var(--smoothly-tertiary-color)) inset;
 }
+tr:not(.spotlight) > td::slotted(*) {
+	box-shadow: -1px 0 0 0 rgb(var(--smoothly-light-shade)), 1px 0 0 0 rgb(var(--smoothly-light-shade));
+}
 td::slotted(*)::before {
 	content: "";
 	position: absolute;
 	display: flex;
 	top: 0;
 	bottom: 0;
-	left: 0;
+	left: -1px;
 	width: calc(var(--expansion-width) + 1px);
 	border-top: 1px solid rgb(var(--smoothly-light-shade));
 }

--- a/src/components/table/index.tsx
+++ b/src/components/table/index.tsx
@@ -13,24 +13,24 @@ export class Table implements ComponentWillLoad {
 	@Prop({ mutable: true, reflect: true }) root = true
 	@Prop({ reflect: true }) align: "middle" | "bottom" | "top" = "middle"
 	@Event() smoothlyNestedTable: EventEmitter<() => void>
-	@Event() spotlightChange: EventEmitter<{ allowSpotlight: boolean; owner?: EventTarget }>
-	@Event() tableLoad: EventEmitter<(owner: EventTarget) => void>
+	@Event() smoothlySpotlightChange: EventEmitter<{ allowSpotlight: boolean; owner?: EventTarget }>
+	@Event() smoothlyTableLoad: EventEmitter<(owner: EventTarget) => void>
 	componentWillLoad() {
 		this.smoothlyNestedTable.emit(() => (this.root = false))
-		this.tableLoad.emit((owner: EventTarget) => (this.owner = owner))
+		this.smoothlyTableLoad.emit((owner: EventTarget) => (this.owner = owner))
 	}
-	@Listen("expandableLoad")
+	@Listen("smoothlyExpandableLoad")
 	handleExpandableLoaded(event: CustomEvent<{ allowSpotlight: (allowed: boolean) => void }>) {
 		event.stopPropagation()
 		event.target && this.expandable.set(event.target, event.detail)
 	}
-	@Listen("expandableChange")
+	@Listen("smoothlyExpandableChange")
 	handleExpandableState(event: CustomEvent<boolean>) {
 		event.stopPropagation()
 		event.target && (event.detail ? this.expanded.add(event.target) : this.expanded.delete(event.target))
-		this.spotlightChange.emit({ allowSpotlight: !this.expanded.size, owner: this.owner })
+		this.smoothlySpotlightChange.emit({ allowSpotlight: !this.expanded.size, owner: this.owner })
 	}
-	@Listen("spotlightChange")
+	@Listen("smoothlySpotlightChange")
 	handleSpotlightState(event: CustomEvent<{ allowSpotlight: boolean; owner?: EventTarget }>) {
 		event.target != this.element &&
 			(event.stopPropagation(),
@@ -40,8 +40,8 @@ export class Table implements ComponentWillLoad {
 	handleNestedTable(event: CustomEvent<() => void>) {
 		event.target != this.element && (event.stopPropagation(), event.detail())
 	}
-	@Listen("expansionLoad")
-	@Listen("expansionOpen")
+	@Listen("smoothlyExpansionLoad")
+	@Listen("smoothlyExpansionOpen")
 	handleEvents(event: Event) {
 		event.stopPropagation()
 	}

--- a/src/components/table/row/index.tsx
+++ b/src/components/table/row/index.tsx
@@ -8,11 +8,11 @@ import { Component, Element, h, Listen } from "@stencil/core"
 export class TableRow {
 	@Element() element: HTMLSmoothlyTableRowElement
 	expansions: HTMLSmoothlyTableExpandableCellElement[] = []
-	@Listen("expansionLoad")
+	@Listen("smoothlyExpansionLoad")
 	onExpansionLoad(event: CustomEvent<void>) {
 		this.expansions.push(event.target as HTMLSmoothlyTableExpandableCellElement)
 	}
-	@Listen("expansionOpen")
+	@Listen("smoothlyExpansionOpen")
 	onExpansionOpen(event: CustomEvent<HTMLElement | undefined>) {
 		this.expansions.forEach(cell => {
 			if (cell != event.target)


### PR DESCRIPTION
* added missing left border to nested expandable rows
* nested expansion no longer grows by 1px per nesting
* prefixed table event names with smoothly