### PR TITLE
fix: cursor pointer on button padding

### DIFF
--- a/src/components/button/style.css
+++ b/src/components/button/style.css
@@ -7,6 +7,7 @@
 	border-radius: 0.5rem;
 	border: solid 1px;
 	transition: background 150ms ease-in-out;
+	cursor: pointer;
 }
 :host([type=link]){
 	display: inline;


### PR DESCRIPTION
if padding was given to the smoothly-button element the padding did not have cursor:pointer. only when the mouse hovered the inner HTML button element the cursor turned to pointer.