### PR TITLE
get parameters in history if path is unchanged

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -51,7 +51,7 @@ export namespace Components {
         "baseUrl": string;
     }
     interface SmoothlyAppRoom {
-        "getContent": () => Promise<HTMLElement>;
+        "getContent": () => Promise<HTMLElement | undefined>;
         "icon"?: Icon;
         "label"?: string;
         "path": string | URLPattern;
@@ -227,6 +227,7 @@ export namespace Components {
         "min": Date;
         "name": string;
         "open": boolean;
+        "showLabel": boolean;
         "value"?: Date;
     }
     interface SmoothlyInputDateRange {
@@ -1359,6 +1360,7 @@ declare namespace LocalJSX {
         "onSmoothlyInputLooks"?: (event: SmoothlyInputDateCustomEvent<(looks: Looks) => void>) => void;
         "onValueChanged"?: (event: SmoothlyInputDateCustomEvent<Date>) => void;
         "open"?: boolean;
+        "showLabel"?: boolean;
         "value"?: Date;
     }
     interface SmoothlyInputDateRange {

--- a/src/components/app/index.tsx
+++ b/src/components/app/index.tsx
@@ -32,11 +32,13 @@ export class SmoothlyApp {
 			const path = value.element.path.toString()
 			this.rooms[path] = value
 
-			history.pushState({ smoothlyPath: path }, value.element.label ?? "", path)
-
-			if (this.mainElement) {
+			const location = new URL(window.location.pathname == path ? window.location.href : window.location.origin)
+			location.pathname = path
+			history.pushState({ smoothlyPath: path }, "", location.href)
+			const content = await value.element.getContent()
+			if (this.mainElement && content) {
 				this.mainElement.innerHTML = ""
-				this.mainElement.appendChild(await value.element.getContent())
+				this.mainElement.appendChild(content)
 			}
 		}
 	}
@@ -53,9 +55,10 @@ export class SmoothlyApp {
 		if (typeof event.state.smoothlyPath != "string" && event.state.smoothlyPath !== this.selected?.element.path) {
 			this.selected = this.rooms[event.state.smoothlyPath]
 		}
-		if (this.mainElement) {
+		const content = await this.rooms[event.state.smoothlyPath].element.getContent()
+		if (this.mainElement && content) {
 			this.mainElement.innerHTML = ""
-			this.mainElement.appendChild(await this.rooms[event.state.smoothlyPath].element.getContent())
+			this.mainElement.appendChild(content)
 		}
 	}
 	@Listen("smoothlyRoomSelected")

--- a/src/components/app/room/index.tsx
+++ b/src/components/app/room/index.tsx
@@ -1,4 +1,4 @@
-import { Component, Event, EventEmitter, h, Method, Prop } from "@stencil/core"
+import { Component, Event, EventEmitter, h, Host, Method, Prop } from "@stencil/core"
 import "urlpattern-polyfill"
 import { Icon } from "../../icon/Icon"
 
@@ -15,7 +15,7 @@ export class SmoothlyAppRoom {
 	@Prop({ reflect: true, mutable: true }) selected?: boolean
 	@Event() smoothlyRoomSelected: EventEmitter
 	@Event() smoothlyRoomLoaded: EventEmitter
-	contentElement: HTMLElement
+	private contentElement?: HTMLElement
 
 	componentWillLoad() {
 		if ((typeof this.path == "string" ? new URLPattern({ pathname: this.path }) : this.path).test(window.location))
@@ -25,27 +25,29 @@ export class SmoothlyAppRoom {
 	}
 
 	@Method()
-	async getContent() {
+	async getContent(): Promise<HTMLElement | undefined> {
 		return this.contentElement
 	}
 
 	render() {
-		return [
-			<li>
-				<a
-					href={typeof this.path == "string" ? this.path : this.path.pathname}
-					onClick={(event: PointerEvent) => {
-						if (!event.metaKey && !event.ctrlKey && event.which != 2 && event.button != 1) {
-							event.preventDefault()
-							this.smoothlyRoomSelected.emit()
-						}
-					}}>
-					{this.icon ? <smoothly-icon name={this.icon} toolTip={this.label}></smoothly-icon> : this.label}
-				</a>
-			</li>,
-			<main ref={(e: HTMLElement) => (this.contentElement = e)}>
-				<slot></slot>
-			</main>,
-		]
+		return (
+			<Host>
+				<li>
+					<a
+						href={typeof this.path == "string" ? this.path : this.path.pathname}
+						onClick={(event: PointerEvent) => {
+							if (!event.metaKey && !event.ctrlKey && event.which != 2 && event.button != 1) {
+								event.preventDefault()
+								this.smoothlyRoomSelected.emit()
+							}
+						}}>
+						{this.icon ? <smoothly-icon name={this.icon} toolTip={this.label}></smoothly-icon> : this.label}
+					</a>
+				</li>
+				<main ref={e => (this.contentElement = e)}>
+					<slot></slot>
+				</main>
+			</Host>
+		)
 	}
 }


### PR DESCRIPTION
* removed undefined cast in `app-room`
* navigation to a room with get parameters no longer throws the get parameters to the void.