### PR TITLE
Set header and main slots in smoothly-app

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -25,7 +25,7 @@ export const App: FunctionalComponent<{ label: string }> = (attributes, nodes, u
 	const children = nodes.map(node => ({ ...nodeToChild(node), node }))
 	return (
 		<smoothly-app>
-			<header>
+			<header slot="header">
 				<h1>
 					<a {...href(resolve("") ?? "/")}>{attributes.label}</a>
 				</h1>
@@ -91,7 +91,7 @@ export const App: FunctionalComponent<{ label: string }> = (attributes, nodes, u
 				</nav>
 				{children.filter(child => child.vattrs?.slot == "header").map(child => child.node)}
 			</header>
-			<main>
+			<main slot="main">
 				<Router.Switch>
 					{children
 						.filter(child => child.vattrs?.path != undefined)

--- a/src/components/app/index.tsx
+++ b/src/components/app/index.tsx
@@ -11,6 +11,8 @@ export class SmoothlyApp {
 	render() {
 		return (
 			<smoothly-notifier>
+				<slot name="header"></slot>
+				<slot name="main"></slot>
 				<slot></slot>
 			</smoothly-notifier>
 		)


### PR DESCRIPTION
The `smoothly-app` will not always place the `header` and the `main` in the order specified.
This can be a problem when using the `smoothly-app` without the functional `App` component, and can then place the header at the bottom of the page.

![image](https://github.com/utily/smoothly/assets/14332757/af6fbc5e-f08f-4da0-9ab8-7de0937f75ab)
