### PR TITLE
smoothly input fix - set lastValue on componentWillLoad

### DIFF
--- a/src/components/input/index.tsx
+++ b/src/components/input/index.tsx
@@ -72,6 +72,7 @@ export class SmoothlyInput {
 	}
 	componentWillLoad() {
 		const value = this.formatter.toString(this.value) || ""
+		this.lastValue = this.value
 		const start = value.length
 		this.state = this.newState({
 			value,


### PR DESCRIPTION
Without this a bug can occur when `value` prop is set on start, but clearing it won't work, because it will compare 
`this.lastValue != value` and since `lastValue` was never set on start it won't clear the field.