### PR TITLE
radiobutton: fix for clear-symbol-button inside the input

### DIFF
--- a/src/components/input/demo/index.tsx
+++ b/src/components/input/demo/index.tsx
@@ -335,14 +335,14 @@ export class SmoothlyInputDemo {
 						<smoothly-input-radio-item slot="options" value={"third"}>
 							Label 3
 						</smoothly-input-radio-item>
-						<smoothly-input-radio-item slot="options" value={"third"}>
-							Label 3
+						<smoothly-input-radio-item slot="options" value={"fourth"}>
+							Label 4
 						</smoothly-input-radio-item>
-						<smoothly-input-radio-item slot="options" value={"third"}>
-							Label 3
+						<smoothly-input-radio-item slot="options" value={"fifth"}>
+							Label 5
 						</smoothly-input-radio-item>
-						<smoothly-input-radio-item slot="options" value={"third"}>
-							Label 3
+						<smoothly-input-radio-item slot="options" value={"sixth"}>
+							Label 6
 						</smoothly-input-radio-item>
 					</smoothly-input-radio>
 				</smoothly-form>

--- a/src/components/input/radio/index.tsx
+++ b/src/components/input/radio/index.tsx
@@ -46,6 +46,13 @@ export class SmoothlyInputRadio implements Input, Clearable, ComponentWillLoad {
 		event.stopPropagation()
 		event.detail(this.name)
 	}
+	@Listen("smoothlyInputLoad")
+	SmoothlyInputLoadHandler(event: CustomEvent<(parent: SmoothlyInputRadio) => void>): void {
+		if (!(event.target && "name" in event.target && event.target.name === this.name)) {
+			event.stopPropagation()
+			event.detail(this)
+		}
+	}
 	@Listen("smoothlySelect")
 	smoothlyRadioInputHandler(event: CustomEvent<Selectable>): void {
 		event.stopPropagation()


### PR DESCRIPTION
this fix stops the entire form from being cleared if a clear-symbol-button within the input is clicked
also, the demo wasnt working cause some of the radiobuttons had the same value (copy paste, copy paste, copy paste) but thats fixed now