### PR TITLE
Navigate Input-select with keys

### DIFF
--- a/src/components/input/select/index.tsx
+++ b/src/components/input/select/index.tsx
@@ -91,6 +91,8 @@ export class SmoothlyInputSelect implements Input {
 					this.move(1)
 					break
 				case "Escape":
+					if (this.filter == "")
+						this.opened = false
 					this.filter = ""
 					break
 				case "Backspace":
@@ -106,10 +108,6 @@ export class SmoothlyInputSelect implements Input {
 				case "Tab":
 					this.opened = false
 					break
-				case " ":
-					if (!this.filter.length)
-						this.opened = false
-					break
 				default:
 					if (event.key.length == 1)
 						this.filter += event.key
@@ -123,28 +121,35 @@ export class SmoothlyInputSelect implements Input {
 					break
 				case "ArrowDown":
 					this.opened = true
-					this.move(1)
+					this.move(0)
 					break
 				case "ArrowUp":
 					this.opened = true
 					this.move(-1)
 					break
+				case "Tab":
+					break
+				default:
+					this.opened = true
+					if (event.key.length == 1)
+						this.filter += event.key
+					break
 			}
 		}
 	}
 	private move(direction: -1 | 0 | 1): void {
-		if (direction) {
-			let markedIndex = this.items.findIndex(item => item.marked)
-			if (markedIndex == -1)
-				markedIndex = this.items.findIndex(item => item.selected)
-			if (this.items[markedIndex])
-				this.items[markedIndex].marked = false
-			do {
-				markedIndex = (markedIndex + direction + this.items.length) % this.items.length
-			} while (this.items[markedIndex].hidden)
-			this.items[markedIndex].marked = true
-			this.items[markedIndex].focus()
-		}
+		let markedIndex = this.items.findIndex(item => item.marked)
+		if (markedIndex == -1)
+			markedIndex = this.items.findIndex(item => item.selected)
+		if (this.items[markedIndex])
+			this.items[markedIndex].marked = false
+		if (markedIndex == -1)
+			markedIndex = 0
+		do {
+			markedIndex = (markedIndex + direction + this.items.length) % this.items.length
+		} while (this.items[markedIndex].hidden)
+		this.items[markedIndex].marked = true
+		this.items[markedIndex].focus()
 	}
 	render() {
 		return (

--- a/src/components/input/select/index.tsx
+++ b/src/components/input/select/index.tsx
@@ -81,15 +81,14 @@ export class SmoothlyInputSelect implements Input {
 	@Listen("keydown")
 	onKeyDown(event: KeyboardEvent) {
 		event.stopPropagation()
-		event.preventDefault()
+		event.key != "Tab" && event.preventDefault()
 		if (this.opened) {
-			let direction: -1 | 0 | 1 = 0
 			switch (event.key) {
 				case "ArrowUp":
-					direction = -1
+					this.move(-1)
 					break
 				case "ArrowDown":
-					direction = 1
+					this.move(1)
 					break
 				case "Escape":
 					this.filter = ""
@@ -99,20 +98,39 @@ export class SmoothlyInputSelect implements Input {
 					break
 				case "Enter":
 					const result = this.items.find(item => item.marked)
-					if (result?.value) {
+					if (result?.value)
 						result.selected = true
-					}
 					this.opened = false
 					this.filter = ""
+					break
+				case "Tab":
+					this.opened = false
+					break
+				case " ":
+					if (!this.filter.length)
+						this.opened = false
 					break
 				default:
 					if (event.key.length == 1)
 						this.filter += event.key
 					break
 			}
-			this.move(direction)
-		} else if (event.key == "Enter")
-			this.opened = true
+		} else {
+			switch (event.key) {
+				case "Enter":
+				case " ":
+					this.opened = true
+					break
+				case "ArrowDown":
+					this.opened = true
+					this.move(1)
+					break
+				case "ArrowUp":
+					this.opened = true
+					this.move(-1)
+					break
+			}
+		}
 	}
 	private move(direction: -1 | 0 | 1): void {
 		if (direction) {
@@ -130,7 +148,7 @@ export class SmoothlyInputSelect implements Input {
 	}
 	render() {
 		return (
-			<Host tabIndex={2} class={(this.missing ? "missing" : this.type) ?? ""}>
+			<Host tabIndex={0} class={(this.missing ? "missing" : this.type) ?? ""}>
 				<main ref={element => (this.mainElement = element)}>{this.initialPrompt ?? "(none)"}</main>
 				{this.filter.length != 0 ? (
 					<aside ref={element => (this.aside = element)}>

--- a/src/components/input/select/index.tsx
+++ b/src/components/input/select/index.tsx
@@ -81,7 +81,8 @@ export class SmoothlyInputSelect implements Input {
 	@Listen("keydown")
 	onKeyDown(event: KeyboardEvent) {
 		event.stopPropagation()
-		event.key != "Tab" && event.preventDefault()
+		if (event.key != "Tab" && !event.ctrlKey && !event.metaKey)
+			event.preventDefault()
 		if (this.opened) {
 			switch (event.key) {
 				case "ArrowUp":


### PR DESCRIPTION
## Navigate item-select
- Use ArrowUp -Down to navigate 
- Enter to select
- Esc to clear and close
- Space to open

## Tab to and from
- Set `tabIndex` to `0`
  - https://www.tpgi.com/using-the-tabindex-attribute/
  - TL:DR:
    - `tabIndex=0` → element focusable like regular input
    - `tabIndex=-1` (negative) → Exclude from tab order, but keep object programmatically focusable
    - `tabIndex=1+` (positive) → Impose tab order according to tabIndex
- Allow tabbing out
  By not preventing default for Tab: `event.key != "Tab" && event.preventDefault()`
 