### PR TITLE
Handle paste as one smoothlyInput event

### DIFF
--- a/src/components/input/index.tsx
+++ b/src/components/input/index.tsx
@@ -215,8 +215,7 @@ export class SmoothlyInput implements Changeable, Clearable, Input {
 		let pasted = event.clipboardData ? event.clipboardData.getData("text") : ""
 		const backend = event.target as HTMLInputElement
 		pasted = this.expiresAutocompleteFix(backend, pasted)
-		for (const letter of pasted)
-			this.processKey({ key: letter }, backend)
+		this.processPaste(pasted, backend)
 	}
 	onInput(event: InputEvent) {
 		if (event.inputType == "insertReplacementText") {
@@ -244,6 +243,12 @@ export class SmoothlyInput implements Changeable, Clearable, Input {
 				? value.substring(0, 2) + value.substring(value.length - 2, value.length)
 				: value
 		return value
+	}
+	private processPaste(pasted: string, backend: HTMLInputElement) {
+		if (!this.readonly) {
+			const after = Action.paste(this.formatter, this.state, pasted)
+			this.updateBackend(after, backend)
+		}
 	}
 	private processKey(event: Action, backend: HTMLInputElement) {
 		if (!this.readonly) {


### PR DESCRIPTION

Before event worked by adding an event for each new character.
With this change - the paste event will trigger one `smoothlyInput` event.

I added this change was added to smoothly0 long ago, but never added it to smoothly1.
- https://github.com/utily/smoothly/pull/453


## Before
![image](https://github.com/utily/smoothly/assets/14332757/78d6ee34-3ab9-4c94-b235-5984c243f747)


## After
![image](https://github.com/utily/smoothly/assets/14332757/db22f942-92cc-49e6-973d-bb60a676105a)
