### PR TITLE
fixed spinner for form

### DIFF
--- a/src/components/form/style.css
+++ b/src/components/form/style.css
@@ -1,5 +1,6 @@
 smoothly-form {
 	display: block;
+	position: relative;
 	--background-color: var(--smoothly-color-shade);
 	--text-color: var(--smoothly-color-contrast)
 }

--- a/src/components/input/demo/index.tsx
+++ b/src/components/input/demo/index.tsx
@@ -415,6 +415,7 @@ export class SmoothlyInputDemo {
 					<smoothly-icon name="checkmark-circle" fill="solid" size="medium" />
 				</smoothly-submit>
 			</smoothly-form>,
+			<h4>Form with spinner showcase</h4>,
 			<smoothly-form looks="line" processing={true} onSmoothlyFormSubmit={e => console.log("form input", e.detail)}>
 				<smoothly-input name="text">Input</smoothly-input>
 				<smoothly-input-file camera="back" placeholder="Capture a photo" name="image">

--- a/src/components/input/demo/index.tsx
+++ b/src/components/input/demo/index.tsx
@@ -415,6 +415,65 @@ export class SmoothlyInputDemo {
 					<smoothly-icon name="checkmark-circle" fill="solid" size="medium" />
 				</smoothly-submit>
 			</smoothly-form>,
+			<smoothly-form looks="line" processing={true} onSmoothlyFormSubmit={e => console.log("form input", e.detail)}>
+				<smoothly-input name="text">Input</smoothly-input>
+				<smoothly-input-file camera="back" placeholder="Capture a photo" name="image">
+					<span slot="label">Testing camera photo</span>
+					<smoothly-icon slot="button" name="camera-outline" />
+				</smoothly-input-file>
+				<smoothly-picker name="picker">
+					<span slot="label">Shape</span>
+					<span slot="search">Search</span>
+					<smoothly-picker-option value={"circle"}>
+						<span slot="label">Circle</span>
+						<smoothly-icon size="tiny" name="ellipse-outline" />
+					</smoothly-picker-option>
+					<smoothly-picker-option value={"cube"}>
+						<span slot={"label"}>Cube</span>
+						<smoothly-icon size="tiny" name="cube-outline" />
+					</smoothly-picker-option>
+					<smoothly-picker-option value={"square"} selected>
+						<span slot={"label"}>Square</span>
+						<smoothly-icon size="tiny" name="square-outline" />
+					</smoothly-picker-option>
+				</smoothly-picker>
+				<smoothly-input-select
+					name="select"
+					initialPrompt="Select..."
+					ref={(element: HTMLSmoothlyInputSelectElement) => (this.selectElement = element)}>
+					<smoothly-item value="1">January</smoothly-item>
+					<smoothly-item value="2">February</smoothly-item>
+					<smoothly-item value="3">March</smoothly-item>
+					<smoothly-item value="4">April</smoothly-item>
+					<smoothly-item value="5">May</smoothly-item>
+					<smoothly-item value="6">June</smoothly-item>
+					<smoothly-item value="7">July</smoothly-item>
+					<smoothly-item value="8">August</smoothly-item>
+					<smoothly-item value="9">September</smoothly-item>
+					<smoothly-item value="10">October</smoothly-item>
+					<smoothly-item value="11">November</smoothly-item>
+					<smoothly-item value="12">December</smoothly-item>
+				</smoothly-input-select>
+				<smoothly-input-date-range
+					name="date-range"
+					start={isoly.Date.now()}
+					end={isoly.Date.nextMonth(isoly.Date.now())}
+					min="2021-10-10"
+					max="2025-12-30"
+					showLabel={false}
+					style={{
+						"--border-radius": "4px",
+						"--padding": "0 0.75em",
+						"--input-width": "12ch",
+					}}
+				/>
+				<smoothly-input-date name="date" value="2021-10-28" max="2021-12-30" min="2021-10-10">
+					Date
+				</smoothly-input-date>
+				<smoothly-submit slot="submit" color="success" fill="solid" size="icon">
+					<smoothly-icon name="checkmark-circle" fill="solid" size="medium" />
+				</smoothly-submit>
+			</smoothly-form>,
 		]
 	}
 }

--- a/src/components/input/file/index.tsx
+++ b/src/components/input/file/index.tsx
@@ -43,7 +43,11 @@ export class SmoothlyInputFile implements Clearable, Input {
 					<slot name={"label"} />
 				</label>
 				<div class="input">
-					<smoothly-button size="flexible" onClick={event => (event.stopPropagation(), this.input?.click())}>
+					<smoothly-button
+						color={this.color}
+						fill={"clear"}
+						size="flexible"
+						onClick={event => (event.stopPropagation(), this.input?.click())}>
 						<slot name={"button"} />
 					</smoothly-button>
 					<span onClick={event => (event.stopPropagation(), this.input?.click())}>

--- a/src/components/spinner/style.scss
+++ b/src/components/spinner/style.scss
@@ -9,6 +9,7 @@ $time: 1.4s;
 	display: block;
 	stroke: rgb(var(--spinner-color, var(--smoothly-primary-tint)));
 	position: absolute;
+	z-index: 4;
 	inset: 0;
 	width: 100%;
 	height: 100%;


### PR DESCRIPTION
* form was missing `position: relative` causing spinner to potentially cover the entire screen.
* spinner was missing proper `z-index` causing parts of some inputs to be in front of the spinner. was set to 4 to still be bellow burger menu.
* added demo to showcase the spinner in use on a form.
* a fix for the file inputs icon background color matching the inputs background color.