### PR TITLE
listenable readonly properties not crashing

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -276,7 +276,7 @@ export namespace Components {
         "validator"?: (value: string) => boolean | { result: boolean; notice: Notice };
     }
     interface SmoothlyPickerOption {
-        "clickHandler": () => Promise<void>;
+        "clickHandler": () => void;
         "labeled": boolean;
         "name": string;
         "readonly": boolean;

--- a/src/model/Listenable.spec.ts
+++ b/src/model/Listenable.spec.ts
@@ -6,6 +6,9 @@ import { StateBase } from "./StateBase"
 
 describe("Listenable", () => {
 	class State extends StateBase<State> {
+		get foo() {
+			return "bar"
+		}
 		disabled = false
 		static create() {
 			return Listenable.load(new State())
@@ -29,6 +32,7 @@ describe("Listenable", () => {
 			}
 		}
 		const components = [new FakeComponent(), new FakeComponent()]
+		expect(state.foo).toEqual("bar")
 		expect(components.every(component => !component.disabled))
 		state.disabled = true
 		expect(components.every(component => component.disabled)).toEqual(true)

--- a/src/model/Listenable.ts
+++ b/src/model/Listenable.ts
@@ -53,7 +53,7 @@ export class Listenable<T extends CanBeListenable> {
 						  }
 						: {
 								get() {
-									return backend[name].bind(backend)
+									return backend[name]
 								},
 						  },
 				])


### PR DESCRIPTION
* listenable crashed if there was a getter and not setter that did not return a function