### PR TITLE
implemented transparent inputs

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -14,8 +14,8 @@ import { CountryCode, Currency, Date, DateRange, DateTime, isoly } from "isoly";
 import { Direction, Type } from "tidily";
 import { Criteria } from "selectively";
 import { Data } from "./model/Data";
-import { GoogleFont } from "./model/GoogleFont";
 import { Looks } from "./components/input/Looks";
+import { GoogleFont } from "./model/GoogleFont";
 import { Controls } from "./components/picker/menu";
 import { Controls as Controls1 } from "./components/picker/menu/index";
 import { Selected } from "./components/radio-button/Selected";
@@ -166,7 +166,7 @@ export namespace Components {
         "changed": boolean;
         "clear": () => Promise<void>;
         "color"?: Color;
-        "looks": "plain" | "grid" | "border" | "line";
+        "looks": Looks;
         "method"?: "GET" | "POST";
         "name"?: string;
         "prevent": boolean;
@@ -1362,7 +1362,7 @@ declare namespace LocalJSX {
         "action"?: string;
         "changed"?: boolean;
         "color"?: Color;
-        "looks"?: "plain" | "grid" | "border" | "line";
+        "looks"?: Looks;
         "method"?: "GET" | "POST";
         "name"?: string;
         "onSmoothlyFormInput"?: (event: SmoothlyFormCustomEvent<Data>) => void;

--- a/src/components/form/index.tsx
+++ b/src/components/form/index.tsx
@@ -16,7 +16,7 @@ export class SmoothlyForm implements Changeable, Clearable, Submittable {
 	private clearables = new Map<string, Clearable>()
 	@Prop({ reflect: true, mutable: true }) color?: Color
 	@Prop({ mutable: true }) value: Readonly<Data> = {}
-	@Prop({ reflect: true, attribute: "looks" }) looks: "plain" | "grid" | "border" | "line" = "plain"
+	@Prop({ reflect: true, attribute: "looks" }) looks: Looks = "plain"
 	@Prop() name?: string
 	@Prop() method?: "GET" | "POST"
 	@Prop() action?: string

--- a/src/components/form/style.css
+++ b/src/components/form/style.css
@@ -32,7 +32,8 @@ smoothly-form[looks="grid"] > form > fieldset {
 	border: rgba(var(--text-color), .5) solid .5px;
 }
 smoothly-form[looks="line"] > form > fieldset,
-smoothly-form[looks="border"] > form > fieldset {
+smoothly-form[looks="border"] > form > fieldset,
+smoothly-form[looks="transparent"] > form > fieldset {
 	gap: 2em
 }
 

--- a/src/components/input/Looks.ts
+++ b/src/components/input/Looks.ts
@@ -1,1 +1,1 @@
-export type Looks = "plain" | "grid" | "border" | "line"
+export type Looks = "plain" | "grid" | "border" | "line" | "transparent"

--- a/src/components/input/date/index.tsx
+++ b/src/components/input/date/index.tsx
@@ -63,7 +63,7 @@ export class InputDate implements Clearable, Input {
 				disabled={this.disabled}
 				type="date"
 				value={this.value}
-				looks="plain"
+				looks={this.looks}
 				showLabel={this.showLabel}
 				onSmoothlyInput={e => (this.value = e.detail[this.name])}>
 				<slot></slot>

--- a/src/components/input/date/range/index.tsx
+++ b/src/components/input/date/range/index.tsx
@@ -1,4 +1,4 @@
-import { Component, Element, Event, EventEmitter, h, Listen, Method, Prop, Watch } from "@stencil/core"
+import { Component, Element, Event, EventEmitter, h, Host, Listen, Method, Prop, Watch } from "@stencil/core"
 import { isoly } from "isoly"
 import { Clearable } from "../../Clearable"
 import { Input } from "../../Input"
@@ -68,47 +68,49 @@ export class InputDateRange implements Clearable, Input {
 		isoly.DateRange.is(event.detail) && this.smoothlyInput.emit({ [this.name]: event.detail })
 	}
 	render() {
-		return [
-			<section onClick={() => (this.open = !this.open)}>
-				<smoothly-input
-					type="date"
-					name="start"
-					value={this.start}
-					looks="plain"
-					showLabel={this.showLabel}
-					onSmoothlyInput={e => (this.start = e.detail.start)}>
-					{`${this.labelStart}`}
-				</smoothly-input>
-				<span>–</span>
-				<smoothly-input
-					type="date"
-					name="end"
-					value={this.end}
-					looks="plain"
-					showLabel={this.showLabel}
-					onSmoothlyInput={e => (this.end = e.detail.end)}>
-					{`${this.labelEnd}`}
-				</smoothly-input>
-			</section>,
-			this.open ? <div onClick={() => (this.open = false)}></div> : [],
-			this.open ? (
-				<nav>
-					<div class="arrow"></div>
-					<smoothly-calendar
-						doubleInput={true}
-						value={this.value ?? isoly.Date.now()}
-						onValueChanged={event => {
-							this.value = event.detail
-							event.stopPropagation()
-						}}
-						start={this.start}
-						end={this.end}
-						max={this.max}
-						min={this.min}></smoothly-calendar>
-				</nav>
-			) : (
-				[]
-			),
-		]
+		return (
+			<Host tabindex={0}>
+				<section onClick={() => (this.open = !this.open)}>
+					<smoothly-input
+						type="date"
+						name="start"
+						value={this.start}
+						looks={this.looks}
+						showLabel={this.showLabel}
+						onSmoothlyInput={e => (this.start = e.detail.start)}>
+						{`${this.labelStart}`}
+					</smoothly-input>
+					<span>–</span>
+					<smoothly-input
+						type="date"
+						name="end"
+						value={this.end}
+						looks={this.looks}
+						showLabel={this.showLabel}
+						onSmoothlyInput={e => (this.end = e.detail.end)}>
+						{`${this.labelEnd}`}
+					</smoothly-input>
+				</section>
+				{this.open ? <div onClick={() => (this.open = false)}></div> : []}
+				{this.open ? (
+					<nav>
+						<div class="arrow"></div>
+						<smoothly-calendar
+							doubleInput={true}
+							value={this.value ?? isoly.Date.now()}
+							onValueChanged={event => {
+								this.value = event.detail
+								event.stopPropagation()
+							}}
+							start={this.start}
+							end={this.end}
+							max={this.max}
+							min={this.min}></smoothly-calendar>
+					</nav>
+				) : (
+					[]
+				)}
+			</Host>
+		)
 	}
 }

--- a/src/components/input/date/range/style.scss
+++ b/src/components/input/date/range/style.scss
@@ -5,6 +5,9 @@
 	display: block;
 	width: fit-content;
 	background-color: rgb(var(--background-color, var(--smoothly-color-shade)));
+	&:focus-within smoothly-input {
+		outline: none;
+	}
 }
 :host > nav {
 	position: absolute;

--- a/src/components/input/date/style.css
+++ b/src/components/input/date/style.css
@@ -5,6 +5,9 @@
 	max-width: 100vw;
 	background-color: rgb(var(--background-color, var(--smoothly-color-shade)));
 }
+:host[looks=transparent] smoothly-input {
+	outline: none;
+}
 nav {
 	position: absolute;
 	z-index: 10;

--- a/src/components/input/demo/index.tsx
+++ b/src/components/input/demo/index.tsx
@@ -42,6 +42,40 @@ export class SmoothlyInputDemo {
 					Duration
 				</smoothly-input>
 			</smoothly-form>,
+			<h2>Transparent inputs</h2>,
+			<smoothly-form looks={"transparent"}>
+				<smoothly-input-file name={"file"}>
+					<span slot={"label"}>File</span>
+					<smoothly-icon slot={"button"} name={"folder-open-outline"} size={"small"} />
+				</smoothly-input-file>
+				<smoothly-input type={"duration"} looks={"transparent"} placeholder={"h:mm"}>
+					Input
+				</smoothly-input>
+				<smoothly-picker>
+					<span slot={"label"}>Picker</span>
+					<span slot={"search"}>Search</span>
+					<smoothly-picker-option value={"circle"}>
+						<smoothly-icon name={"ellipse-outline"} />
+					</smoothly-picker-option>
+					<smoothly-picker-option value={"square"}>
+						<smoothly-icon name={"square-outline"} />
+					</smoothly-picker-option>
+				</smoothly-picker>
+				<smoothly-input-date>Date</smoothly-input-date>
+				<smoothly-input-date-range>Date Range</smoothly-input-date-range>
+				<smoothly-input-select name={"transport"}>
+					<smoothly-item value={"plane"}>
+						<smoothly-icon name={"airplane-outline"} />
+					</smoothly-item>
+					<smoothly-item value={"car"}>
+						<smoothly-icon name={"car-outline"} />
+					</smoothly-item>
+					<smoothly-item value={"bus"} selected>
+						<smoothly-icon name={"bus-outline"} />
+					</smoothly-item>
+				</smoothly-input-select>
+			</smoothly-form>,
+
 			<h2>Submit</h2>,
 			<smoothly-form looks="border">
 				<smoothly-input type="email" name="email">

--- a/src/components/input/file/index.tsx
+++ b/src/components/input/file/index.tsx
@@ -37,6 +37,8 @@ export class SmoothlyInputFile implements Clearable, Input {
 		return (
 			<Host
 				class={{ dragging: this.dragging }}
+				tabindex={0}
+				onClick={() => this.input?.click()}
 				onDragOver={(event: Event) => (event.preventDefault(), event.stopPropagation())}
 				onDragEnter={() => (this.dragging = true)}>
 				<label>

--- a/src/components/input/shared.css
+++ b/src/components/input/shared.css
@@ -13,3 +13,16 @@
 :host[looks="grid"] {
 	border: rgba(var(--text-color, var(--smoothly-color-contrast)), .5) solid .5px;
 }
+:host[looks="transparent"] {
+	border: none;
+}
+:host[looks="transparent"]:not(:focus-within) {
+	background-color: transparent;
+}
+:host[looks="transparent"]:not(:focus-within) input {
+	background: transparent;
+}
+:host[looks="transparent"]:focus-within {
+	outline: 1px solid rgb(var(--smoothly-color-contrast));
+
+}

--- a/src/components/picker/index.tsx
+++ b/src/components/picker/index.tsx
@@ -93,7 +93,7 @@ export class SmoothlyPicker implements Clearable, Input {
 	}
 	render() {
 		return (
-			<Host>
+			<Host tabindex={0}>
 				<smoothly-slot-elements class={"selected"} nodes={this.display} />
 				<span class={"label"}>
 					<slot name={"label"} />

--- a/src/components/picker/style.css
+++ b/src/components/picker/style.css
@@ -31,6 +31,8 @@ smoothly-slot-elements {
 	bottom: 0;
 	right: 0;
 	width: 2ch;
+}
+:host:not([looks=transparent]) .selected::after {
 	background: linear-gradient(90deg, rgba(var(--background-color, var(--smoothly-color-shade)), 0) 0%, rgba(var(--background-color, var(--smoothly-color-shade)), 1) 100%);
 }
 .selected * {


### PR DESCRIPTION
Additions
* added a new transparent input to input looks

Fixes
* fixed some tabbing issues to get focus to work better on inputs supporting transparent look
* some inputs did not pass their look down to their child input. now they do.

Some screenshots but make sure to also check top of input room in the CF pages build.
* ![image](https://github.com/utily/smoothly/assets/25643315/c8bb1545-2360-43e2-92d2-d7b2a631243e)
* ![image](https://github.com/utily/smoothly/assets/25643315/93f9aa31-de56-47a9-bdfb-2eb438a3925a)
* ![image](https://github.com/utily/smoothly/assets/25643315/a6ca58a3-db01-4441-a298-bc85be3fb17b)
* ![image](https://github.com/utily/smoothly/assets/25643315/6ad46494-3a77-4da7-850d-86e1309921cd)
* ![image](https://github.com/utily/smoothly/assets/25643315/0d322399-3bf5-4f4b-92a0-dbb6a0912563)
* ![image](https://github.com/utily/smoothly/assets/25643315/d80f5c47-f13c-43a4-ad4f-8a637e23a575)
