### PR TITLE
Formstyle

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -15,6 +15,7 @@ import { Direction, Type } from "tidily";
 import { Criteria } from "selectively";
 import { Data } from "./model/Data";
 import { GoogleFont } from "./model/GoogleFont";
+import { Looks } from "./components/input/Looks";
 import { Controls } from "./components/picker/menu";
 import { Controls as Controls1 } from "./components/picker/menu/index";
 import { Selected } from "./components/radio-button/Selected";
@@ -194,6 +195,7 @@ export namespace Components {
         "currency"?: Currency;
         "disabled": boolean;
         "getFormData": (name: string) => Promise<Record<string, any>>;
+        "looks": Looks;
         "maxLength": number;
         "minLength": number;
         "name": string;
@@ -220,6 +222,7 @@ export namespace Components {
     interface SmoothlyInputDate {
         "clear": () => Promise<void>;
         "disabled": boolean;
+        "looks": Looks;
         "max": Date;
         "min": Date;
         "name": string;
@@ -231,6 +234,7 @@ export namespace Components {
         "end"?: isoly.Date;
         "labelEnd": string;
         "labelStart": string;
+        "looks": Looks;
         "max": isoly.Date;
         "min": isoly.Date;
         "name": string;
@@ -245,6 +249,7 @@ export namespace Components {
         "accept"?: string;
         "camera": "front" | "back";
         "clear": () => Promise<void>;
+        "looks": Looks;
         "name": string;
         "placeholder": string | undefined;
         "showLabel": boolean;
@@ -255,6 +260,8 @@ export namespace Components {
     }
     interface SmoothlyInputSelect {
         "initialPrompt"?: string;
+        "looks": Looks;
+        "name": string;
         "reset": () => Promise<void>;
     }
     interface SmoothlyItem {
@@ -272,6 +279,7 @@ export namespace Components {
     }
     interface SmoothlyPicker {
         "clear": () => Promise<void>;
+        "looks": Looks;
         "multiple": boolean;
         "mutable": boolean;
         "name": string;
@@ -282,6 +290,7 @@ export namespace Components {
     interface SmoothlyPickerDemo {
     }
     interface SmoothlyPickerMenu {
+        "looks": Looks;
         "multiple": boolean;
         "mutable": boolean;
         "readonly": boolean;
@@ -1313,12 +1322,14 @@ declare namespace LocalJSX {
         "changed"?: boolean;
         "currency"?: Currency;
         "disabled"?: boolean;
+        "looks"?: Looks;
         "maxLength"?: number;
         "minLength"?: number;
         "name"?: string;
         "onSmoothlyBlur"?: (event: SmoothlyInputCustomEvent<void>) => void;
         "onSmoothlyChange"?: (event: SmoothlyInputCustomEvent<Record<string, any>>) => void;
         "onSmoothlyInput"?: (event: SmoothlyInputCustomEvent<Record<string, any>>) => void;
+        "onSmoothlyInputLooks"?: (event: SmoothlyInputCustomEvent<(looks: Looks) => void>) => void;
         "pattern"?: RegExp | undefined;
         "placeholder"?: string | undefined;
         "readonly"?: boolean;
@@ -1340,9 +1351,12 @@ declare namespace LocalJSX {
     }
     interface SmoothlyInputDate {
         "disabled"?: boolean;
+        "looks"?: Looks;
         "max"?: Date;
         "min"?: Date;
         "name"?: string;
+        "onSmoothlyInput"?: (event: SmoothlyInputDateCustomEvent<Record<number, any>>) => void;
+        "onSmoothlyInputLooks"?: (event: SmoothlyInputDateCustomEvent<(looks: Looks) => void>) => void;
         "onValueChanged"?: (event: SmoothlyInputDateCustomEvent<Date>) => void;
         "open"?: boolean;
         "value"?: Date;
@@ -1351,10 +1365,12 @@ declare namespace LocalJSX {
         "end"?: isoly.Date;
         "labelEnd"?: string;
         "labelStart"?: string;
+        "looks"?: Looks;
         "max"?: isoly.Date;
         "min"?: isoly.Date;
         "name"?: string;
         "onSmoothlyInput"?: (event: SmoothlyInputDateRangeCustomEvent<Data1>) => void;
+        "onSmoothlyInputLooks"?: (event: SmoothlyInputDateRangeCustomEvent<(looks: Looks) => void>) => void;
         "onValueChanged"?: (event: SmoothlyInputDateRangeCustomEvent<isoly.Date>) => void;
         "open"?: boolean;
         "showLabel"?: boolean;
@@ -1366,9 +1382,11 @@ declare namespace LocalJSX {
     interface SmoothlyInputFile {
         "accept"?: string;
         "camera"?: "front" | "back";
+        "looks"?: Looks;
         "name"?: string;
         "onSmoothlyChange"?: (event: SmoothlyInputFileCustomEvent<Record<string, File>>) => void;
         "onSmoothlyInput"?: (event: SmoothlyInputFileCustomEvent<Record<string, File>>) => void;
+        "onSmoothlyInputLooks"?: (event: SmoothlyInputFileCustomEvent<(looks: Looks) => void>) => void;
         "placeholder"?: string | undefined;
         "showLabel"?: boolean;
         "value"?: File;
@@ -1379,7 +1397,11 @@ declare namespace LocalJSX {
     }
     interface SmoothlyInputSelect {
         "initialPrompt"?: string;
+        "looks"?: Looks;
+        "name"?: string;
         "onSelected"?: (event: SmoothlyInputSelectCustomEvent<any>) => void;
+        "onSmoothlyInput"?: (event: SmoothlyInputSelectCustomEvent<Record<number, any>>) => void;
+        "onSmoothlyInputLooks"?: (event: SmoothlyInputSelectCustomEvent<(looks: Looks) => void>) => void;
     }
     interface SmoothlyItem {
         "marked"?: boolean;
@@ -1396,11 +1418,13 @@ declare namespace LocalJSX {
     interface SmoothlyNotifier {
     }
     interface SmoothlyPicker {
+        "looks"?: Looks;
         "multiple"?: boolean;
         "mutable"?: boolean;
         "name"?: string;
         "onSmoothlyChange"?: (event: SmoothlyPickerCustomEvent<Record<string, any | any[]>>) => void;
         "onSmoothlyInput"?: (event: SmoothlyPickerCustomEvent<Record<string, any | any[]>>) => void;
+        "onSmoothlyInputLooks"?: (event: SmoothlyPickerCustomEvent<(looks: Looks) => void>) => void;
         "onSmoothlyPickerLoaded"?: (event: SmoothlyPickerCustomEvent<Controls>) => void;
         "open"?: boolean;
         "readonly"?: boolean;
@@ -1409,6 +1433,7 @@ declare namespace LocalJSX {
     interface SmoothlyPickerDemo {
     }
     interface SmoothlyPickerMenu {
+        "looks"?: Looks;
         "multiple"?: boolean;
         "mutable"?: boolean;
         "onNotice"?: (event: SmoothlyPickerMenuCustomEvent<Notice>) => void;

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -1355,7 +1355,7 @@ declare namespace LocalJSX {
         "max"?: Date;
         "min"?: Date;
         "name"?: string;
-        "onSmoothlyInput"?: (event: SmoothlyInputDateCustomEvent<Record<number, any>>) => void;
+        "onSmoothlyInput"?: (event: SmoothlyInputDateCustomEvent<Record<string, any>>) => void;
         "onSmoothlyInputLooks"?: (event: SmoothlyInputDateCustomEvent<(looks: Looks) => void>) => void;
         "onValueChanged"?: (event: SmoothlyInputDateCustomEvent<Date>) => void;
         "open"?: boolean;

--- a/src/components/form/index.tsx
+++ b/src/components/form/index.tsx
@@ -4,6 +4,7 @@ import { Data } from "../../model/Data"
 import { Notice } from "../../model/Notice"
 import { Changeable } from "../input/Changeable"
 import { Clearable } from "../input/Clearable"
+import { Looks } from "../input/Looks"
 import { Submitable } from "../input/Submitable"
 
 @Component({
@@ -33,6 +34,11 @@ export class SmoothlyForm implements Changeable, Clearable, Submitable {
 	watchValue() {
 		this.changed = Object.values(this.value).filter(value => Boolean(value)).length > 0
 		this.listeners.changed?.forEach(l => l(this))
+	}
+	@Listen("smoothlyInputLooks")
+	smoothlyInputLooksHandler(event: CustomEvent<(looks: Looks) => void>) {
+		event.stopPropagation()
+		event.detail(this.looks)
 	}
 	@Listen("smoothlyInput")
 	async smoothlyInputHandler(event: CustomEvent<Record<string, any>>): Promise<void> {

--- a/src/components/form/style.css
+++ b/src/components/form/style.css
@@ -21,28 +21,13 @@ smoothly-form > form > fieldset {
 	border-color: unset;
 	border-image: unset;
 }
-
 smoothly-form > form > fieldset > * {
+	box-sizing: border-box;
 	flex-grow: 1;
 	min-width: 10em;
 	flex-basis: 40%;
 }
-smoothly-form > form > fieldset smoothly-picker smoothly-picker-menu,
-smoothly-form[looks="border"] > form > fieldset smoothly-picker smoothly-input,
-smoothly-form[looks="grid"] > form > fieldset smoothly-picker smoothly-input,
-smoothly-form[looks="border"] > form > fieldset > *,
-smoothly-form[looks="grid"] > form > fieldset > * {
-	border: rgb(var(--smoothly-default-contrast)) solid 1px;
-}
-smoothly-form[looks="line"] > form > fieldset smoothly-picker smoothly-input,
-smoothly-form[looks="line"] > form > fieldset > * {
-	border-bottom: rgb(var(--smoothly-default-contrast)) solid 1px;
-}
 smoothly-form[looks="grid"] > form > fieldset {
-	border: rgba(var(--smoothly-default-contrast), .5) solid .5px;
-}
-smoothly-form[looks="grid"] > form > fieldset smoothly-picker smoothly-input,
-smoothly-form[looks="grid"] > form > fieldset > * {
 	border: rgba(var(--smoothly-default-contrast), .5) solid .5px;
 }
 smoothly-form[looks="line"] > form > fieldset,

--- a/src/components/form/style.css
+++ b/src/components/form/style.css
@@ -22,7 +22,6 @@ smoothly-form > form > fieldset {
 	border-image: unset;
 }
 smoothly-form > form > fieldset > * {
-	box-sizing: border-box;
 	flex-grow: 1;
 	min-width: 10em;
 	flex-basis: 40%;

--- a/src/components/input/Input.ts
+++ b/src/components/input/Input.ts
@@ -1,0 +1,9 @@
+import { EventEmitter } from "@stencil/core"
+import { Looks } from "./Looks"
+
+export interface Input {
+	name: string
+	looks: Looks
+	smoothlyInput: EventEmitter<Record<number, any>>
+	smoothlyInputLooks: EventEmitter<(looks: Looks) => void>
+}

--- a/src/components/input/Looks.ts
+++ b/src/components/input/Looks.ts
@@ -1,0 +1,1 @@
+export type Looks = "plain" | "grid" | "border" | "line"

--- a/src/components/input/date/index.tsx
+++ b/src/components/input/date/index.tsx
@@ -19,7 +19,7 @@ export class InputDate implements Clearable, Input {
 	@Prop({ mutable: true }) min: Date
 	@Prop({ mutable: true }) disabled: boolean
 	@Event() valueChanged: EventEmitter<Date>
-	@Event() smoothlyInput: EventEmitter<Record<number, any>>
+	@Event() smoothlyInput: EventEmitter<Record<string, any>>
 	@Event() smoothlyInputLooks: EventEmitter<(looks: Looks) => void>
 
 	componentWillLoad() {
@@ -33,7 +33,12 @@ export class InputDate implements Clearable, Input {
 	@Watch("value")
 	onStart(next: Date) {
 		this.valueChanged.emit(next)
-		this.smoothlyInput.emit(next)
+		this.smoothlyInput.emit({ [this.name]: next })
+	}
+	@Listen("smoothlyInput")
+	smoothlyInputHandler(event: CustomEvent<Record<string, any>>) {
+		if (event.target != this.element)
+			event.stopPropagation()
 	}
 	@Listen("smoothlyInputLooks")
 	smoothlyInputLooksHandler(event: CustomEvent<(looks: Looks) => void>) {

--- a/src/components/input/date/range/index.tsx
+++ b/src/components/input/date/range/index.tsx
@@ -42,6 +42,11 @@ export class InputDateRange implements Clearable, Input {
 	onValue(next: isoly.Date) {
 		this.valueChanged.emit(next)
 	}
+	@Listen("smoothlyInput")
+	smoothlyInputHandler(event: CustomEvent<Record<string, any>>) {
+		if (event.target != this.element)
+			event.stopPropagation()
+	}
 	@Listen("smoothlyInputLooks")
 	smoothlyInputLooksHandler(event: CustomEvent<(looks: Looks) => void>) {
 		if (event.target != this.element)
@@ -70,7 +75,7 @@ export class InputDateRange implements Clearable, Input {
 					value={this.start}
 					looks="plain"
 					showLabel={this.showLabel}
-					onSmoothlyInput={e => (this.start = e.detail.start) && e.stopPropagation()}>
+					onSmoothlyInput={e => (this.start = e.detail.start)}>
 					{`${this.labelStart}`}
 				</smoothly-input>
 				<span>–</span>
@@ -80,7 +85,7 @@ export class InputDateRange implements Clearable, Input {
 					value={this.end}
 					looks="plain"
 					showLabel={this.showLabel}
-					onSmoothlyInput={e => (this.end = e.detail.end) && e.stopPropagation()}>
+					onSmoothlyInput={e => (this.end = e.detail.end)}>
 					{`${this.labelEnd}`}
 				</smoothly-input>
 			</section>,

--- a/src/components/input/date/range/style.scss
+++ b/src/components/input/date/range/style.scss
@@ -1,3 +1,5 @@
+@import "../../looks.css";
+
 :host {
 	position: relative;
 	display: block;

--- a/src/components/input/date/range/style.scss
+++ b/src/components/input/date/range/style.scss
@@ -1,4 +1,4 @@
-@import "../../looks.css";
+@import "../../shared.css";
 
 :host {
 	position: relative;

--- a/src/components/input/date/style.css
+++ b/src/components/input/date/style.css
@@ -1,4 +1,4 @@
-@import "../looks.css";
+@import "../shared.css";
 
 :host {
 	position: relative;

--- a/src/components/input/date/style.css
+++ b/src/components/input/date/style.css
@@ -1,3 +1,5 @@
+@import "../looks.css";
+
 :host {
 	position: relative;
 	max-width: 100vw;

--- a/src/components/input/demo/index.tsx
+++ b/src/components/input/demo/index.tsx
@@ -56,7 +56,7 @@ export class SmoothlyInputDemo {
 				<smoothly-input type="password" name="password">
 					Password
 				</smoothly-input>
-				<smoothly-submit onSubmit={(e: Event) => alert(e)} color="success" fill="solid">
+				<smoothly-submit slot="submit" onSubmit={(e: Event) => alert(e)} color="success" fill="solid">
 					Send
 				</smoothly-submit>
 			</smoothly-form>,

--- a/src/components/input/demo/index.tsx
+++ b/src/components/input/demo/index.tsx
@@ -304,6 +304,7 @@ export class SmoothlyInputDemo {
 			</smoothly-form>,
 
 			<smoothly-input-date-range
+				looks="grid"
 				start={isoly.Date.now()}
 				end={isoly.Date.nextMonth(isoly.Date.now())}
 				min="2021-10-10"
@@ -317,6 +318,7 @@ export class SmoothlyInputDemo {
 			<br />,
 			<h4>Smoothly Selector</h4>,
 			<smoothly-input-select
+				looks="line"
 				initialPrompt="Select..."
 				ref={(element: HTMLSmoothlyInputSelectElement) => (this.selectElement = element)}>
 				<smoothly-item value="1">January</smoothly-item>

--- a/src/components/input/demo/index.tsx
+++ b/src/components/input/demo/index.tsx
@@ -336,14 +336,16 @@ export class SmoothlyInputDemo {
 			</smoothly-input-select>,
 			<button onClick={async () => this.selectElement.reset()}>Reset select</button>,
 
-			<smoothly-form looks="line" onSmoothlyFormSubmit={e => console.log("Submitted", e.detail)}>
+			<smoothly-form looks="grid" onSmoothlyFormSubmit={e => console.log("Submitted", e.detail)}>
 				<smoothly-input type="text" name="text">
 					Text
 				</smoothly-input>
-				<smoothly-input-file placeholder="Select or drag a file here" name="file">
-					<span slot="label">Testing file input</span>
-					<smoothly-icon slot="button" name="folder-outline" />
-				</smoothly-input-file>
+				<div>
+					<smoothly-input-file placeholder="Select or drag a file here" name="file">
+						<span slot="label">Testing file input</span>
+						<smoothly-icon slot="button" name="folder-outline" />
+					</smoothly-input-file>
+				</div>
 				<smoothly-input-file camera="back" placeholder="Capture a photo" name="image">
 					<span slot="label">Testing camera photo</span>
 					<smoothly-icon slot="button" name="camera-outline" />

--- a/src/components/input/demo/index.tsx
+++ b/src/components/input/demo/index.tsx
@@ -356,13 +356,13 @@ export class SmoothlyInputDemo {
 				<smoothly-submit slot="submit">Submit</smoothly-submit>
 			</smoothly-form>,
 			<br />,
-			<smoothly-form looks="line">
-				<smoothly-input>Input</smoothly-input>
+			<smoothly-form looks="line" onSmoothlyFormSubmit={e => console.log("form input", e.detail)}>
+				<smoothly-input name="text">Input</smoothly-input>
 				<smoothly-input-file camera="back" placeholder="Capture a photo" name="image">
 					<span slot="label">Testing camera photo</span>
 					<smoothly-icon slot="button" name="camera-outline" />
 				</smoothly-input-file>
-				<smoothly-picker name="shape">
+				<smoothly-picker name="picker">
 					<span slot="label">Shape</span>
 					<span slot="search">Search</span>
 					<smoothly-picker-option value={"circle"}>
@@ -379,6 +379,7 @@ export class SmoothlyInputDemo {
 					</smoothly-picker-option>
 				</smoothly-picker>
 				<smoothly-input-select
+					name="select"
 					initialPrompt="Select..."
 					ref={(element: HTMLSmoothlyInputSelectElement) => (this.selectElement = element)}>
 					<smoothly-item value="1">January</smoothly-item>
@@ -395,6 +396,7 @@ export class SmoothlyInputDemo {
 					<smoothly-item value="12">December</smoothly-item>
 				</smoothly-input-select>
 				<smoothly-input-date-range
+					name="date-range"
 					start={isoly.Date.now()}
 					end={isoly.Date.nextMonth(isoly.Date.now())}
 					min="2021-10-10"
@@ -406,9 +408,12 @@ export class SmoothlyInputDemo {
 						"--input-width": "12ch",
 					}}
 				/>
-				<smoothly-input-date value="2021-10-28" max="2021-12-30" min="2021-10-10">
+				<smoothly-input-date name="date" value="2021-10-28" max="2021-12-30" min="2021-10-10">
 					Date
 				</smoothly-input-date>
+				<smoothly-submit slot="submit" color="success" fill="solid" size="icon">
+					<smoothly-icon name="checkmark-circle" fill="solid" size="medium" />
+				</smoothly-submit>
 			</smoothly-form>,
 		]
 	}

--- a/src/components/input/demo/index.tsx
+++ b/src/components/input/demo/index.tsx
@@ -313,7 +313,7 @@ export class SmoothlyInputDemo {
 				style={{
 					"--border-radius": "4px",
 					"--padding": "0 0.75em",
-					"--input-width": "6rem",
+					"--input-width": "12ch",
 				}}></smoothly-input-date-range>,
 			<br />,
 			<h4>Smoothly Selector</h4>,
@@ -335,7 +335,7 @@ export class SmoothlyInputDemo {
 				<smoothly-item value="12">December</smoothly-item>
 			</smoothly-input-select>,
 			<button onClick={async () => this.selectElement.reset()}>Reset select</button>,
-
+			<br />,
 			<smoothly-form looks="grid" onSmoothlyFormSubmit={e => console.log("Submitted", e.detail)}>
 				<smoothly-input type="text" name="text">
 					Text
@@ -356,6 +356,60 @@ export class SmoothlyInputDemo {
 				<smoothly-submit slot="submit">Submit</smoothly-submit>
 			</smoothly-form>,
 			<br />,
+			<smoothly-form looks="line">
+				<smoothly-input>Input</smoothly-input>
+				<smoothly-input-file camera="back" placeholder="Capture a photo" name="image">
+					<span slot="label">Testing camera photo</span>
+					<smoothly-icon slot="button" name="camera-outline" />
+				</smoothly-input-file>
+				<smoothly-picker name="shape">
+					<span slot="label">Shape</span>
+					<span slot="search">Search</span>
+					<smoothly-picker-option value={"circle"}>
+						<span slot="label">Circle</span>
+						<smoothly-icon size="tiny" name="ellipse-outline" />
+					</smoothly-picker-option>
+					<smoothly-picker-option value={"cube"}>
+						<span slot={"label"}>Cube</span>
+						<smoothly-icon size="tiny" name="cube-outline" />
+					</smoothly-picker-option>
+					<smoothly-picker-option value={"square"} selected>
+						<span slot={"label"}>Square</span>
+						<smoothly-icon size="tiny" name="square-outline" />
+					</smoothly-picker-option>
+				</smoothly-picker>
+				<smoothly-input-select
+					initialPrompt="Select..."
+					ref={(element: HTMLSmoothlyInputSelectElement) => (this.selectElement = element)}>
+					<smoothly-item value="1">January</smoothly-item>
+					<smoothly-item value="2">February</smoothly-item>
+					<smoothly-item value="3">March</smoothly-item>
+					<smoothly-item value="4">April</smoothly-item>
+					<smoothly-item value="5">May</smoothly-item>
+					<smoothly-item value="6">June</smoothly-item>
+					<smoothly-item value="7">July</smoothly-item>
+					<smoothly-item value="8">August</smoothly-item>
+					<smoothly-item value="9">September</smoothly-item>
+					<smoothly-item value="10">October</smoothly-item>
+					<smoothly-item value="11">November</smoothly-item>
+					<smoothly-item value="12">December</smoothly-item>
+				</smoothly-input-select>
+				<smoothly-input-date-range
+					start={isoly.Date.now()}
+					end={isoly.Date.nextMonth(isoly.Date.now())}
+					min="2021-10-10"
+					max="2025-12-30"
+					showLabel={false}
+					style={{
+						"--border-radius": "4px",
+						"--padding": "0 0.75em",
+						"--input-width": "12ch",
+					}}
+				/>
+				<smoothly-input-date value="2021-10-28" max="2021-12-30" min="2021-10-10">
+					Date
+				</smoothly-input-date>
+			</smoothly-form>,
 		]
 	}
 }

--- a/src/components/input/file/index.tsx
+++ b/src/components/input/file/index.tsx
@@ -1,23 +1,31 @@
 import { Component, Event, EventEmitter, h, Host, Method, Prop, State } from "@stencil/core"
 import { Clearable } from "../Clearable"
+import { Input } from "../Input"
+import { Looks } from "../Looks"
 
 @Component({
 	tag: "smoothly-input-file",
 	styleUrl: "style.css",
 	scoped: true,
 })
-export class SmoothlyInputFile implements Clearable {
+export class SmoothlyInputFile implements Clearable, Input {
 	private transfer: DataTransfer = new DataTransfer()
 	private input?: HTMLInputElement
 	@State() dragging = false
 	@Prop() accept?: string
+	@Prop({ reflect: true, mutable: true }) looks: Looks = "plain"
 	@Prop({ reflect: true }) camera: "front" | "back"
 	@Prop({ reflect: true }) name: string
 	@Prop({ reflect: true }) showLabel = true
 	@Prop({ mutable: true }) value?: File
 	@Prop({ mutable: true, reflect: true }) placeholder: string | undefined
+	@Event() smoothlyInputLooks: EventEmitter<(looks: Looks) => void>
 	@Event() smoothlyInput: EventEmitter<Record<string, File>>
 	@Event() smoothlyChange: EventEmitter<Record<string, File>>
+
+	componentWillLoad() {
+		this.smoothlyInputLooks.emit(looks => (this.looks = looks))
+	}
 
 	@Method()
 	async clear(): Promise<void> {

--- a/src/components/input/file/style.css
+++ b/src/components/input/file/style.css
@@ -1,3 +1,5 @@
+@import "../looks.css";
+
 :host {
 	display: flex;
 	align-items: center;

--- a/src/components/input/file/style.css
+++ b/src/components/input/file/style.css
@@ -1,4 +1,4 @@
-@import "../looks.css";
+@import "../shared.css";
 
 :host {
 	display: flex;

--- a/src/components/input/index.tsx
+++ b/src/components/input/index.tsx
@@ -3,18 +3,21 @@ import { Currency, Language, Locale } from "isoly"
 import { Action, Converter, Direction, Formatter, get, Settings, State as TidilyState, StateEditor, Type } from "tidily"
 import { Changeable } from "./Changeable"
 import { Clearable } from "./Clearable"
+import { Input } from "./Input"
+import { Looks } from "./Looks"
 
 @Component({
 	tag: "smoothly-input",
 	styleUrl: "style.css",
 	scoped: true,
 })
-export class SmoothlyInput implements Changeable, Clearable {
+export class SmoothlyInput implements Changeable, Clearable, Input {
 	private inputElement: HTMLInputElement
 	/** On re-render the input will blur. This boolean is meant to keep track of if input should keep its focus. */
 	private keepFocusOnReRender = false
 	private lastValue: any
 	private state: Readonly<TidilyState> & Readonly<Settings>
+	@Prop({ reflect: true, mutable: true }) looks: Looks = "plain"
 	@Prop({ reflect: true }) name: string
 	@Prop({ mutable: true }) value: any
 	@Prop({ reflect: true }) type = "text"
@@ -29,6 +32,7 @@ export class SmoothlyInput implements Changeable, Clearable {
 	@Prop({ mutable: true, reflect: true }) readonly = false
 	@Prop({ reflect: true }) currency?: Currency
 	@State() initialValue?: any
+	@Event() smoothlyInputLooks: EventEmitter<(looks: Looks) => void>
 
 	@Prop({ mutable: true, reflect: true }) changed = false
 	private listener: { changed?: (parent: Changeable) => Promise<void> } = {}
@@ -96,6 +100,7 @@ export class SmoothlyInput implements Changeable, Clearable {
 			value,
 			selection: { start, end: start, direction: "none" },
 		})
+		this.smoothlyInputLooks.emit(looks => (this.looks = looks))
 	}
 	componentDidRender() {
 		if (this.keepFocusOnReRender) {

--- a/src/components/input/looks.css
+++ b/src/components/input/looks.css
@@ -1,0 +1,12 @@
+:host[looks="border"]::slotted(smoothly-picker-menu smoothly-input),
+:host[looks="border"] {
+	border: rgb(var(--smoothly-default-contrast)) solid 1px;
+}
+:host[looks="line"]::slotted(smoothly-picker-menu smoothly-input),
+:host[looks="line"] {
+	border-bottom: rgb(var(--smoothly-default-contrast)) solid 1px;
+}
+:host[looks="grid"]::slotted(smoothly-picker-menu smoothly-input),
+:host[looks="grid"] {
+	border: rgba(var(--smoothly-default-contrast), .5) solid .5px;
+}

--- a/src/components/input/select/index.tsx
+++ b/src/components/input/select/index.tsx
@@ -1,11 +1,15 @@
 import { Component, Element, Event, EventEmitter, h, Host, Listen, Method, Prop, State, Watch } from "@stencil/core"
+import { Input } from "../Input"
+import { Looks } from "../Looks"
 @Component({
 	tag: "smoothly-input-select",
 	styleUrl: "style.css",
 	scoped: true,
 })
-export class SmoothlyInputSelect {
+export class SmoothlyInputSelect implements Input {
 	@Element() element: HTMLSmoothlyInputSelectElement
+	@Prop() name: string
+	@Prop({ reflect: true, mutable: true }) looks: Looks = "plain"
 	@Prop() initialPrompt?: string
 	@State() opened = false
 	items: HTMLSmoothlyItemElement[] = []
@@ -14,7 +18,13 @@ export class SmoothlyInputSelect {
 	mainElement?: HTMLElement
 	@State() filter = ""
 	@Event() selected: EventEmitter<any>
+	@Event() smoothlyInput: EventEmitter<Record<number, any>>
 	aside?: HTMLElement
+	@Event() smoothlyInputLooks: EventEmitter<(looks: Looks) => void>
+
+	componentWillLoad() {
+		this.smoothlyInputLooks.emit(looks => (this.looks = looks))
+	}
 
 	@Method()
 	async reset() {
@@ -30,6 +40,7 @@ export class SmoothlyInputSelect {
 		if (old)
 			old.selected = false
 		this.selected.emit(value?.value)
+		this.smoothlyInput.emit({ [this.name]: value?.value })
 	}
 	@Watch("filter")
 	async onFilterChange(value: string) {

--- a/src/components/input/select/style.css
+++ b/src/components/input/select/style.css
@@ -3,7 +3,6 @@
 :host {
 	display: flex;
 	position: relative;
-	height: 100%;
 }
 :host > main,
 :host > main > * {

--- a/src/components/input/select/style.css
+++ b/src/components/input/select/style.css
@@ -1,4 +1,4 @@
-@import "../looks.css";
+@import "../shared.css";
 
 :host {
 	display: flex;

--- a/src/components/input/select/style.css
+++ b/src/components/input/select/style.css
@@ -1,4 +1,7 @@
+@import "../looks.css";
+
 :host {
+	display: flex;
 	position: relative;
 	height: 100%;
 }

--- a/src/components/input/shared.css
+++ b/src/components/input/shared.css
@@ -1,3 +1,6 @@
+:host {
+	box-sizing: border-box;
+}
 :host[looks="border"]::slotted(smoothly-picker-menu smoothly-input),
 :host[looks="border"] {
 	border: rgb(var(--smoothly-default-contrast)) solid 1px;

--- a/src/components/input/style.css
+++ b/src/components/input/style.css
@@ -1,3 +1,5 @@
+@import "./looks.css";
+
 :host {
 	display: flex;
 	align-items: center;

--- a/src/components/input/style.css
+++ b/src/components/input/style.css
@@ -1,4 +1,4 @@
-@import "./looks.css";
+@import "./shared.css";
 
 :host {
 	display: flex;

--- a/src/components/picker/index.tsx
+++ b/src/components/picker/index.tsx
@@ -1,6 +1,8 @@
 import { Component, Element, Event, EventEmitter, h, Host, Listen, Method, Prop, State, Watch } from "@stencil/core"
 import { Notice, Option } from "../../model"
 import { Clearable } from "../input/Clearable"
+import { Input } from "../input/Input"
+import { Looks } from "../input/Looks"
 import { Controls } from "./menu"
 
 @Component({
@@ -8,10 +10,11 @@ import { Controls } from "./menu"
 	styleUrl: "style.css",
 	scoped: true,
 })
-export class SmoothlyPicker implements Clearable {
+export class SmoothlyPicker implements Clearable, Input {
 	@Element() element: HTMLSmoothlyPickerElement
+	@Prop({ reflect: true, mutable: true }) looks: Looks = "plain"
 	@Prop({ reflect: true }) name: string
-	@Prop({ mutable: true, reflect: true }) open = false
+	@Prop({ reflect: true, mutable: true }) open = false
 	@Prop({ reflect: true }) mutable = false
 	@Prop({ reflect: true }) multiple = false
 	@Prop({ reflect: true }) readonly = false
@@ -21,7 +24,12 @@ export class SmoothlyPicker implements Clearable {
 	@Event() smoothlyPickerLoaded: EventEmitter<Controls>
 	@Event() smoothlyInput: EventEmitter<Record<string, any | any[]>> // multiple -> any[]
 	@Event() smoothlyChange: EventEmitter<Record<string, any | any[]>> // multiple -> any[]
+	@Event() smoothlyInputLooks: EventEmitter<(looks: Looks) => void>
 	private controls?: Controls
+
+	componentWillLoad() {
+		this.smoothlyInputLooks.emit(looks => (this.looks = looks))
+	}
 
 	@Watch("selected")
 	selectedChanged() {
@@ -38,6 +46,11 @@ export class SmoothlyPicker implements Clearable {
 	componentDidLoad() {
 		if (this.controls)
 			this.smoothlyPickerLoaded.emit(this.controls)
+	}
+	@Listen("smoothlyInputLooks")
+	smoothlyInputLooksHandler(event: CustomEvent<(looks: Looks) => void>) {
+		if (event.target != this.element)
+			event.stopPropagation()
 	}
 	@Listen("smoothlyPickerMenuLoaded")
 	menuLoadedHandler(event: CustomEvent<Controls>) {
@@ -87,6 +100,7 @@ export class SmoothlyPicker implements Clearable {
 					<smoothly-icon size="tiny" name={this.open ? "caret-down-outline" : "caret-forward-outline"} />
 				</button>
 				<smoothly-picker-menu
+					looks={this.looks}
 					onClick={e => e.stopPropagation()}
 					multiple={this.multiple}
 					mutable={this.mutable}

--- a/src/components/picker/menu/index.tsx
+++ b/src/components/picker/menu/index.tsx
@@ -1,5 +1,6 @@
 import { Component, Element, Event, EventEmitter, h, Host, Listen, Prop, State, Watch } from "@stencil/core"
 import { Notice, Option } from "../../../model"
+import { Looks } from "../../input/Looks"
 import { Slot } from "../slot-elements"
 
 function* chain<T>(...iterables: Iterable<T>[]): Iterable<T> {
@@ -30,6 +31,7 @@ export interface Controls {
 })
 export class SmoothlyPickerMenu {
 	@Element() element: HTMLSmoothlyPickerMenuElement
+	@Prop() looks: Looks
 	@Prop({ reflect: true }) multiple = false
 	@Prop({ reflect: true }) mutable = false
 	@Prop({ reflect: true }) readonly = false
@@ -80,7 +82,6 @@ export class SmoothlyPickerMenu {
 		for (const option of chain(this.options.values(), this.backend.values()))
 			option.element, option.set.readonly(this.readonly)
 	}
-
 	@Listen("smoothlyPickerOptionLoad")
 	optionLoadHandler(event: CustomEvent<Option.Load>) {
 		if (!this.listElement || !event.composedPath().includes(this.listElement)) {
@@ -189,6 +190,7 @@ export class SmoothlyPickerMenu {
 						ref={e => (this.searchElement = e)}
 						name="search"
 						value={this.search}
+						looks={this.looks}
 						onKeyDown={e => this.keyDownHandler(e)}
 						onSmoothlyInput={e => this.inputHandler(e)}
 						onSmoothlyChange={e => e.stopPropagation()}

--- a/src/components/picker/menu/style.css
+++ b/src/components/picker/menu/style.css
@@ -9,6 +9,7 @@
 	right: -1px;
 	background-color: rgb(var(--background-color));
 	padding: 0.5rem;
+	border: rgb(var(--smoothly-default-contrast)) solid 1px;
 }
 .list {
 	display: grid;

--- a/src/components/picker/style.css
+++ b/src/components/picker/style.css
@@ -1,3 +1,5 @@
+@import "../input/looks.css";
+
 :host {
 	display: flex;
 	position: relative;

--- a/src/components/picker/style.css
+++ b/src/components/picker/style.css
@@ -1,4 +1,4 @@
-@import "../input/looks.css";
+@import "../input/shared.css";
 
 :host {
 	display: flex;


### PR DESCRIPTION
* moved style applied to the forms input from the form to the inputs. The form informs the inputs which style to use via event to support nesting the inputs under the form element
* created an interface to enforce common smoothly input properties
* added smoothlyInput event to some inputs. kept old events for some backwards comparability. should they be removed?