### PR TITLE
Table chevron squish

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -78,7 +78,7 @@ export namespace Components {
         "link"?: string;
         "shape"?: "rounded";
         "size": "small" | "large" | "icon" | "flexible";
-        "type": "link" | "button" | "submit" | "reset";
+        "type": "link" | "button";
     }
     interface SmoothlyButtonDemo {
     }
@@ -1208,7 +1208,7 @@ declare namespace LocalJSX {
         "link"?: string;
         "shape"?: "rounded";
         "size"?: "small" | "large" | "icon" | "flexible";
-        "type"?: "link" | "button" | "submit" | "reset";
+        "type"?: "link" | "button";
     }
     interface SmoothlyButtonDemo {
     }

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -78,7 +78,7 @@ export namespace Components {
         "link"?: string;
         "shape"?: "rounded";
         "size": "small" | "large" | "icon" | "flexible";
-        "type": "link" | "button";
+        "type": "link" | "button" | "submit" | "reset";
     }
     interface SmoothlyButtonDemo {
     }
@@ -1208,7 +1208,7 @@ declare namespace LocalJSX {
         "link"?: string;
         "shape"?: "rounded";
         "size"?: "small" | "large" | "icon" | "flexible";
-        "type"?: "link" | "button";
+        "type"?: "link" | "button" | "submit" | "reset";
     }
     interface SmoothlyButtonDemo {
     }

--- a/src/components/table/cell/style.css
+++ b/src/components/table/cell/style.css
@@ -24,8 +24,10 @@ smoothly-table-expandable-row[open] > div :host:last-of-type smoothly-icon {
 	transform: rotate(90deg);
 }
 :host > div {
-	display: flex;
+	display: grid;
+	grid-auto-flow: column;
 	align-items: center;
+	justify-content: space-between;
 }
 :host > div > div {
 	width: 100%;

--- a/src/components/table/demo/index.tsx
+++ b/src/components/table/demo/index.tsx
@@ -268,6 +268,23 @@ export class TableDemo {
 					<smoothly-table-cell>ddd</smoothly-table-cell>
 				</smoothly-table-row>
 			</smoothly-table>,
+			<smoothly-table>
+				<smoothly-table-row>
+					<smoothly-table-header>First name</smoothly-table-header>
+					<smoothly-table-header>Last name</smoothly-table-header>
+					<smoothly-table-header style={{ width: "1px" }}>
+						<smoothly-icon name="alert-outline" />
+					</smoothly-table-header>
+				</smoothly-table-row>
+				<smoothly-table-expandable-row>
+					<smoothly-table-cell>Jessie</smoothly-table-cell>
+					<smoothly-table-cell>Doe</smoothly-table-cell>
+					<smoothly-table-cell></smoothly-table-cell>
+					<div slot="detail">
+						<p>This is Jessie</p>
+					</div>
+				</smoothly-table-expandable-row>
+			</smoothly-table>,
 		]
 	}
 }

--- a/src/components/table/expandable/cell/style.css
+++ b/src/components/table/expandable/cell/style.css
@@ -31,7 +31,10 @@
 	transform: rotate(90deg);
 }
 aside {
-	display: flex;
+	display: grid;
+	grid-auto-flow: column;
+	justify-content: start;
+	align-items: center;
 }
 .hide {
 	display: none;


### PR DESCRIPTION
chevron got squished if a thin cell in the header was used:
![image](https://github.com/utily/smoothly/assets/25643315/349fc42c-8687-420d-86a4-6af7af13802a)

new CSS fixes this
![image](https://github.com/utily/smoothly/assets/25643315/30618023-1af6-48ce-8101-cdd839f91e3d)
