### PR TITLE
Cross browser redirect

### DIFF
--- a/src/model/redirect.ts
+++ b/src/model/redirect.ts
@@ -1,5 +1,7 @@
 export function redirect(path: string) {
-	window.history.pushState({ smoothlyPath: path }, "", new URL(window.location.href).origin + path)
-	window.history.back()
-	window.history.forward()
+	const state = { smoothlyPath: path }
+	const url = new URL(window.location.href)
+	url.pathname = path
+	window.history.pushState(state, "", path)
+	window.dispatchEvent(new PopStateEvent("popstate", { state }))
 }

--- a/src/model/redirect.ts
+++ b/src/model/redirect.ts
@@ -1,4 +1,4 @@
-export function redirect(path: string) {
+export function redirect(path: string): void {
 	const state = { smoothlyPath: path }
 	const url = new URL(window.location.href)
 	url.pathname = path


### PR DESCRIPTION
instead of moving back and forth to trigger the popstate event. the popstate is dispatched manually. This method actually works Chromium and better than the previous solution on Firefox.