### PR TITLE
Fix styles to icon demo

### DIFF
--- a/src/components/icon-demo/index.tsx
+++ b/src/components/icon-demo/index.tsx
@@ -10,7 +10,7 @@ export class SmoothlyIconDemo {
 	render() {
 		return [
 			<h1>Icons</h1>,
-			<content>
+			<div>
 				{[
 					"add-circle",
 					"add",
@@ -482,7 +482,7 @@ export class SmoothlyIconDemo {
 					.map(name => (
 						<smoothly-icon name={name as Icon} toolTip={name}></smoothly-icon>
 					))}
-			</content>,
+			</div>,
 		]
 	}
 }

--- a/src/components/icon-demo/style.css
+++ b/src/components/icon-demo/style.css
@@ -1,14 +1,13 @@
-icon-demo {
+:host {
 	display: block;
-	
 }
-icon-demo[hidden] {
+:host([hidden]) {
 	display: none;
 }
-icon-demo > content {
+:host > content {
 	display: flex;
 	flex-flow: row wrap;
 }
-icon-demo > content > * {
-	margin: 1cm;
+:host > content > * {
+	margin: 0.5cm;
 }

--- a/src/components/icon-demo/style.css
+++ b/src/components/icon-demo/style.css
@@ -4,10 +4,10 @@
 :host([hidden]) {
 	display: none;
 }
-:host > content {
+:host > div {
 	display: flex;
 	flex-flow: row wrap;
 }
-:host > content > * {
+:host > div > * {
 	margin: 0.5cm;
 }


### PR DESCRIPTION
Styles was applied to `icon-demo` which is the incorrect name (should be `smoothly-icon-demo`).
Also `:host` should be used instead.

Now icon columns adapt to width of window.

## Before
![image](https://github.com/utily/smoothly/assets/14332757/33459b65-9697-4341-82a2-c2614b95d7cd)

## After
![image](https://github.com/utily/smoothly/assets/14332757/84339fa4-89c9-4f07-a8c5-7059e901bd0a)
