### PR TITLE
Rangepicker: step can now be added as prop

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -272,6 +272,7 @@ export namespace Components {
         "max": number;
         "min": number;
         "name": string;
+        "step": number | "any";
         "value": number;
     }
     interface SmoothlyInputSelect {
@@ -1509,6 +1510,7 @@ declare namespace LocalJSX {
         "min"?: number;
         "name"?: string;
         "onSmoothlyInput"?: (event: SmoothlyInputRangeCustomEvent<Record<string, any>>) => void;
+        "step"?: number | "any";
         "value"?: number;
     }
     interface SmoothlyInputSelect {

--- a/src/components/input/demo/index.tsx
+++ b/src/components/input/demo/index.tsx
@@ -19,7 +19,7 @@ export class SmoothlyInputDemo {
 			<Host>
 				<h2>Range</h2>
 				<smoothly-form>
-					<smoothly-input-range step={10}>
+					<smoothly-input-range step={1}>
 						<div slot="label">Select number in range</div>
 					</smoothly-input-range>
 				</smoothly-form>

--- a/src/components/input/demo/index.tsx
+++ b/src/components/input/demo/index.tsx
@@ -19,7 +19,7 @@ export class SmoothlyInputDemo {
 			<Host>
 				<h2>Range</h2>
 				<smoothly-form>
-					<smoothly-input-range labelText="Hej">
+					<smoothly-input-range step={10}>
 						<div slot="label">Select number in range</div>
 					</smoothly-input-range>
 				</smoothly-form>

--- a/src/components/input/range/index.tsx
+++ b/src/components/input/range/index.tsx
@@ -17,6 +17,10 @@ export class SmoothlyInputRange {
 	valueChanged(): void {
 		this.smoothlyInput.emit({ [this.name]: this.value })
 	}
+	inputHandler(e: Event): void {
+		e.target instanceof HTMLInputElement &&
+			(this.value = this.step !== "any" ? e.target.valueAsNumber : Math.round(e.target.valueAsNumber * 100) / 100)
+	}
 
 	render() {
 		return (
@@ -34,9 +38,7 @@ export class SmoothlyInputRange {
 					min={this.min}
 					max={this.max}
 					step={this.step}
-					onInput={e =>
-						e.target instanceof HTMLInputElement && (this.value = Math.trunc(e.target.valueAsNumber * 100) / 100)
-					}
+					onInput={e => this.inputHandler(e)}
 					value={this.value}
 				/>
 				<p class="min">{this.min}</p>

--- a/src/components/input/range/index.tsx
+++ b/src/components/input/range/index.tsx
@@ -8,9 +8,10 @@ import { Component, Event, EventEmitter, h, Host, Prop, Watch } from "@stencil/c
 export class SmoothlyInputRange {
 	@Prop({ mutable: true }) value = 0
 	@Prop() min = 0
-	@Prop() max = 1
+	@Prop() max = 100
 	@Prop() name: string
 	@Prop() labelText?: string
+	@Prop() step: number | "any" = "any"
 	@Event() smoothlyInput: EventEmitter<Record<string, any>>
 	@Watch("value")
 	valueChanged(): void {
@@ -32,8 +33,10 @@ export class SmoothlyInputRange {
 					type="range"
 					min={this.min}
 					max={this.max}
-					step={"any"}
-					onInput={e => e.target instanceof HTMLInputElement && (this.value = Number.parseFloat(e.target.value))}
+					step={this.step}
+					onInput={e =>
+						e.target instanceof HTMLInputElement && (this.value = Math.trunc(e.target.valueAsNumber * 100) / 100)
+					}
 					value={this.value}
 				/>
 				<p class="min">{this.min}</p>

--- a/src/components/input/range/style.css
+++ b/src/components/input/range/style.css
@@ -1,4 +1,4 @@
- :host {
+:host {
 	display: flex;
 	position: relative;
 	flex-wrap: wrap;
@@ -13,7 +13,7 @@
 	height: 2em;
 }
 
-:host output{
+:host output {
 	position: absolute;
 	transform: translateX(-50%);
 	font-weight: 600;
@@ -22,7 +22,7 @@
 }
 
 :host ::slotted(div),
-:host label{
+:host label {
 	margin-bottom: .5em;
 	font-size: 1.5em;
 }

--- a/src/components/input/range/style.css
+++ b/src/components/input/range/style.css
@@ -1,18 +1,18 @@
-:host {
+ :host {
 	display: flex;
 	position: relative;
-	
 	flex-wrap: wrap;
 	width: 100%;
 	justify-content: space-between;
 }
 
 :host .output-container {
-	width: 98%;
-	margin: auto;
+	width: 100%;
+	margin: 0 1.2em;
 	position: relative;
 	height: 2em;
 }
+
 :host output{
 	position: absolute;
 	transform: translateX(-50%);
@@ -21,13 +21,11 @@
 	left: var(--left-adjustment, 0);
 }
 
-
 :host ::slotted(div),
 :host label{
-	margin-bottom: 1.5em;
+	margin-bottom: .5em;
 	font-size: 1.5em;
 }
-
 
 /*--------------------Reset browserspecific CSS------------------ */
 input[type=range] {
@@ -35,7 +33,6 @@ input[type=range] {
   width: 100%; /* Specific width is required for Firefox. */
   background: transparent; /* Otherwise white in Chrome */
 	height: 3em;
-	
 }
 
 /*--------------------THUMB------------------ */
@@ -63,7 +60,7 @@ input[type=range]::-moz-range-thumb {
 
 /*--------------------SLIDER TRACK------------------ */
 input[type=range]::-webkit-slider-runnable-track {
-	padding: 0 7px;
+	padding: 0 .6em;
   height: 100%;
   cursor: pointer;
 	background-color: rgb(var(--smoothly-primary-tint));
@@ -71,7 +68,7 @@ input[type=range]::-webkit-slider-runnable-track {
 }
 
 input[type=range]::-moz-range-track {
-  width: 101%;
+  width: calc(100% + 1em);
   height: 3em;
   cursor: pointer;
   background-color: rgb(var(--smoothly-primary-tint));
@@ -80,7 +77,7 @@ input[type=range]::-moz-range-track {
 
 .min, .max {
 	display: inline-block;
-	margin: 0.5em;
+	margin: 0.5em .8em;
 }
 
 .max {


### PR DESCRIPTION
This commit includes: 
- small changes in css for better responsiveness and empty line removals
- step to be passed down as prop
- returning value with 2 decimals (when in "any" mode that returns a whole lotta decimals)