### PR TITLE
download fix, redirect fix, example fix

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -10,6 +10,7 @@ import { address } from "./components/address-display";
 import { address as address1 } from "./components/address-display/index";
 import { Color, Data as Data1, Fill, Message, Notice, Option, Trigger } from "./model";
 import { Icon } from "./components/icon/Icon";
+import { Button } from "./components/Button";
 import { CountryCode, Currency, Date, DateRange, DateTime, isoly } from "isoly";
 import { Direction, Type } from "tidily";
 import { Criteria } from "selectively";
@@ -72,13 +73,12 @@ export namespace Components {
     interface SmoothlyButton {
         "color"?: Color;
         "disabled": boolean;
-        "download"?: boolean;
         "expand"?: "block" | "full";
         "fill"?: Fill;
         "link"?: string;
         "shape"?: "rounded";
         "size": "small" | "large" | "icon" | "flexible";
-        "type": "link" | "button";
+        "type": Button.Properties["type"];
     }
     interface SmoothlyButtonDemo {
     }
@@ -1202,13 +1202,12 @@ declare namespace LocalJSX {
     interface SmoothlyButton {
         "color"?: Color;
         "disabled"?: boolean;
-        "download"?: boolean;
         "expand"?: "block" | "full";
         "fill"?: Fill;
         "link"?: string;
         "shape"?: "rounded";
         "size"?: "small" | "large" | "icon" | "flexible";
-        "type"?: "link" | "button";
+        "type"?: Button.Properties["type"];
     }
     interface SmoothlyButtonDemo {
     }

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -30,11 +30,10 @@ function convert(path: string): string {
 		result = new URL(path).pathname
 	else {
 		const url = new URL(path, window.location.origin)
-		if (!url.href.startsWith(window.location.href)) {
+		if (!url.href.startsWith(window.location.href))
 			result = url.pathname
-		} else {
+		else
 			result = new URL(window.location.href + url.pathname).pathname
-		}
 	}
 	return result
 }

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,16 +1,17 @@
 import { FunctionalComponent, h } from "@stencil/core"
+import { redirect } from "../model"
 
-export const Button: FunctionalComponent<Button.Properties> = ({ disabled, type, link, download }) => {
+export const Button: FunctionalComponent<Button.Properties> = ({ disabled, type, link }) => {
 	return disabled && (link || type == "link") ? (
 		<slot></slot>
-	) : link ? (
-		<a href={link} target="_blank" download={download}>
+	) : type == "link" ? (
+		<a href={link} onClick={!link || !local(link) ? undefined : e => (e.preventDefault(), redirect(convert(link)))}>
 			<slot name="start"></slot>
 			<slot></slot>
 			<slot name="end"></slot>
 		</a>
-	) : type == "link" ? (
-		<a href={link}>
+	) : type == "download" ? (
+		<a href={link} target="_blank" download>
 			<slot name="start"></slot>
 			<slot></slot>
 			<slot name="end"></slot>
@@ -23,11 +24,32 @@ export const Button: FunctionalComponent<Button.Properties> = ({ disabled, type,
 		</button>
 	)
 }
+function convert(path: string): string {
+	let result: ReturnType<typeof convert>
+	if (path.startsWith(window.location.origin))
+		result = new URL(path).pathname
+	else {
+		const url = new URL(path, window.location.origin)
+		console.log(url)
+		if (!url.href.startsWith(window.location.href)) {
+			result = url.pathname
+			console.log("absolute path, url", url)
+			console.log("absolute path, result", result)
+		} else {
+			result = new URL(window.location.href + url.pathname).pathname
+			console.log("relative path?", url, result)
+		}
+	}
+	return result
+}
+
+function local(path: string): boolean {
+	return new URL(path, window.location.origin).origin == window.location.origin
+}
 export namespace Button {
 	export interface Properties {
 		disabled: boolean
-		type: "link" | "button"
+		type: "link" | "button" | "download"
 		link?: string
-		download?: boolean
 	}
 }

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -30,14 +30,10 @@ function convert(path: string): string {
 		result = new URL(path).pathname
 	else {
 		const url = new URL(path, window.location.origin)
-		console.log(url)
 		if (!url.href.startsWith(window.location.href)) {
 			result = url.pathname
-			console.log("absolute path, url", url)
-			console.log("absolute path, result", result)
 		} else {
 			result = new URL(window.location.href + url.pathname).pathname
-			console.log("relative path?", url, result)
 		}
 	}
 	return result

--- a/src/components/app-demo/index.tsx
+++ b/src/components/app-demo/index.tsx
@@ -1,6 +1,4 @@
 import { Component, h, Prop } from "@stencil/core"
-import { redirect } from "../../model"
-
 @Component({
 	tag: "smoothly-app-demo",
 })
@@ -23,7 +21,7 @@ export class SmoothlyAppDemo {
 							fill="solid"
 							color="danger"
 							link="https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf"
-							download={true}>
+							type="download">
 							download
 						</smoothly-button>
 						<smoothly-button fill="solid" color="danger" onClick={() => alert("clicked")}>
@@ -60,9 +58,15 @@ export class SmoothlyAppDemo {
 				</smoothly-app-room>
 				<smoothly-app-room path="/old" label="Old" to="select"></smoothly-app-room>
 				<smoothly-app-room path="/redirect" label="Redirect">
-					<smoothly-button onClick={() => redirect("/input")}>To input</smoothly-button>
-					<smoothly-button onClick={() => redirect("/button")}>To button</smoothly-button>
-					<smoothly-button onClick={() => redirect("/hidden")}>To hidden</smoothly-button>
+					<smoothly-button type="link" link="/input">
+						To input
+					</smoothly-button>
+					<smoothly-button type="link" link="../button">
+						To button
+					</smoothly-button>
+					<smoothly-button type="link" link={new URL("/hidden", window.location.origin).href}>
+						To hidden
+					</smoothly-button>
 				</smoothly-app-room>
 				<smoothly-app-room path="/hidden">
 					<p>hello world!</p>

--- a/src/components/button/index.tsx
+++ b/src/components/button/index.tsx
@@ -12,15 +12,14 @@ export class SmoothlyButton {
 	@Prop({ reflect: true }) expand?: "block" | "full"
 	@Prop({ reflect: true }) fill?: Fill
 	@Prop({ reflect: true }) disabled = false
-	@Prop({ reflect: true }) type: "link" | "button" = "button"
+	@Prop({ reflect: true }) type: Button.Properties["type"] = "button"
 	@Prop({ reflect: true }) size: "small" | "large" | "icon" | "flexible"
 	@Prop({ reflect: true }) shape?: "rounded"
 	@Prop() link?: string
-	@Prop() download?: boolean
 
 	render() {
 		return (
-			<Button disabled={this.disabled} type={this.type} link={this.link} download={this.download}>
+			<Button disabled={this.disabled} type={this.type} link={this.link}>
 				<slot />
 			</Button>
 		)

--- a/src/components/button/style.css
+++ b/src/components/button/style.css
@@ -25,6 +25,8 @@ button{
 	cursor: pointer;
 	display: inline-flex;
 	gap: 0.5rem;
+}
+button {
 	justify-content: center;
 	height: 100%;
 	width: 100%;

--- a/src/components/button/style.css
+++ b/src/components/button/style.css
@@ -25,8 +25,6 @@ button{
 	cursor: pointer;
 	display: inline-flex;
 	gap: 0.5rem;
-}
-button {
 	justify-content: center;
 	height: 100%;
 	width: 100%;


### PR DESCRIPTION
breaking changes on button.

- using button for a download now requires type="download" and a link to the download
- fixed the demo for download to reflect changes
- fix redirect so that it now accepts a local full link, local absolute link, or a local relative link

