### PR TITLE
checkbox: fix for clear-symbol-button inside the input

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -218,7 +218,7 @@ export namespace Components {
         "disabled": boolean;
         "looks": Looks;
         "name": string;
-        "value": any;
+        "value": Data[string];
     }
     interface SmoothlyInputClear {
         "color"?: Color;
@@ -1461,10 +1461,10 @@ declare namespace LocalJSX {
         "disabled"?: boolean;
         "looks"?: Looks;
         "name"?: string;
-        "onSmoothlyInput"?: (event: SmoothlyInputCheckboxCustomEvent<Record<string, any>>) => void;
+        "onSmoothlyInput"?: (event: SmoothlyInputCheckboxCustomEvent<Data>) => void;
         "onSmoothlyInputLoad"?: (event: SmoothlyInputCheckboxCustomEvent<(parent: HTMLElement) => void>) => void;
         "onSmoothlyInputLooks"?: (event: SmoothlyInputCheckboxCustomEvent<(looks: Looks, color: Color) => void>) => void;
-        "value"?: any;
+        "value"?: Data[string];
     }
     interface SmoothlyInputClear {
         "color"?: Color;

--- a/src/components/input/range/index.tsx
+++ b/src/components/input/range/index.tsx
@@ -42,7 +42,6 @@ export class SmoothlyInputRange implements Input, Clearable, ComponentWillLoad {
 	}
 	@Listen("smoothlyInputLoad")
 	SmoothlyInputLoadHandler(event: CustomEvent<(parent: SmoothlyInputRange) => void>): void {
-		console.log(event.target)
 		if (!(event.target && "name" in event.target && event.target.name === this.name)) {
 			event.stopPropagation()
 			event.detail(this)

--- a/src/components/input/range/index.tsx
+++ b/src/components/input/range/index.tsx
@@ -1,4 +1,16 @@
-import { Component, ComponentWillLoad, Event, EventEmitter, h, Host, Method, Prop, VNode, Watch } from "@stencil/core"
+import {
+	Component,
+	ComponentWillLoad,
+	Event,
+	EventEmitter,
+	h,
+	Host,
+	Listen,
+	Method,
+	Prop,
+	VNode,
+	Watch,
+} from "@stencil/core"
 import { Color } from "../../../model"
 import { Clearable } from "../Clearable"
 import { Input } from "../Input"
@@ -27,6 +39,14 @@ export class SmoothlyInputRange implements Input, Clearable, ComponentWillLoad {
 		this.smoothlyInputLoad.emit(() => {
 			return
 		})
+	}
+	@Listen("smoothlyInputLoad")
+	SmoothlyInputLoadHandler(event: CustomEvent<(parent: SmoothlyInputRange) => void>): void {
+		console.log(event.target)
+		if (!(event.target && "name" in event.target && event.target.name === this.name)) {
+			event.stopPropagation()
+			event.detail(this)
+		}
 	}
 	@Method()
 	async clear(): Promise<void> {


### PR DESCRIPTION
this fix stops the entire form from being cleared if a clear-symbol-button within the input is clicked

the changes in components.d.ts actullay belongs to a different branch, i missed adding it to that one i guess..