### PR TITLE
fix: expandable cell in header styling

### DIFF
--- a/src/components/table/demo/index.tsx
+++ b/src/components/table/demo/index.tsx
@@ -61,9 +61,14 @@ export class TableDemo {
 			<smoothly-table>
 				<smoothly-table-row>
 					<smoothly-table-header>Header A</smoothly-table-header>
+					<smoothly-table-expandable-cell>
+						Header expansion
+						<div slot="detail">Expansion content</div>
+					</smoothly-table-expandable-cell>
 				</smoothly-table-row>
 				<smoothly-table-expandable-row>
 					<smoothly-table-cell>A Content</smoothly-table-cell>
+					<smoothly-table-cell>Expansion cell</smoothly-table-cell>
 					<div slot="detail">
 						<smoothly-tab-switch>
 							<smoothly-tab label="innertable 1" open={true}>

--- a/src/components/table/expandable/cell/style.css
+++ b/src/components/table/expandable/cell/style.css
@@ -13,6 +13,9 @@
 	background-color: rgb(var(--smoothly-color));
 	box-shadow: 1px 0 0 0 rgb(var(--smoothly-color-shade)) inset, -1px 0 0 0 rgb(var(--smoothly-color-shade)) inset, 0 1px 0 0 rgb(var(--smoothly-color-shade)) inset;
 }
+smoothly-table-header ~ :host:not([open]) {
+	box-shadow: 0 1px 0 0 rgb(var(--smoothly-color-shade)), 0 1px 0 0 rgb(var(--smoothly-color-shade)) inset;
+}
 :host smoothly-icon {
 	width: 1em;
 	float: left;


### PR DESCRIPTION
using an expandable cell in the header row caused it to have the wrong styling
* expandable cells that are preceding siblings of smoothly headers have correct styling in table
  * before:
    ![image](https://github.com/utily/smoothly/assets/25643315/733e3ef0-97fd-46fa-9a05-d7988b57d540)
  * after:
    ![image](https://github.com/utily/smoothly/assets/25643315/692f58d7-d96a-43ba-b216-d5ad47e8978c)
