### PR TITLE
Chevron to caret

### DIFF
--- a/src/components/table/cell/index.tsx
+++ b/src/components/table/cell/index.tsx
@@ -13,7 +13,7 @@ export class TableCell {
 					<div>
 						<slot></slot>
 					</div>
-					<smoothly-icon name="chevron-forward" size="tiny" />
+					<smoothly-icon name="caret-forward-outline" size="tiny" />
 				</div>
 			</Host>
 		)

--- a/src/components/table/cell/style.css
+++ b/src/components/table/cell/style.css
@@ -7,6 +7,15 @@
 }
 :host smoothly-icon {
 	display: none;
+	width: 1em;
+	height: auto;
+	aspect-ratio: 1 / 1;
+	margin: 0 0.3rem;
+	transition: transform 0.2s, opacity 0.1s;
+	opacity: 0.3;
+}
+:host:hover smoothly-icon {
+	opacity: 1;
 }
 smoothly-table-expandable-row > div :host:last-of-type smoothly-icon {
 	display: flex;
@@ -14,19 +23,12 @@ smoothly-table-expandable-row > div :host:last-of-type smoothly-icon {
 smoothly-table-expandable-row[open] > div :host:last-of-type smoothly-icon {
 	transform: rotate(90deg);
 }
-
 :host > div {
 	display: flex;
 	align-items: center;
 }
 :host > div > div {
 	width: 100%;
-}
-:host smoothly-icon {
-	width: 0.6rem;
-	height: 0.6rem;
-	margin: 0 0.3rem;
-	transition: transform 0.2s;
 }
 smoothly-table[align=bottom] :host {
 	vertical-align: bottom;

--- a/src/components/table/expandable/cell/index.tsx
+++ b/src/components/table/expandable/cell/index.tsx
@@ -68,7 +68,7 @@ export class TableExpandableCell implements ComponentWillLoad {
 		return (
 			<Host style={{ textAlign: this.align }}>
 				<aside>
-					<smoothly-icon name="chevron-forward" size="tiny"></smoothly-icon>
+					<smoothly-icon name="caret-forward-outline"></smoothly-icon>
 					<slot></slot>
 				</aside>
 				<tr class={{ spotlight: this.spotlight }} ref={e => (this.expansionElement = e)}>

--- a/src/components/table/expandable/cell/style.css
+++ b/src/components/table/expandable/cell/style.css
@@ -14,12 +14,13 @@
 	box-shadow: 1px 0 0 0 rgb(var(--smoothly-light-shade)) inset, -1px 0 0 0 rgb(var(--smoothly-light-shade)) inset, 0 1px 0 0 rgb(var(--smoothly-light-shade)) inset;
 }
 :host smoothly-icon {
-	width: 1rem;
+	width: 1em;
 	float: left;
 	padding: 0 0.3rem;
-	transition: transform 0.2s;
+	transition: transform 0.2s, opacity 0.1s;
 	display: flex;
-	height: 100%;
+	height: auto;
+	aspect-ratio: 1 / 1;
 	align-self: center;
 	opacity: 0.3;
 }

--- a/src/components/table/expandable/cell/style.css
+++ b/src/components/table/expandable/cell/style.css
@@ -14,13 +14,17 @@
 	box-shadow: 1px 0 0 0 rgb(var(--smoothly-light-shade)) inset, -1px 0 0 0 rgb(var(--smoothly-light-shade)) inset, 0 1px 0 0 rgb(var(--smoothly-light-shade)) inset;
 }
 :host smoothly-icon {
-	width: 0.6rem;
+	width: 1rem;
 	float: left;
 	padding: 0 0.3rem;
 	transition: transform 0.2s;
 	display: flex;
 	height: 100%;
 	align-self: center;
+	opacity: 0.3;
+}
+:host:hover smoothly-icon {
+	opacity: 1;
 }
 :host[open] smoothly-icon {
 	transform: rotate(90deg);


### PR DESCRIPTION
Changed expandable-cell and expandable-row to use carets instead of chevron to indicate it is openable. The caret is also made to be opaque when not hovered to indicate it is actionable.

