### PR TITLE
fix: less restrictive style for header expansion cell

### DIFF
--- a/src/components/table/demo/index.tsx
+++ b/src/components/table/demo/index.tsx
@@ -92,6 +92,13 @@ export class TableDemo {
 						</smoothly-tab-switch>
 					</div>
 				</smoothly-table-expandable-row>
+				<smoothly-table-row>
+					<smoothly-table-cell>A Content</smoothly-table-cell>
+					<smoothly-table-expandable-cell>
+						Expandable cell
+						<div slot="detail">Expansion content</div>
+					</smoothly-table-expandable-cell>
+				</smoothly-table-row>
 			</smoothly-table>,
 			<smoothly-table>
 				<smoothly-table-row>

--- a/src/components/table/expandable/cell/style.css
+++ b/src/components/table/expandable/cell/style.css
@@ -5,16 +5,13 @@
 	line-height: 1.5rem;
 }
 :host:not([open]) {
-	box-shadow: 0 1px 0 0 rgb(var(--smoothly-color-shade));
+	box-shadow: 0 1px 0 0 rgb(var(--smoothly-color-shade)), 0 1px 0 0 rgb(var(--smoothly-color-shade)) inset;
 }
 :host[open] {
 	position: relative;
 	z-index: 3;
 	background-color: rgb(var(--smoothly-color));
 	box-shadow: 1px 0 0 0 rgb(var(--smoothly-color-shade)) inset, -1px 0 0 0 rgb(var(--smoothly-color-shade)) inset, 0 1px 0 0 rgb(var(--smoothly-color-shade)) inset;
-}
-smoothly-table-header ~ :host:not([open]) {
-	box-shadow: 0 1px 0 0 rgb(var(--smoothly-color-shade)), 0 1px 0 0 rgb(var(--smoothly-color-shade)) inset;
 }
 :host smoothly-icon {
 	width: 1em;


### PR DESCRIPTION
It should look the same. but with this styling there can be components wrapping the cell.