### PR TITLE
Add batch listen and unlisten

### DIFF
--- a/src/model/Listenable.spec.ts
+++ b/src/model/Listenable.spec.ts
@@ -1,7 +1,7 @@
 // TODO: Should be imported with
 // import * as model from "../model/index"
 // But test fails because of test not handling ESM-module of imported libraries.
-import { Listenable, WithListenable } from "./Listenable"
+import { Listenable, ListenerBatch, WithListenable } from "./Listenable"
 import { StateBase } from "./StateBase"
 
 describe("Listenable", () => {
@@ -13,6 +13,7 @@ describe("Listenable", () => {
 			return "bar"
 		}
 		disabled = false
+		count = 0
 		static create() {
 			return Listenable.load(new State())
 		}
@@ -21,6 +22,8 @@ describe("Listenable", () => {
 		const state = State.create()
 		expect(typeof state.listen).toEqual("function")
 		expect(typeof state.unlisten).toEqual("function")
+		expect(typeof state.batchListen).toEqual("function")
+		expect(typeof state.batchUnlisten).toEqual("function")
 		expect(state.disabled).toEqual(false)
 	})
 	it("subscribe", () => {
@@ -67,6 +70,40 @@ describe("Listenable", () => {
 		component.disconnectedCallback()
 		state.disabled = false
 		expect(count).toEqual(2)
+	})
+	it("batchListen and batchUnlisten", () => {
+		const state = State.create()
+		class FakeComponent {
+			disabled: boolean
+			count: number
+			listeners: ListenerBatch<State> = {
+				disabled: (disabled: boolean) => (this.disabled = disabled),
+				count: (count: number) => (this.count = count),
+			}
+			constructor() {
+				this.componentWillLoad()
+			}
+			componentWillLoad() {
+				state.batchListen(this.listeners)
+			}
+			disconnectedCallback() {
+				state.batchUnlisten(this.listeners)
+			}
+		}
+		const components = [new FakeComponent(), new FakeComponent()]
+		expect(components.every(components => components.disabled == false)).toBeTruthy()
+		expect(components.every(components => components.count == 0)).toBeTruthy()
+		state.disabled = true
+		state.count++
+		expect(components.every(components => components.disabled == true)).toBeTruthy()
+		expect(components.every(components => components.count == 1)).toBeTruthy()
+		components[0].disconnectedCallback()
+		state.disabled = false
+		state.count = 123
+		expect(components[0].disabled).toEqual(true)
+		expect(components[0].count).toEqual(1)
+		expect(components[1].disabled).toEqual(false)
+		expect(components[1].count).toEqual(123)
 	})
 	it("internal subscriptions", async () => {
 		class Dependency extends StateBase<Dependency> {

--- a/src/model/Listenable.ts
+++ b/src/model/Listenable.ts
@@ -22,6 +22,18 @@ export class Listenable<T extends CanBeListenable> {
 		const index = this.#listeners[property]?.indexOf(listener)
 		index != undefined && index >= 0 && this.#listeners[property]?.splice(index, 1)
 	}
+	batchListen(this: T & Listenable<T>, listeners: ListenerBatch<T>, options?: { lazy?: boolean }) {
+		for (const key in listeners) {
+			const listener = listeners[key]
+			listener && this.listen(key, listener, options)
+		}
+	}
+	batchUnlisten(listeners: ListenerBatch<T>) {
+		for (const key in listeners) {
+			const listener = listeners[key]
+			listener && this.unlisten(key, listener)
+		}
+	}
 
 	static load<T extends HasListenable<CanBeListenable>>(backend: T): WithListenable<T> {
 		const result = backend.listenable
@@ -72,3 +84,5 @@ export type Listener<V> = (value: V) => void
 export type Listeners<T> = {
 	[K in keyof T]?: Listener<T[K]>[]
 }
+
+export type ListenerBatch<T> = { [K in keyof ListenableProperties<T>]?: Listener<T[K]> }


### PR DESCRIPTION
While using the listener, I realized that I needed to `listen` and `unlisten` to multiple variables in a component. 
To make this simpler I added `batchListen` and `batchUnlisten`, to reduce the amount of code needed when using the listener.


### Example usage
```tsx
import * as smoothly from "smoothly"
import { state, Users } from "../../../State"

@Component({
	tag: "my-component",
	styleUrl: "style.css",
	scoped: true,
})
export class MyComponent {
	@State() users?: User[]
	@State() loadingMoreUsers = false
	@State() loadingUsers = true
	@State() totalCount: number
	@State() translate: langly.Translate
	@Event() notice: EventEmitter<Notice>
	listeners: smoothly.ListenerBatch<Users> = {
		users: users => (this.users = users),
		totalCount: totalCount => (this.totalCount = totalCount),
		loading: loadingUsers => (this.loadingUsers = loadingUsers),
		loadingMore: loadingMoreUsers => (this.loadingMoreUsers = loadingMoreUsers),
		notice: notice => notice && this.notice.emit(notice),
	}
	componentWillLoad() {
		this.translate = langly.create(translation, this.element)
		state.users.batchListen(this.listeners)
	}
	disconnectedCallback() {
		state.users.batchUnlisten(this.listeners)
	}
	// ...
}
```

### Same example without batchListen and batchUnlisten
```tsx
import * as smoothly from "smoothly"
import { state } from "../../../State"

@Component({
	tag: "my-component",
	styleUrl: "style.css",
	scoped: true,
})
export class MyComponent {
	@State() users?: User[]
	@State() loadingMoreUsers = false
	@State() loadingUsers = true
	@State() totalCount: number
	@State() translate: langly.Translate
	@Event() notice: EventEmitter<Notice>
	userListener = (users: User) => (this.users = users)
	totalCountListener = (totalCount: number) => (this.totalCount = totalCount)	
	loadingListener: (loadingUsers: boolean) => (this.loadingUsers = loadingUsers)
	loadingMoreListener: (loadingMoreUsers: boolean) => (this.loadingMoreUsers = loadingMoreUsers)
	noticeListener: (notice: smoothly.Notice) => (notice && this.notice.emit(notice))
	
	componentWillLoad() {
		this.translate = langly.create(translation, this.element)
		state.users.listen("users", this.userListener)
		state.users.listen("totalCount", this.totalCountListener)
		state.users.listen("loadingUsers", this.loadingListener)
		state.users.listen("loadingMoreUsers", this.loadingMoreListener)
		state.users.listen("notice", this.noticeListener)
	}
	disconnectedCallback() {
		state.users.unlisten("users", this.userListener)
		state.users.unlisten("totalCount", this.totalCountListener)
		state.users.unlisten("loadingUsers", this.loadingListener)
		state.users.unlisten("loadingMoreUsers", this.loadingMoreListener)
		state.users.unlisten("notice", this.noticeListener)
	}
	// ...
}
```