### PR TITLE
fix blurry icons on safari

### DIFF
--- a/src/components/icon/style.css
+++ b/src/components/icon/style.css
@@ -3,6 +3,8 @@
 }
 :host {
 	display: block;
+	transform: translate3d(0,0,0);
+	-webkit-transform: translate3d(0,0,0)
 }
 :host[hidden] {
 	display: none;


### PR DESCRIPTION
icons are currently blurry on safari.
this change lets safari to perform hardware acceleration to the element but with a transformation that doesn't actually change its position.