### PR TITLE
Picker event spam

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -305,6 +305,7 @@ export namespace Components {
         "looks": Looks;
         "multiple": boolean;
         "mutable": boolean;
+        "name"?: string;
         "open": boolean;
         "readonly": boolean;
         "validator"?: (value: string) => boolean | { result: boolean; notice: Notice };
@@ -1507,8 +1508,9 @@ declare namespace LocalJSX {
         "looks"?: Looks;
         "multiple"?: boolean;
         "mutable"?: boolean;
+        "name"?: string;
         "onNotice"?: (event: SmoothlyPickerMenuCustomEvent<Notice>) => void;
-        "onSmoothlyPickerMenuLoaded"?: (event: SmoothlyPickerMenuCustomEvent<Controls>) => void;
+        "onSmoothlyPickerMenuLoaded"?: (event: SmoothlyPickerMenuCustomEvent<Controls & { synced: () => boolean }>) => void;
         "open"?: boolean;
         "readonly"?: boolean;
         "validator"?: (value: string) => boolean | { result: boolean; notice: Notice };

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -305,7 +305,6 @@ export namespace Components {
         "looks": Looks;
         "multiple": boolean;
         "mutable": boolean;
-        "name"?: string;
         "open": boolean;
         "readonly": boolean;
         "validator"?: (value: string) => boolean | { result: boolean; notice: Notice };
@@ -1508,7 +1507,6 @@ declare namespace LocalJSX {
         "looks"?: Looks;
         "multiple"?: boolean;
         "mutable"?: boolean;
-        "name"?: string;
         "onNotice"?: (event: SmoothlyPickerMenuCustomEvent<Notice>) => void;
         "onSmoothlyPickerMenuLoaded"?: (event: SmoothlyPickerMenuCustomEvent<Controls & { synced: () => boolean }>) => void;
         "open"?: boolean;

--- a/src/components/picker/demo/index.tsx
+++ b/src/components/picker/demo/index.tsx
@@ -70,6 +70,7 @@ export class SmoothlyPickerDemo {
 						key={Array.from({ length: this.counter }).toString()}
 						name="counter"
 						multiple
+						mutable
 						onSmoothlyInput={e => console.log("demo counter input", e.detail)}>
 						{Array.from({ length: this.counter }).map((_, index) => (
 							<smoothly-picker-option key={index.toString()} value={index} selected={index < this.counter - 1}>

--- a/src/components/picker/demo/index.tsx
+++ b/src/components/picker/demo/index.tsx
@@ -157,7 +157,7 @@ export class SmoothlyPickerDemo {
 							<smoothly-icon size="tiny" name="square-outline" />
 						</smoothly-picker-option>
 					</smoothly-picker>
-					<smoothly-picker multiple readonly onSmoothlyInput={e => console.log("demo picker animals input", e.detail)}>
+					<smoothly-picker multiple readonly name="animals">
 						<span slot="label">Animals</span>
 						<span slot="search">Search</span>
 						<smoothly-picker-option selected value={"cat"}>

--- a/src/components/picker/demo/index.tsx
+++ b/src/components/picker/demo/index.tsx
@@ -73,7 +73,7 @@ export class SmoothlyPickerDemo {
 						mutable
 						onSmoothlyInput={e => console.log("demo counter input", e.detail)}>
 						{Array.from({ length: this.counter }).map((_, index) => (
-							<smoothly-picker-option key={index.toString()} value={index} selected={index < this.counter - 1}>
+							<smoothly-picker-option value={index} selected={index < this.counter - 1}>
 								{index}
 							</smoothly-picker-option>
 						))}

--- a/src/components/picker/demo/index.tsx
+++ b/src/components/picker/demo/index.tsx
@@ -219,7 +219,6 @@ export class SmoothlyPickerDemo {
 						<smoothly-icon size="tiny" name="fast-food-outline" />
 					</smoothly-picker-option>
 				</smoothly-picker>
-				<smoothly-picker></smoothly-picker>
 			</Host>
 		)
 	}

--- a/src/components/picker/demo/index.tsx
+++ b/src/components/picker/demo/index.tsx
@@ -157,11 +157,7 @@ export class SmoothlyPickerDemo {
 							<smoothly-icon size="tiny" name="square-outline" />
 						</smoothly-picker-option>
 					</smoothly-picker>
-					<smoothly-picker
-						multiple
-						readonly
-						name="animals"
-						onSmoothlyInput={e => console.log("demo picker animals input", e.detail)}>
+					<smoothly-picker multiple readonly onSmoothlyInput={e => console.log("demo picker animals input", e.detail)}>
 						<span slot="label">Animals</span>
 						<span slot="search">Search</span>
 						<smoothly-picker-option selected value={"cat"}>

--- a/src/components/picker/demo/index.tsx
+++ b/src/components/picker/demo/index.tsx
@@ -18,6 +18,7 @@ export class SmoothlyPickerDemo {
 		"jessie@rocket.com": "jessie doe",
 		"james@rocket.com": "james doe",
 	}
+	@State() counter = 3
 	@State() data = {
 		message: "hello world",
 		emails: ["jessie@rocket.com", "james@rocket.com"],
@@ -61,6 +62,26 @@ export class SmoothlyPickerDemo {
 	render() {
 		return (
 			<Host>
+				<div>
+					<smoothly-button onClick={() => (this.counter += 1)}>Add one</smoothly-button>
+					<smoothly-button onClick={() => (this.counter -= 1)}>Remove one</smoothly-button>
+					<smoothly-picker
+						class={"counter"}
+						key={Array.from({ length: this.counter }).toString()}
+						name="counter"
+						multiple
+						onSmoothlyInput={e => console.log("demo counter input", e.detail)}>
+						{Array.from({ length: this.counter }).map((_, index) => (
+							<smoothly-picker-option key={index.toString()} value={index} selected={index < this.counter - 1}>
+								{index}
+							</smoothly-picker-option>
+						))}
+						<span slot="search">Search</span>
+						<button slot="child" class={"counter-button"}>
+							<smoothly-icon name={"add-outline"} />
+						</button>
+					</smoothly-picker>
+				</div>
 				<smoothly-button onClick={() => this.clickHandler()}>
 					{!this.change ? "start edit" : "end edit"}
 				</smoothly-button>
@@ -135,7 +156,11 @@ export class SmoothlyPickerDemo {
 							<smoothly-icon size="tiny" name="square-outline" />
 						</smoothly-picker-option>
 					</smoothly-picker>
-					<smoothly-picker multiple readonly name="animals">
+					<smoothly-picker
+						multiple
+						readonly
+						name="animals"
+						onSmoothlyInput={e => console.log("demo picker animals input", e.detail)}>
 						<span slot="label">Animals</span>
 						<span slot="search">Search</span>
 						<smoothly-picker-option selected value={"cat"}>
@@ -193,6 +218,7 @@ export class SmoothlyPickerDemo {
 						<smoothly-icon size="tiny" name="fast-food-outline" />
 					</smoothly-picker-option>
 				</smoothly-picker>
+				<smoothly-picker></smoothly-picker>
 			</Host>
 		)
 	}

--- a/src/components/picker/demo/style.css
+++ b/src/components/picker/demo/style.css
@@ -2,6 +2,28 @@
 	display: flex;
 	flex-direction: column;
 }
-smoothly-form {
+:host smoothly-form {
 	max-width: 50rem;
+}
+:host .counter {
+	position: relative;
+	width: 3rem;
+	height: 3rem;
+}
+.picker {
+	position: relative;
+}
+:host .counter-button {
+	position: absolute;
+	top: 0;
+	left: 0;
+	padding: 0;
+	margin: 0;
+	height: 3rem;
+	width: 3rem;
+	background-color: inherit;
+	border: none;
+	display: flex;
+	justify-content: center;
+	align-items: center;
 }

--- a/src/components/picker/demo/style.css
+++ b/src/components/picker/demo/style.css
@@ -10,9 +10,6 @@
 	width: 3rem;
 	height: 3rem;
 }
-.picker {
-	position: relative;
-}
 :host .counter-button {
 	position: absolute;
 	top: 0;

--- a/src/components/picker/index.tsx
+++ b/src/components/picker/index.tsx
@@ -103,7 +103,6 @@ export class SmoothlyPicker implements Clearable, Input {
 				</button>
 				<slot name="child" />
 				<smoothly-picker-menu
-					name={this.name}
 					open={this.open}
 					looks={this.looks}
 					onClick={e => e.stopPropagation()}

--- a/src/components/picker/menu/index.tsx
+++ b/src/components/picker/menu/index.tsx
@@ -54,7 +54,6 @@ export class SmoothlyPickerMenu {
 	private searchElement?: HTMLElement
 	private loading = true
 	private synced = false
-	@Prop() name?: string
 
 	componentWillLoad() {
 		if (!Observers.has(this.element)) {

--- a/src/components/picker/menu/index.tsx
+++ b/src/components/picker/menu/index.tsx
@@ -52,7 +52,7 @@ export class SmoothlyPickerMenu {
 	private memory?: { backend: SmoothlyPickerMenu["backend"]; options: SmoothlyPickerMenu["options"] }
 	private listElement?: HTMLElement
 	private searchElement?: HTMLElement
-	private loading = true
+	// private loading = true
 	private synced = false
 
 	componentWillLoad() {
@@ -71,17 +71,12 @@ export class SmoothlyPickerMenu {
 		}
 	}
 	sync() {
-		if (this.synced || this.backend.size != this.options.size)
+		if (this.backend.size != this.options.size)
 			this.synced = false
-		else {
+		else
 			this.synced = true
-			if (this.loading) {
-				this.loading = false
-				this.didLoad()
-			}
-		}
 	}
-	didLoad() {
+	componentDidLoad() {
 		this.smoothlyPickerMenuLoaded.emit({
 			remember: () => {
 				this.memory = {

--- a/src/components/picker/menu/index.tsx
+++ b/src/components/picker/menu/index.tsx
@@ -52,7 +52,6 @@ export class SmoothlyPickerMenu {
 	private memory?: { backend: SmoothlyPickerMenu["backend"]; options: SmoothlyPickerMenu["options"] }
 	private listElement?: HTMLElement
 	private searchElement?: HTMLElement
-	// private loading = true
 	private synced = false
 
 	componentWillLoad() {

--- a/src/components/picker/style.css
+++ b/src/components/picker/style.css
@@ -7,7 +7,10 @@
 	padding: 1.2em 0.7em 0.2em 0.8em;
 	background-color: rgb(var(--background-color, var(--smoothly-color-shade)));
 }
-
+:host div.element {
+	display: flex;
+	background-color: inherit;
+}
 smoothly-slot-elements {
 	white-space: nowrap;
 }


### PR DESCRIPTION
When the picker was first rendered it triggered a smoothlyInput event for every option that it was given. resulting in potentially many component updates if it was used as a "controlled input". 

With these changes it will not send an update at all when it is loading (just like the other smoothly inputs). It will only send an input event if the user changes its state.

fixes:
* picker no longer spams events. it will now wait until its loaded then react to changes.
* added a slot that can be used for styling
