### PR TITLE
Set input changed on start

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -194,7 +194,6 @@ export namespace Components {
     }
     interface SmoothlyInput {
         "autocomplete": boolean;
-        "changed": boolean;
         "clear": () => Promise<void>;
         "color"?: Color;
         "currency"?: Currency;
@@ -1426,7 +1425,6 @@ declare namespace LocalJSX {
     }
     interface SmoothlyInput {
         "autocomplete"?: boolean;
-        "changed"?: boolean;
         "color"?: Color;
         "currency"?: Currency;
         "disabled"?: boolean;

--- a/src/components/input/demo/index.tsx
+++ b/src/components/input/demo/index.tsx
@@ -100,8 +100,10 @@ export class SmoothlyInputDemo {
 
 				<h4>Clear</h4>
 				<smoothly-form looks="border">
-					<smoothly-input name="First Name">First name</smoothly-input>
-					<smoothly-input name="Last name">
+					<smoothly-input name="First Name" value="John">
+						First name
+					</smoothly-input>
+					<smoothly-input name="Last name" value="Doe">
 						Last name
 						<smoothly-input-clear slot="end">
 							<smoothly-icon name="close" />

--- a/src/components/input/index.tsx
+++ b/src/components/input/index.tsx
@@ -276,6 +276,7 @@ export class SmoothlyInput implements Changeable, Clearable, Input {
 		return (
 			<Host
 				class={{ "has-value": this.state?.value != undefined && this.state?.value != "" }}
+				changed={this.changed}
 				onclick={() => this.inputElement?.focus()}>
 				<slot name="start"></slot>
 				<div>

--- a/src/components/input/index.tsx
+++ b/src/components/input/index.tsx
@@ -37,7 +37,7 @@ export class SmoothlyInput implements Changeable, Clearable, Input {
 	@State() initialValue?: any
 	@Event() smoothlyInputLooks: EventEmitter<(looks: Looks, color: Color) => void>
 
-	@Prop({ mutable: true, reflect: true }) changed = false
+	@State() changed = false
 	private listener: { changed?: (parent: Changeable) => Promise<void> } = {}
 
 	listen(property: "changed", listener: (parent: Changeable) => Promise<void>): void {
@@ -100,12 +100,15 @@ export class SmoothlyInput implements Changeable, Clearable, Input {
 	componentWillLoad() {
 		this.typeChange()
 		const value = this.formatter.toString(this.value) || ""
+		this.lastValue = this.value
 		const start = value.length
 		this.state = this.newState({
 			value,
 			selection: { start, end: start, direction: "none" },
 		})
 		this.smoothlyInputLooks.emit((looks, color) => ((this.looks = looks), !this.color && (this.color = color)))
+		this.changed = Boolean(this.value)
+		this.listener.changed?.(this)
 	}
 	componentDidRender() {
 		if (this.keepFocusOnReRender) {


### PR DESCRIPTION
Make initial value be clearable for `smoothly-input-clear`
Also change `smoothly-input.changed` from Prop to State. - I could no find any styling based on changed.

## Before

[Screencast from 2024-03-14 15:40:59.webm](https://github.com/utily/smoothly/assets/14332757/600a6fd3-4a72-4a34-9356-7ade1fa57ce5)


## After

[Screencast from 2024-03-14 16:04:59.webm](https://github.com/utily/smoothly/assets/14332757/0e2b6f91-419d-4b78-a38d-7a5e7035300f)
