### PR TITLE
fix: duration input

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
 				"langly": "2.0.3",
 				"normalize.css": "^8.0.1",
 				"selectively": "^2.0.4",
-				"tidily": "^0.0.65",
+				"tidily": "^0.0.67",
 				"urlpattern-polyfill": "^6.0.2"
 			},
 			"devDependencies": {
@@ -6126,9 +6126,9 @@
 			"license": "MIT"
 		},
 		"node_modules/tidily": {
-			"version": "0.0.65",
-			"resolved": "https://registry.npmjs.org/tidily/-/tidily-0.0.65.tgz",
-			"integrity": "sha512-8X9lP5Vtzw9l1Vqcwlo598/dGxc/eZEPgVaRuRfw7DRRudR6LrrO5fnWTz8+30tB7BVz9CDbahPYRLCiw7HV5A==",
+			"version": "0.0.67",
+			"resolved": "https://registry.npmjs.org/tidily/-/tidily-0.0.67.tgz",
+			"integrity": "sha512-LKLub27SlxiCMfzvZg2l2br6wXF2xM5KTwWb8AeIEaOJ38cxj6WBkJPVb6aX7RnKulVC4Atz1bnLaXaKZ5yr5Q==",
 			"dependencies": {
 				"isoly": "^2.3.6"
 			}

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
 		"langly": "2.0.3",
 		"normalize.css": "^8.0.1",
 		"selectively": "^2.0.4",
-		"tidily": "^0.0.65",
+		"tidily": "^0.0.67",
 		"urlpattern-polyfill": "^6.0.2"
 	},
 	"devDependencies": {

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -122,7 +122,6 @@ export namespace Components {
         "currency"?: Currency;
         "format"?: DateTime.Format;
         "type": Type;
-        "unit"?: string;
         "value"?: any;
     }
     interface SmoothlyDisplayAmount {
@@ -1308,7 +1307,6 @@ declare namespace LocalJSX {
         "currency"?: Currency;
         "format"?: DateTime.Format;
         "type"?: Type;
-        "unit"?: string;
         "value"?: any;
     }
     interface SmoothlyDisplayAmount {

--- a/src/components/display-demo/index.tsx
+++ b/src/components/display-demo/index.tsx
@@ -15,6 +15,17 @@ export class SmoothlyDisplayDemo {
 				<fieldset>
 					<h2>Smoothly display</h2>
 					<dl>
+						<dt>Duration</dt>
+						<dd>
+							<div>
+								<smoothly-display type="duration" value={{ hours: 13, minutes: 100 }} />
+								<smoothly-display type="duration" value={{ hours: 8 }} />
+								<smoothly-display type="duration" value={{ minutes: 3 }} />
+								<smoothly-display type="duration" value={{ hours: -13, minutes: 100 }} />
+								<smoothly-display type="duration" value={{ hours: -8 }} />
+								<smoothly-display type="duration" value={{ minutes: -3 }} />
+							</div>
+						</dd>
 						<dt>text</dt>
 						<dd>
 							<smoothly-display type="text" value="text"></smoothly-display>
@@ -102,8 +113,6 @@ export class SmoothlyDisplayDemo {
 						<dd>
 							<smoothly-quiet color="dark">-</smoothly-quiet>
 						</dd>
-						<dt>Duration</dt>
-						<dd><smoothly-display type="duration" value={{hours: 13, minutes: 100}} /><smoothly-display type="duration" value={{hours: 8, minutes: 30}} /><smoothly-display type="duration" value={{hours: 0, minutes: 3}} /></dd>
 					</dl>
 				</fieldset>
 				<fieldset>

--- a/src/components/display/index.tsx
+++ b/src/components/display/index.tsx
@@ -13,7 +13,6 @@ export class SmoothlyDisplay {
 	@Prop() currency?: Currency
 	@Prop() country?: CountryCode.Alpha2
 	@Prop() format?: DateTime.Format
-	@Prop() unit?: string
 	render() {
 		let result: string | HTMLElement | undefined
 		const type = this.type
@@ -37,7 +36,7 @@ export class SmoothlyDisplay {
 				result = get(this.type as Type, getLocale())?.toString(this.value)
 				break
 			case "duration":
-				result = format(this.value, type, this.unit)
+				result = format(this.value, type)
 				break
 			case "date-time":
 				result = this.format

--- a/src/components/input/demo/index.tsx
+++ b/src/components/input/demo/index.tsx
@@ -6,7 +6,7 @@ import { isoly } from "isoly"
 })
 export class SmoothlyInputDemo {
 	private selectElement: HTMLSmoothlyInputSelectElement
-	@State() duration: isoly.TimeSpan = { hours: -5, minutes: 30 }
+	@State() duration: isoly.TimeSpan = { hours: 8 }
 
 	@Listen("selectionChanged")
 	handleSelectionChanged(event: CustomEvent<{ identifier: string; value: string }>) {

--- a/src/components/input/index.tsx
+++ b/src/components/input/index.tsx
@@ -66,8 +66,7 @@ export class SmoothlyInput implements Changeable, Clearable, Input {
 		this.formatter = result || get("text")!
 	}
 	private newState(state: TidilyState) {
-		const formatter = this.formatter
-		return formatter.format(StateEditor.copy(formatter.unformat(StateEditor.copy(state))))
+		return this.formatter.format(StateEditor.copy(this.formatter.unformat(StateEditor.copy(state))))
 	}
 	@Event() smoothlyBlur: EventEmitter<void>
 	@Event() smoothlyChange: EventEmitter<Record<string, any>>
@@ -154,7 +153,6 @@ export class SmoothlyInput implements Changeable, Clearable, Input {
 			...this.state,
 			selection: { start, end, direction: direction != undefined ? direction : this.state.selection.direction },
 		})
-
 		const after = this.formatter.format(StateEditor.copy(this.formatter.unformat(StateEditor.copy({ ...this.state }))))
 		this.updateBackend(after, this.inputElement)
 	}


### PR DESCRIPTION
Fixes: 
* updated tidily
* removed unused property `unit` from `<smoothly-display>`
* added more display demo to make sure formatting is correct
* added more `<smoothly-input type="duration">` demo to make sure it is working

Notes:
The duration is not correctly formatted since the span `{ minutes: 3 }` should be formatted to `0:3`. It works like this for now since there is currently no hook in tidily that can tell the formatter that the user is still editing and aggressive formatting should / should not be done. The formatting that guaranteed always is desired is done otherwise the value for now is left alone.