### PR TITLE
cleanup

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -100,6 +100,7 @@ export namespace Components {
         "name": string;
         "size": "tiny" | "small" | "medium" | "large";
         "toggle": () => Promise<void>;
+        "unavailable": boolean;
         "value": any;
     }
     interface SmoothlyColor {
@@ -1285,6 +1286,7 @@ declare namespace LocalJSX {
         "name"?: string;
         "onSmoothlyInput"?: (event: SmoothlyCheckboxCustomEvent<Record<string, any>>) => void;
         "size"?: "tiny" | "small" | "medium" | "large";
+        "unavailable"?: boolean;
         "value"?: any;
     }
     interface SmoothlyColor {

--- a/src/components/checkbox/index.tsx
+++ b/src/components/checkbox/index.tsx
@@ -23,6 +23,7 @@ export class SmoothlyCheckbox implements Clearable {
 		this.t = translation.create(this.element)
 	}
 
+	@Watch("checked")
 	@Watch("unavailable")
 	unavailableChanged(): void {
 		if (this.unavailable && this.checked)

--- a/src/components/checkbox/index.tsx
+++ b/src/components/checkbox/index.tsx
@@ -43,27 +43,24 @@ export class SmoothlyCheckbox implements Clearable {
 	render() {
 		return (
 			<Host>
-				<main>
-					<div>
-						<smoothly-icon
-							toolTip={this.t(!this.checked ? "Select" : "De-select")}
-							onClick={e => {
-								this.toggle()
-							}}
-							size={this.size}
-							name={
-								this.intermediate && !this.checked
-									? "remove-outline"
-									: this.checked && !this.intermediate
-									? "checkmark-outline"
-									: "empty"
-							}></smoothly-icon>
-					</div>
-					<label htmlFor={this.name}>
-						<slot></slot>
-					</label>
-				</main>
-				<slot name="expansion" />
+				<smoothly-icon
+					toolTip={this.t(!this.checked ? "Select" : "De-select")}
+					onClick={() => this.toggle()}
+					size={this.size}
+					name={
+						this.intermediate && !this.checked
+							? "remove-outline"
+							: this.checked && !this.intermediate
+							? "checkmark-outline"
+							: "empty"
+					}
+				/>
+				<label htmlFor={this.name}>
+					<slot></slot>
+				</label>
+				<div class={"expansion"}>
+					<slot name="expansion" />
+				</div>
 			</Host>
 		)
 	}

--- a/src/components/checkbox/style.css
+++ b/src/components/checkbox/style.css
@@ -18,6 +18,7 @@
 
 :host smoothly-icon {
 	grid-column: 1;
+	line-height: 0;
 	border: 1px solid rgb(var(--smoothly-color-contrast));
 }
 :host[disabled] smoothly-icon {
@@ -48,3 +49,63 @@
 	left: 0.5rem;
 	color: rgb(var(--smoothly-secondary-color))
 }
+
+/* :host {
+	display: block;
+} */
+
+/* :host > main {
+	display: flex;
+	align-items: center;
+	width: fit-content;
+	height: max-content;
+	margin: 0.3rem 0;
+	line-height: 0;
+} */
+
+/* :host > main > label {
+	display:flex;
+	justify-content: center;
+	align-items: center;
+	margin: 0 0.2em;
+} */
+
+/* :host > main > div {
+	border: 1px solid rgb(var(--smoothly-color-contrast));
+} */
+
+/* :host > main > div > smoothly-icon {
+	display: flex;
+	justify-content: center;	
+	align-items: center;
+} */
+
+/* :host:not([checked]) > main > div > smoothly-icon,
+:host:not([intermediate]) > main > div > smoothly-icon {
+	stroke: rgb(var(--smoothly-color-contrast));
+} */
+
+/* :host[disabled] > main > div {
+	border: 1px solid rgb(var(--smoothly-color-contrast), 0.3);
+} */
+
+/* ::slotted([slot=expansion]) {
+	display: none;
+	background-color: rgb(var(--smoothly-secondary-color));
+	color: rgb(var(--smoothly-secondary-contrast));
+} */
+
+/* [checked]::slotted([slot=expansion]) {
+	display: block;
+	padding: 0.5em;
+	border-radius: 5px;
+	margin: 0.5rem 0;
+} */
+
+/* [checked]::slotted([slot=expansion])::before {
+	content: "\25B2";
+	position: relative;
+	top: -1.35em;
+	left: 2rem;
+	color: rgb(var(--smoothly-secondary-color))
+} */

--- a/src/components/checkbox/style.css
+++ b/src/components/checkbox/style.css
@@ -43,68 +43,8 @@
 :host div.expansion::before {
 	content: "\25B2";
 	position: absolute;
-	bottom: calc(100% + 0.5rem);
+	bottom: calc(100% + 0.5rem /* <-- alignment */ - 0.3rem /* <-- adjustment*/);
 	line-height: 0;
 	left: 0.5rem;
 	color: rgb(var(--smoothly-secondary-color))
 }
-
-/* :host {
-	display: block;
-} */
-
-/* :host > main {
-	display: flex;
-	align-items: center;
-	width: fit-content;
-	height: max-content;
-	margin: 0.3rem 0;
-	line-height: 0;
-} */
-
-/* :host > main > label {
-	display:flex;
-	justify-content: center;
-	align-items: center;
-	margin: 0 0.2em;
-} */
-
-/* :host > main > div {
-	border: 1px solid rgb(var(--smoothly-color-contrast));
-} */
-
-/* :host > main > div > smoothly-icon {
-	display: flex;
-	justify-content: center;	
-	align-items: center;
-} */
-
-/* :host:not([checked]) > main > div > smoothly-icon,
-:host:not([intermediate]) > main > div > smoothly-icon {
-	stroke: rgb(var(--smoothly-color-contrast));
-} */
-
-/* :host[disabled] > main > div {
-	border: 1px solid rgb(var(--smoothly-color-contrast), 0.3);
-} */
-
-/* ::slotted([slot=expansion]) {
-	display: none;
-	background-color: rgb(var(--smoothly-secondary-color));
-	color: rgb(var(--smoothly-secondary-contrast));
-} */
-
-/* [checked]::slotted([slot=expansion]) {
-	display: block;
-	padding: 0.5em;
-	border-radius: 5px;
-	margin: 0.5rem 0;
-} */
-
-/* [checked]::slotted([slot=expansion])::before {
-	content: "\25B2";
-	position: relative;
-	top: -1.35em;
-	left: 2rem;
-	color: rgb(var(--smoothly-secondary-color))
-} */

--- a/src/components/checkbox/style.css
+++ b/src/components/checkbox/style.css
@@ -25,10 +25,11 @@
 	cursor: pointer;
 }
 :host[disabled] smoothly-icon {
-	border: 1px solid rgb(var(--smoothly-color-contrast), 0.3);
+	border-color: rgb(var(--smoothly-color-contrast), 0.3);
 }
 :host:not([checked]) smoothly-icon,
-:host:not([intermediate]) smoothly-icon {
+:host:not([intermediate]) smoothly-icon
+:host[unavailable] {
 	stroke: rgb(var(--smoothly-color-contrast));
 }
 
@@ -52,63 +53,3 @@
 	left: 0.5rem;
 	color: rgb(var(--smoothly-secondary-color))
 }
-
-/* :host {
-	display: block;
-} */
-
-/* :host > main {
-	display: flex;
-	align-items: center;
-	width: fit-content;
-	height: max-content;
-	margin: 0.3rem 0;
-	line-height: 0;
-} */
-
-/* :host > main > label {
-	display:flex;
-	justify-content: center;
-	align-items: center;
-	margin: 0 0.2em;
-} */
-
-/* :host > main > div {
-	border: 1px solid rgb(var(--smoothly-color-contrast));
-} */
-
-/* :host > main > div > smoothly-icon {
-	display: flex;
-	justify-content: center;	
-	align-items: center;
-} */
-
-/* :host:not([checked]) > main > div > smoothly-icon,
-:host:not([intermediate]) > main > div > smoothly-icon {
-	stroke: rgb(var(--smoothly-color-contrast));
-} */
-
-/* :host[disabled] > main > div {
-	border: 1px solid rgb(var(--smoothly-color-contrast), 0.3);
-} */
-
-/* ::slotted([slot=expansion]) {
-	display: none;
-	background-color: rgb(var(--smoothly-secondary-color));
-	color: rgb(var(--smoothly-secondary-contrast));
-} */
-
-/* [checked]::slotted([slot=expansion]) {
-	display: block;
-	padding: 0.5em;
-	border-radius: 5px;
-	margin: 0.5rem 0;
-} */
-
-/* [checked]::slotted([slot=expansion])::before {
-	content: "\25B2";
-	position: relative;
-	top: -1.35em;
-	left: 2rem;
-	color: rgb(var(--smoothly-secondary-color))
-} */

--- a/src/components/checkbox/style.css
+++ b/src/components/checkbox/style.css
@@ -21,15 +21,20 @@
 	line-height: 0;
 	border: 1px solid rgb(var(--smoothly-color-contrast));
 }
-:host:not([disabled]) smoothly-icon {
+:host:not([disabled]):not([unavailable]) smoothly-icon {
 	cursor: pointer;
 }
-:host[disabled] smoothly-icon {
+:host[disabled] smoothly-icon,
+:host[unavailable] smoothly-icon {
 	border-color: rgb(var(--smoothly-color-contrast), 0.3);
+}
+:host[disabled] smoothly-icon,
+:host[unavailable] smoothly-icon {
+	opacity: 0.7;
 }
 :host:not([checked]) smoothly-icon,
 :host:not([intermediate]) smoothly-icon
-:host[unavailable] {
+:host:not([unavailable]) {
 	stroke: rgb(var(--smoothly-color-contrast));
 }
 

--- a/src/components/checkbox/style.css
+++ b/src/components/checkbox/style.css
@@ -1,63 +1,110 @@
 * {
 	box-sizing: border-box;
 }
-
 :host {
-	display: block;
+	display: grid;
+	width: fit-content;
+	grid-template-columns: auto 1fr;
+	row-gap: 0.5rem;
+	align-items: center;
+}
+:host label:empty {
+	display: none;
+}
+:host label {
+	grid-column: 2;
+	margin-left: 0.2rem;
 }
 
-:host > main {
+:host smoothly-icon {
+	grid-column: 1;
+	border: 1px solid rgb(var(--smoothly-color-contrast));
+}
+:host[disabled] smoothly-icon {
+	border: 1px solid rgb(var(--smoothly-color-contrast), 0.3);
+}
+:host:not([checked]) smoothly-icon,
+:host:not([intermediate]) smoothly-icon {
+	stroke: rgb(var(--smoothly-color-contrast));
+}
+
+:host div.expansion {
+	position: relative;
+	grid-column-start: 2;
+	background-color: rgb(var(--smoothly-secondary-color));
+	color: rgb(var(--smoothly-secondary-contrast));
+	padding: 0.5rem;
+	border-radius: 5px;
+}
+:host:not([checked]) div.expansion,
+:host div.expansion:empty {
+	display: none;
+}
+:host div.expansion::before {
+	content: "\25B2";
+	position: absolute;
+	bottom: calc(100% + 0.5rem);
+	line-height: 0;
+	left: 0.5rem;
+	color: rgb(var(--smoothly-secondary-color))
+}
+
+/* :host {
+	display: block;
+} */
+
+/* :host > main {
 	display: flex;
 	align-items: center;
 	width: fit-content;
 	height: max-content;
 	margin: 0.3rem 0;
 	line-height: 0;
-}
+} */
 
-:host > main > label {
+/* :host > main > label {
 	display:flex;
 	justify-content: center;
 	align-items: center;
 	margin: 0 0.2em;
-}
+} */
 
-:host > main > div {
+/* :host > main > div {
 	border: 1px solid rgb(var(--smoothly-color-contrast));
-}
+} */
 
-:host > main > div > smoothly-icon {
+/* :host > main > div > smoothly-icon {
 	display: flex;
 	justify-content: center;	
 	align-items: center;
-}
+} */
 
-:host:not([checked]) > main > div > smoothly-icon,
+/* :host:not([checked]) > main > div > smoothly-icon,
 :host:not([intermediate]) > main > div > smoothly-icon {
 	stroke: rgb(var(--smoothly-color-contrast));
-}
+} */
 
-:host[disabled] > main > div {
+/* :host[disabled] > main > div {
 	border: 1px solid rgb(var(--smoothly-color-contrast), 0.3);
-}
+} */
 
-::slotted([slot=expansion]) {
+/* ::slotted([slot=expansion]) {
 	display: none;
 	background-color: rgb(var(--smoothly-secondary-color));
 	color: rgb(var(--smoothly-secondary-contrast));
-}
+} */
 
-[checked]::slotted([slot=expansion]) {
+/* [checked]::slotted([slot=expansion]) {
 	display: block;
 	padding: 0.5em;
 	border-radius: 5px;
 	margin: 0.5rem 0;
-}
+} */
 
-[checked]::slotted([slot=expansion])::before {
+/* [checked]::slotted([slot=expansion])::before {
 	content: "\25B2";
 	position: relative;
 	top: -1.35em;
 	left: 2rem;
 	color: rgb(var(--smoothly-secondary-color))
-}
+} */

--- a/src/components/checkbox/style.css
+++ b/src/components/checkbox/style.css
@@ -21,6 +21,9 @@
 	line-height: 0;
 	border: 1px solid rgb(var(--smoothly-color-contrast));
 }
+:host:not([disabled]) smoothly-icon {
+	cursor: pointer;
+}
 :host[disabled] smoothly-icon {
 	border: 1px solid rgb(var(--smoothly-color-contrast), 0.3);
 }

--- a/src/components/input/demo/index.tsx
+++ b/src/components/input/demo/index.tsx
@@ -230,6 +230,14 @@ export class SmoothlyInputDemo {
 					<smoothly-checkbox>Label</smoothly-checkbox>
 					<smoothly-checkbox disabled={true} />
 					<smoothly-checkbox />
+					<smoothly-checkbox
+						name={"unavailable"}
+						value={true}
+						disabled
+						unavailable
+						checked
+						onSmoothlyInput={e => console.log("unavailable", e.detail)}
+					/>
 				</div>
 			</smoothly-form>,
 			<h4>Smoothly Radio Buttons</h4>,

--- a/src/components/input/demo/index.tsx
+++ b/src/components/input/demo/index.tsx
@@ -225,9 +225,11 @@ export class SmoothlyInputDemo {
 					<smoothly-checkbox>
 						Check me
 						<div slot="expansion">Some context</div>
+						<div slot="expansion">Some more context</div>
 					</smoothly-checkbox>
 					<smoothly-checkbox>Label</smoothly-checkbox>
 					<smoothly-checkbox disabled={true} />
+					<smoothly-checkbox />
 				</div>
 			</smoothly-form>,
 			<h4>Smoothly Radio Buttons</h4>,

--- a/src/components/input/demo/index.tsx
+++ b/src/components/input/demo/index.tsx
@@ -238,6 +238,13 @@ export class SmoothlyInputDemo {
 						checked
 						onSmoothlyInput={e => console.log("unavailable", e.detail)}
 					/>
+					<smoothly-checkbox
+						name={"unavailable"}
+						value={true}
+						unavailable
+						checked
+						onSmoothlyInput={e => console.log("unavailable", e.detail)}
+					/>
 				</div>
 			</smoothly-form>,
 			<h4>Smoothly Radio Buttons</h4>,


### PR DESCRIPTION

* Added unavailable state to the checkbox visualized with a cross.
   ![image](https://github.com/utily/smoothly/assets/25643315/7f1e1148-073a-412d-b08e-4f70d02df6d9)

* Removed the checkboxes internal margins / paddings when possible. Mainly when there was not content label.   
  * Checkbox with content:
    * before
   ![image](https://github.com/utily/smoothly/assets/25643315/5260e43c-f137-470a-a54e-4be92a010107)
    * after
   ![image](https://github.com/utily/smoothly/assets/25643315/5d81f82b-4c69-4c6f-bd06-55aaedfc6ad1)

  *  Checkbox with no content:
     * before
   ![image](https://github.com/utily/smoothly/assets/25643315/9a88c487-1d6e-4163-b2bb-c882daa7ac50)
     * before with `width: fit-content;`
   ![image](https://github.com/utily/smoothly/assets/25643315/39069bb6-9fb9-4154-be3a-5c3b47c5a54f)
     * after
   ![image](https://github.com/utily/smoothly/assets/25643315/068376e7-80fb-4ca3-8f04-77cd2aa438e8)
