### PR TITLE
fixed duplicate entries in picker

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -265,11 +265,9 @@ export namespace Components {
         "name": string;
         "open": boolean;
         "readonly": boolean;
-        "searchLabel": string;
         "validator"?: (value: string) => boolean | { result: boolean; notice: Notice };
     }
     interface SmoothlyPickerMenu {
-        "label": string;
         "labeledDefault": boolean;
         "multiple": boolean;
         "mutable": boolean;
@@ -283,6 +281,8 @@ export namespace Components {
         "selected": boolean;
         "value": any;
         "visible": boolean;
+    }
+    interface SmoothlyPickerTester {
     }
     interface SmoothlyPopup {
         "direction": "up" | "down";
@@ -815,6 +815,12 @@ declare global {
         prototype: HTMLSmoothlyPickerOptionElement;
         new (): HTMLSmoothlyPickerOptionElement;
     };
+    interface HTMLSmoothlyPickerTesterElement extends Components.SmoothlyPickerTester, HTMLStencilElement {
+    }
+    var HTMLSmoothlyPickerTesterElement: {
+        prototype: HTMLSmoothlyPickerTesterElement;
+        new (): HTMLSmoothlyPickerTesterElement;
+    };
     interface HTMLSmoothlyPopupElement extends Components.SmoothlyPopup, HTMLStencilElement {
     }
     var HTMLSmoothlyPopupElement: {
@@ -1045,6 +1051,7 @@ declare global {
         "smoothly-picker": HTMLSmoothlyPickerElement;
         "smoothly-picker-menu": HTMLSmoothlyPickerMenuElement;
         "smoothly-picker-option": HTMLSmoothlyPickerOptionElement;
+        "smoothly-picker-tester": HTMLSmoothlyPickerTesterElement;
         "smoothly-popup": HTMLSmoothlyPopupElement;
         "smoothly-quiet": HTMLSmoothlyQuietElement;
         "smoothly-radio": HTMLSmoothlyRadioElement;
@@ -1351,11 +1358,9 @@ declare namespace LocalJSX {
         "onSmoothlyInput"?: (event: SmoothlyPickerCustomEvent<Record<string, any | any[]>>) => void;
         "open"?: boolean;
         "readonly"?: boolean;
-        "searchLabel"?: string;
         "validator"?: (value: string) => boolean | { result: boolean; notice: Notice };
     }
     interface SmoothlyPickerMenu {
-        "label"?: string;
         "labeledDefault"?: boolean;
         "multiple"?: boolean;
         "mutable"?: boolean;
@@ -1373,6 +1378,8 @@ declare namespace LocalJSX {
         "selected"?: boolean;
         "value"?: any;
         "visible"?: boolean;
+    }
+    interface SmoothlyPickerTester {
     }
     interface SmoothlyPopup {
         "direction"?: "up" | "down";
@@ -1572,6 +1579,7 @@ declare namespace LocalJSX {
         "smoothly-picker": SmoothlyPicker;
         "smoothly-picker-menu": SmoothlyPickerMenu;
         "smoothly-picker-option": SmoothlyPickerOption;
+        "smoothly-picker-tester": SmoothlyPickerTester;
         "smoothly-popup": SmoothlyPopup;
         "smoothly-quiet": SmoothlyQuiet;
         "smoothly-radio": SmoothlyRadio;
@@ -1655,6 +1663,7 @@ declare module "@stencil/core" {
             "smoothly-picker": LocalJSX.SmoothlyPicker & JSXBase.HTMLAttributes<HTMLSmoothlyPickerElement>;
             "smoothly-picker-menu": LocalJSX.SmoothlyPickerMenu & JSXBase.HTMLAttributes<HTMLSmoothlyPickerMenuElement>;
             "smoothly-picker-option": LocalJSX.SmoothlyPickerOption & JSXBase.HTMLAttributes<HTMLSmoothlyPickerOptionElement>;
+            "smoothly-picker-tester": LocalJSX.SmoothlyPickerTester & JSXBase.HTMLAttributes<HTMLSmoothlyPickerTesterElement>;
             "smoothly-popup": LocalJSX.SmoothlyPopup & JSXBase.HTMLAttributes<HTMLSmoothlyPopupElement>;
             "smoothly-quiet": LocalJSX.SmoothlyQuiet & JSXBase.HTMLAttributes<HTMLSmoothlyQuietElement>;
             "smoothly-radio": LocalJSX.SmoothlyRadio & JSXBase.HTMLAttributes<HTMLSmoothlyRadioElement>;

--- a/src/components/form/index.tsx
+++ b/src/components/form/index.tsx
@@ -36,7 +36,6 @@ export class SmoothlyForm implements Changeable, Clearable, Submitable {
 	}
 	@Listen("smoothlyInput")
 	async smoothlyInputHandler(event: CustomEvent<Record<string, any>>): Promise<void> {
-		console.log("form caught")
 		this.notice = undefined
 		this.smoothlyFormInput.emit(
 			(this.value = Object.entries(event.detail).reduce(

--- a/src/components/form/index.tsx
+++ b/src/components/form/index.tsx
@@ -34,8 +34,9 @@ export class SmoothlyForm implements Changeable, Clearable, Submitable {
 		this.changed = Object.values(this.value).filter(value => Boolean(value)).length > 0
 		this.listeners.changed?.forEach(l => l(this))
 	}
-	@Listen("smoothlyInput", { capture: true })
+	@Listen("smoothlyInput")
 	async smoothlyInputHandler(event: CustomEvent<Record<string, any>>): Promise<void> {
+		console.log("form caught")
 		this.notice = undefined
 		this.smoothlyFormInput.emit(
 			(this.value = Object.entries(event.detail).reduce(

--- a/src/components/input/demo/index.tsx
+++ b/src/components/input/demo/index.tsx
@@ -292,11 +292,12 @@ export class SmoothlyInputDemo {
 				<smoothly-picker
 					multiple
 					mutable
-					label="Emails"
 					name="emails"
 					validator={value =>
 						value.match(/^.+@.+/) ? true : { result: false, notice: Notice.failed("That is not an email") }
 					}>
+					<span slot="label">Emails</span>
+					<span slot="search">Search</span>
 					<smoothly-picker-option value={"james@rocket.com"}>james@rocket.com</smoothly-picker-option>
 					<smoothly-picker-option selected value={"jessie@rocket.com"}>
 						jessie@rocket.com
@@ -315,7 +316,9 @@ export class SmoothlyInputDemo {
 						<smoothly-icon name="square-outline" />
 					</smoothly-picker-option>
 				</smoothly-picker>
-				<smoothly-picker multiple readonly name="animals" label="Animals">
+				<smoothly-picker multiple readonly name="animals">
+					<span slot="label">Animals</span>
+					<span slot="search">Search</span>
 					<smoothly-picker-option selected value={"cat"}>
 						Cat
 					</smoothly-picker-option>
@@ -323,6 +326,7 @@ export class SmoothlyInputDemo {
 					<smoothly-picker-option value={"fish"}>Fish</smoothly-picker-option>
 				</smoothly-picker>
 			</smoothly-form>,
+			<smoothly-picker-tester />,
 			<smoothly-backtotop></smoothly-backtotop>,
 			<h4>Smoothly Date</h4>,
 			<smoothly-input-date>Date</smoothly-input-date>,

--- a/src/components/picker/index.tsx
+++ b/src/components/picker/index.tsx
@@ -14,7 +14,6 @@ export class SmoothlyPicker {
 	@Prop() multiple = false
 	@Prop() mutable = false
 	@Prop() readonly = false
-	@Prop() searchLabel = "Search"
 	@Prop() validator?: (value: string) => boolean | { result: boolean; notice: Notice }
 	@Prop() labeledDefault = false
 	@State() selected = new Map<string, Option>()
@@ -64,19 +63,21 @@ export class SmoothlyPicker {
 		return (
 			<Host>
 				<div ref={element => (this.selectedElement = element)} class={"selected"} />
-				<span class={"label"}>{this.label}</span>
+				<span class={"label"}>
+					<slot name="label" />
+				</span>
 				<button type={"button"}>
 					<smoothly-icon name={this.open ? "chevron-down-outline" : "chevron-forward-outline"} />
 				</button>
 				<smoothly-picker-menu
 					onClick={event => event.stopPropagation()}
-					label={this.searchLabel}
 					labeledDefault={this.labeledDefault}
 					validator={this.validator}
 					multiple={this.multiple}
 					mutable={this.mutable}
 					readonly={this.readonly}
 					class={"menu"}>
+					<slot name="search" slot="search" />
 					<slot />
 				</smoothly-picker-menu>
 			</Host>

--- a/src/components/picker/menu/index.tsx
+++ b/src/components/picker/menu/index.tsx
@@ -11,7 +11,6 @@ export class SmoothlyPickerMenu {
 	@Prop({ reflect: true }) multiple = false
 	@Prop({ reflect: true }) mutable = false
 	@Prop({ reflect: true }) readonly = false
-	// @Prop() label = "Search"
 	@Prop() validator?: (value: string) => boolean | { result: boolean; notice: Notice }
 	@Prop() labeledDefault = false
 	@State() allowed = false

--- a/src/components/picker/menu/index.tsx
+++ b/src/components/picker/menu/index.tsx
@@ -11,7 +11,7 @@ export class SmoothlyPickerMenu {
 	@Prop({ reflect: true }) multiple = false
 	@Prop({ reflect: true }) mutable = false
 	@Prop({ reflect: true }) readonly = false
-	@Prop() label = "Search"
+	// @Prop() label = "Search"
 	@Prop() validator?: (value: string) => boolean | { result: boolean; notice: Notice }
 	@Prop() labeledDefault = false
 	@State() allowed = false
@@ -29,6 +29,10 @@ export class SmoothlyPickerMenu {
 
 	@Listen("smoothlyPickerOptionLoaded")
 	optionLoadedHandler(event: CustomEvent<Option>) {
+		const old = this.options.get(event.detail.element.name)
+		const filtered = this.new.filter(option => option.value != old?.value)
+		if (filtered.length != this.new.length)
+			this.new = filtered
 		this.options.set(event.detail.element.name, event.detail)
 	}
 	@Listen("smoothlyPickerOptionChanged")
@@ -40,7 +44,7 @@ export class SmoothlyPickerMenu {
 		}
 	}
 	inputHandler(event: CustomEvent<Record<string, any>>) {
-		event.stopImmediatePropagation()
+		event.stopPropagation()
 		this.search = event.detail.search
 		if (!this.search) {
 			this.allowed = false
@@ -79,12 +83,12 @@ export class SmoothlyPickerMenu {
 				<div class={"controls"}>
 					<smoothly-input
 						ref={element => (this.searchElement = element)}
-						name={"search"}
 						value={this.search}
 						onSmoothlyInput={e => this.inputHandler(e)}
 						onSmoothlyChange={e => this.inputHandler(e)}
+						onSmoothlyBlur={e => e.stopPropagation()}
 						onKeyDown={event => this.keyDownHandler(event)}>
-						{this.label}
+						<slot name="search" />
 					</smoothly-input>
 					{this.mutable ? (
 						<button onClick={() => this.addHandler()} disabled={!this.allowed} class={"add"} type={"button"}>

--- a/src/components/picker/testing/index.tsx
+++ b/src/components/picker/testing/index.tsx
@@ -1,0 +1,35 @@
+import { Component, h, State } from "@stencil/core"
+
+@Component({
+	tag: "smoothly-picker-tester",
+	styleUrl: "style.css",
+	scoped: true,
+})
+export class SmoothlyPickerTester {
+	@State() data = {
+		message: "hello world",
+		emails: ["giovani@rocket.com", "jessie@rocket.com", "james@rocket.com"],
+	}
+	render() {
+		return (
+			<smoothly-form
+				looks="grid"
+				onSmoothlyFormInput={e => console.log("input", (this.data = { ...this.data, ...e.detail }))}
+				onSmoothlyFormSubmit={e => console.log("submit", { ...this.data, ...e.detail })}>
+				<smoothly-input type="text" name="message" value={this.data.message}>
+					Message
+				</smoothly-input>
+				<smoothly-picker name="type" multiple mutable>
+					<span slot="label">Emails</span>
+					<span slot="search">Search</span>
+					{this.data.emails.map(email => (
+						<smoothly-picker-option value={email} selected>
+							{email}
+						</smoothly-picker-option>
+					))}
+				</smoothly-picker>
+				<smoothly-submit slot="submit">Submit</smoothly-submit>
+			</smoothly-form>
+		)
+	}
+}

--- a/src/components/picker/testing/index.tsx
+++ b/src/components/picker/testing/index.tsx
@@ -14,7 +14,7 @@ export class SmoothlyPickerTester {
 		return (
 			<smoothly-form
 				looks="grid"
-				onSmoothlyFormInput={e => console.log("input", (this.data = { ...this.data, ...e.detail }))}
+				onSmoothlyFormInput={e => (this.data = { ...this.data, ...e.detail })}
 				onSmoothlyFormSubmit={e => console.log("submit", { ...this.data, ...e.detail })}>
 				<smoothly-input type="text" name="message" value={this.data.message}>
 					Message


### PR DESCRIPTION
* picker menus new array is filtered from options that already exists in case they are being handled from outside the component
* removed forms `{capture: true}` so the search field in the picker does not contaminate the forms input/submit event data
  * if this removal is unsafe please give feedback in review