### PR TITLE
lazy subscriptions

### DIFF
--- a/src/model/Listenable.spec.ts
+++ b/src/model/Listenable.spec.ts
@@ -112,6 +112,8 @@ describe("Listenable", () => {
 			private calculate() {
 				if (this.foo != undefined && this.raw != undefined)
 					this.listenable.value = this.foo + this.raw
+				else if (this.#value != undefined)
+					this.listenable.value = undefined
 			}
 
 			private subscriptions = {
@@ -126,10 +128,9 @@ describe("Listenable", () => {
 			}
 		}
 		class State {
-			readonly dependency: WithListenable<Dependency>
+			readonly dependency = Dependency.create()
 			readonly dependant: WithListenable<Dependant>
 			constructor(options?: { lazy?: boolean }) {
-				this.dependency = Dependency.create()
 				this.dependant = Dependant.create(this.dependency, options)
 			}
 		}

--- a/src/model/Listenable.spec.ts
+++ b/src/model/Listenable.spec.ts
@@ -1,10 +1,13 @@
 // TODO: Should be imported with
 // import * as model from "../model/index"
 // But test fails because of test not handling ESM-module of imported libraries.
-import { Listenable } from "./Listenable"
+import { Listenable, WithListenable } from "./Listenable"
 import { StateBase } from "./StateBase"
 
 describe("Listenable", () => {
+	async function sleep(duration: number): Promise<void> {
+		await new Promise(resolve => setTimeout(resolve, duration))
+	}
 	class State extends StateBase<State> {
 		get foo() {
 			return "bar"
@@ -64,5 +67,111 @@ describe("Listenable", () => {
 		component.disconnectedCallback()
 		state.disabled = false
 		expect(count).toEqual(2)
+	})
+	it("internal subscriptions", async () => {
+		class Dependency extends StateBase<Dependency> {
+			#value?: Dependency["value"]
+			get value(): number | undefined {
+				return (this.#value ??=
+					(new Promise(resolve => setTimeout(() => resolve((this.listenable.value = 100)), 0)), undefined))
+			}
+			set value(value: Dependency["value"]) {
+				this.#value = value
+			}
+			static create(): WithListenable<Dependency> {
+				const backend = new this()
+				const listenable = Listenable.load(backend)
+				return listenable
+			}
+		}
+		class Dependant extends StateBase<Dependant> {
+			#raw: Dependant["raw"]
+			get raw(): number | undefined {
+				return this.#raw
+			}
+			set raw(raw: Dependant["raw"]) {
+				this.#raw = raw
+				this.calculate()
+			}
+			#value: Dependant["value"]
+			get value(): number | undefined {
+				return (this.#value ??= (this.calculate(), undefined))
+			}
+			private set value(value: Dependant["value"]) {
+				this.#value = value
+			}
+			#foo: Dependant["foo"]
+			get foo(): Dependency["value"] {
+				return this.#foo
+			}
+			private set foo(foo: Dependant["foo"]) {
+				this.#foo = foo
+				this.calculate()
+			}
+
+			private calculate() {
+				if (this.foo != undefined && this.raw != undefined)
+					this.listenable.value = this.foo + this.raw
+			}
+
+			private subscriptions = {
+				foo: (value: Dependency["value"]) => (this.foo = value),
+			}
+
+			static create(foo: WithListenable<Dependency>, options?: { lazy?: boolean }): WithListenable<Dependant> {
+				const backend = new this()
+				const listenable = Listenable.load(backend)
+				foo.listen("value", value => backend.subscriptions.foo(value), options)
+				return listenable
+			}
+		}
+		class State {
+			readonly dependency: WithListenable<Dependency>
+			readonly dependant: WithListenable<Dependant>
+			constructor(options?: { lazy?: boolean }) {
+				this.dependency = Dependency.create()
+				this.dependant = Dependant.create(this.dependency, options)
+			}
+		}
+
+		const eager = new State()
+		await sleep(0) // context switch. do not remove
+		expect(eager.dependant.foo).toEqual(100)
+		expect(eager.dependant.raw).toEqual(undefined)
+		expect(eager.dependant.value).toEqual(undefined)
+		expect(eager.dependency.value).toEqual(100)
+		await sleep(0) // context switch. do not remove
+		expect(eager.dependant.foo).toEqual(100)
+		expect(eager.dependant.raw).toEqual(undefined)
+		expect(eager.dependant.value).toEqual(undefined)
+		expect(eager.dependency.value).toEqual(100)
+		eager.dependant.raw = 50
+		await sleep(0) // context switch. do not remove
+		expect(eager.dependant.foo).toEqual(100)
+		expect(eager.dependant.raw).toEqual(50)
+		expect(eager.dependant.value).toEqual(150)
+		expect(eager.dependency.value).toEqual(100)
+		eager.dependency.value = 200
+		await sleep(0) // context switch. do not remove
+		expect(eager.dependant.value).toEqual(250)
+
+		const lazy = new State({ lazy: true })
+		await sleep(0) // context switch. do not remove
+		expect(lazy.dependant.foo).toEqual(undefined)
+		expect(lazy.dependant.raw).toEqual(undefined)
+		expect(lazy.dependant.value).toEqual(undefined)
+		expect(lazy.dependency.value).toEqual(undefined)
+		await sleep(0) // context switch. do not remove
+		expect(lazy.dependant.foo).toEqual(100)
+		expect(lazy.dependant.raw).toEqual(undefined)
+		expect(lazy.dependant.value).toEqual(undefined)
+		expect(lazy.dependency.value).toEqual(100)
+		lazy.dependant.raw = 50
+		await sleep(0) // context switch. do not remove
+		expect(lazy.dependant.raw).toEqual(50)
+		expect(lazy.dependant.value).toEqual(150)
+		lazy.dependency.value = 200
+		await sleep(0) // context switch. do not remove
+		expect(lazy.dependant.value).toEqual(250)
 	})
 })

--- a/src/model/Listenable.spec.ts
+++ b/src/model/Listenable.spec.ts
@@ -116,7 +116,7 @@ describe("Listenable", () => {
 			}
 
 			private subscriptions = {
-				dependency: (value: Dependency["value"]) => (this.dependency = value),
+				dependency: (value: Dependency["value"]) => (this.listenable.dependency = value),
 			}
 
 			static create(dependency: WithListenable<Dependency>, options?: { lazy?: boolean }): WithListenable<Dependant> {

--- a/src/model/Listenable.spec.ts
+++ b/src/model/Listenable.spec.ts
@@ -99,30 +99,30 @@ describe("Listenable", () => {
 			private set value(value: Dependant["value"]) {
 				this.#value = value
 			}
-			#foo: Dependant["foo"]
-			get foo(): Dependency["value"] {
-				return this.#foo
+			#dependency: Dependant["dependency"]
+			get dependency(): Dependency["value"] {
+				return this.#dependency
 			}
-			private set foo(foo: Dependant["foo"]) {
-				this.#foo = foo
+			private set dependency(dependency: Dependant["dependency"]) {
+				this.#dependency = dependency
 				this.calculate()
 			}
 
 			private calculate() {
-				if (this.foo != undefined && this.raw != undefined)
-					this.listenable.value = this.foo + this.raw
+				if (this.dependency != undefined && this.raw != undefined)
+					this.listenable.value = this.dependency + this.raw
 				else if (this.#value != undefined)
 					this.listenable.value = undefined
 			}
 
 			private subscriptions = {
-				foo: (value: Dependency["value"]) => (this.foo = value),
+				dependency: (value: Dependency["value"]) => (this.dependency = value),
 			}
 
-			static create(foo: WithListenable<Dependency>, options?: { lazy?: boolean }): WithListenable<Dependant> {
+			static create(dependency: WithListenable<Dependency>, options?: { lazy?: boolean }): WithListenable<Dependant> {
 				const backend = new this()
 				const listenable = Listenable.load(backend)
-				foo.listen("value", value => backend.subscriptions.foo(value), options)
+				dependency.listen("value", value => backend.subscriptions.dependency(value), options)
 				return listenable
 			}
 		}
@@ -136,18 +136,18 @@ describe("Listenable", () => {
 
 		const eager = new State()
 		await asyncContextSwitch()
-		expect(eager.dependant.foo).toEqual(100)
+		expect(eager.dependant.dependency).toEqual(100)
 		expect(eager.dependant.raw).toEqual(undefined)
 		expect(eager.dependant.value).toEqual(undefined)
 		expect(eager.dependency.value).toEqual(100)
 		await asyncContextSwitch()
-		expect(eager.dependant.foo).toEqual(100)
+		expect(eager.dependant.dependency).toEqual(100)
 		expect(eager.dependant.raw).toEqual(undefined)
 		expect(eager.dependant.value).toEqual(undefined)
 		expect(eager.dependency.value).toEqual(100)
 		eager.dependant.raw = 50
 		await asyncContextSwitch()
-		expect(eager.dependant.foo).toEqual(100)
+		expect(eager.dependant.dependency).toEqual(100)
 		expect(eager.dependant.raw).toEqual(50)
 		expect(eager.dependant.value).toEqual(150)
 		expect(eager.dependency.value).toEqual(100)
@@ -157,12 +157,12 @@ describe("Listenable", () => {
 
 		const lazy = new State({ lazy: true })
 		await asyncContextSwitch()
-		expect(lazy.dependant.foo).toEqual(undefined)
+		expect(lazy.dependant.dependency).toEqual(undefined)
 		expect(lazy.dependant.raw).toEqual(undefined)
 		expect(lazy.dependant.value).toEqual(undefined)
 		expect(lazy.dependency.value).toEqual(undefined)
 		await asyncContextSwitch()
-		expect(lazy.dependant.foo).toEqual(100)
+		expect(lazy.dependant.dependency).toEqual(100)
 		expect(lazy.dependant.raw).toEqual(undefined)
 		expect(lazy.dependant.value).toEqual(undefined)
 		expect(lazy.dependency.value).toEqual(100)

--- a/src/model/Listenable.ts
+++ b/src/model/Listenable.ts
@@ -11,10 +11,12 @@ export class Listenable<T extends CanBeListenable> {
 	listen<K extends keyof ListenableProperties<T>>(
 		this: T & Listenable<T>,
 		property: K,
-		listener: Listener<T[K]>
+		listener: Listener<T[K]>,
+		options?: { lazy?: boolean }
 	): void {
 		this.#listeners[property]?.push(listener) ?? (this.#listeners[property] = [listener])
-		listener(this[property])
+		if (!options?.lazy)
+			listener(this[property])
 	}
 	unlisten<K extends keyof ListenableProperties<T>>(property: K, listener: Listener<T[K]>): void {
 		const index = this.#listeners[property]?.indexOf(listener)


### PR DESCRIPTION
Added lazy option to `Listenable.listen(...)` so a subscription can be added without any side effects from `get`ters