### PR TITLE
can control open state of summary

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -351,6 +351,7 @@ export namespace Components {
     interface SmoothlySummary {
         "color": Color;
         "fill": Fill;
+        "open": boolean;
         "size": "tiny" | "small" | "medium" | "large";
     }
     interface SmoothlySvg {
@@ -1484,6 +1485,7 @@ declare namespace LocalJSX {
     interface SmoothlySummary {
         "color"?: Color;
         "fill"?: Fill;
+        "open"?: boolean;
         "size"?: "tiny" | "small" | "medium" | "large";
     }
     interface SmoothlySvg {

--- a/src/components/display-demo/index.tsx
+++ b/src/components/display-demo/index.tsx
@@ -197,7 +197,7 @@ export class SmoothlyDisplayDemo {
 						<div slot="summary" style={{display: "flex", gap: "0.3rem"}}><span>Person</span><smoothly-icon name="person" color="light" fill="clear" size="tiny"></smoothly-icon></div>
 						<p slot="content">Some person information.</p>
 					</smoothly-summary>
-					<smoothly-summary color="danger" fill="clear">
+					<smoothly-summary color="danger" fill="clear" open>
 						<p slot="summary">Some other title</p>
 						<p slot="content">A lot more content, yes please. A lot more content, yes please. A lot more content, yes please. A lot more content, yes please. A lot more content, yes please.A lot more content, yes please. A lot more content, yes please. A lot more content, yes please. A lot more content, yes please.</p>
 					</smoothly-summary>

--- a/src/components/summary/index.tsx
+++ b/src/components/summary/index.tsx
@@ -12,9 +12,8 @@ export class SmoothlySummary {
 	@Prop() size: "tiny" | "small" | "medium" | "large" = "tiny"
 
 	toggleHandler(event: Event) {
-		if (event.target instanceof HTMLDetailsElement) {
+		if (event.target instanceof HTMLDetailsElement)
 			this.open = event.target.open
-		}
 	}
 
 	render() {

--- a/src/components/summary/index.tsx
+++ b/src/components/summary/index.tsx
@@ -6,13 +6,20 @@ import { Color, Fill } from "../../model"
 	scoped: true,
 })
 export class SmoothlySummary {
+	@Prop({ mutable: true, reflect: true }) open = false
 	@Prop() color: Color = "primary"
 	@Prop() fill: Fill = "solid"
 	@Prop() size: "tiny" | "small" | "medium" | "large" = "tiny"
 
+	toggleHandler(event: Event) {
+		if (event.target instanceof HTMLDetailsElement) {
+			this.open = event.target.open
+		}
+	}
+
 	render() {
 		return (
-			<details>
+			<details onToggle={e => this.toggleHandler(e)} open={this.open}>
 				<summary>
 					<smoothly-icon name="chevron-forward" color={this.color} fill={this.fill} size={this.size}></smoothly-icon>
 					<slot name="summary"></slot>


### PR DESCRIPTION
* summary components open state can be controlled with its new `open` property.