### PR TITLE
fix: required picker option

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -312,6 +312,7 @@ export namespace Components {
     interface SmoothlyPickerOption {
         "clickHandler": () => Promise<void>;
         "position": number;
+        "required": boolean;
         "search": string[];
         "selected": boolean;
         "value": any;
@@ -1487,6 +1488,7 @@ declare namespace LocalJSX {
         "onSmoothlyPickerOptionLoad"?: (event: SmoothlyPickerOptionCustomEvent<Option.Load>) => void;
         "onSmoothlyPickerOptionLoaded"?: (event: SmoothlyPickerOptionCustomEvent<Option>) => void;
         "position"?: number;
+        "required"?: boolean;
         "search"?: string[];
         "selected"?: boolean;
         "value"?: any;

--- a/src/components/picker/demo/index.tsx
+++ b/src/components/picker/demo/index.tsx
@@ -145,10 +145,10 @@ export class SmoothlyPickerDemo {
 						<smoothly-picker-option value={"fish"}>Fish</smoothly-picker-option>
 					</smoothly-picker>
 				</smoothly-form>
-				<smoothly-picker looks="border" name="icon">
+				<smoothly-picker looks="border" name="icon" multiple>
 					<span slot="label">Icon</span>
 					<span slot="search">Search</span>
-					<smoothly-picker-option value={"circle"}>
+					<smoothly-picker-option value={"circle"} required>
 						<span slot="label">Circle</span>
 						<smoothly-icon size="tiny" name="ellipse-outline" />
 					</smoothly-picker-option>

--- a/src/components/picker/option/index.tsx
+++ b/src/components/picker/option/index.tsx
@@ -12,6 +12,7 @@ export class SmoothlyPickerOption {
 	@Prop({ mutable: true }) value: any
 	@Prop({ mutable: true }) search: string[] = []
 	@Prop({ reflect: true }) position = -1
+	@Prop({ reflect: true }) required = false
 	@State() readonly = false
 	@State() slotted: Node[] = []
 	@Event() smoothlyPickerOptionLoad: EventEmitter<Option.Load>
@@ -23,6 +24,7 @@ export class SmoothlyPickerOption {
 			element: this.element,
 			selected: this.selected,
 			readonly: this.readonly,
+			required: this.required,
 			visible: this.visible,
 			search: this.search,
 			value: this.value,
@@ -49,6 +51,8 @@ export class SmoothlyPickerOption {
 	}
 
 	componentWillLoad() {
+		if (this.required)
+			this.selected = true
 		this.smoothlyPickerOptionLoad.emit((({ slotted, ...option }) => option)(this.option))
 	}
 	componentDidLoad() {
@@ -60,7 +64,7 @@ export class SmoothlyPickerOption {
 	}
 	@Method()
 	async clickHandler() {
-		if (!this.readonly)
+		if (!this.readonly && !this.required)
 			this.selected = !this.selected
 	}
 

--- a/src/components/picker/option/style.css
+++ b/src/components/picker/option/style.css
@@ -22,6 +22,9 @@
 	column-gap: 1rem;
 	justify-content: space-between;
 }
+:host([required]) > * {
+	cursor: default;
+}
 :host([required]) button {
 	opacity: 0.65;
 }

--- a/src/components/picker/option/style.css
+++ b/src/components/picker/option/style.css
@@ -22,3 +22,6 @@
 	column-gap: 1rem;
 	justify-content: space-between;
 }
+:host([required]) button {
+	opacity: 0.65;
+}

--- a/src/model/Option.ts
+++ b/src/model/Option.ts
@@ -2,6 +2,7 @@ export interface Option {
 	element: HTMLSmoothlyPickerOptionElement
 	selected: boolean
 	readonly: boolean
+	required: boolean
 	visible: boolean
 	search: string[]
 	value: any


### PR DESCRIPTION
Picker option can now be set to be required. 
This is meant to be used in multiple mode only. 
If an option is required its opacity is slightly dropped.
![image](https://github.com/utily/smoothly/assets/25643315/f0861d5f-aa74-4ce0-b121-4d3c3c2acf12)
