### PR TITLE
Set menuHeight on smoothly-input-select

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -321,6 +321,7 @@ export namespace Components {
         "initialPrompt"?: string;
         "initialValue"?: unknown;
         "looks": Looks;
+        "menuHeight"?: `${number}${"items" | "rem" | "px" | "vh"}`;
         "name": string;
         "reset": () => Promise<void>;
         "showSelected"?: boolean;
@@ -1607,6 +1608,7 @@ declare namespace LocalJSX {
         "initialPrompt"?: string;
         "initialValue"?: unknown;
         "looks"?: Looks;
+        "menuHeight"?: `${number}${"items" | "rem" | "px" | "vh"}`;
         "name"?: string;
         "onSmoothlyInput"?: (event: SmoothlyInputSelectCustomEvent<Data>) => void;
         "onSmoothlyInputLooks"?: (event: SmoothlyInputSelectCustomEvent<(looks: Looks, color: Color) => void>) => void;

--- a/src/components/input/demo/index.tsx
+++ b/src/components/input/demo/index.tsx
@@ -475,6 +475,7 @@ export class SmoothlyInputDemo {
 					<smoothly-input-select
 						name="select"
 						initialPrompt="Select..."
+						menuHeight="7.5items"
 						ref={(element: HTMLSmoothlyInputSelectElement) => (this.selectElement = element)}>
 						<smoothly-item value="1">January</smoothly-item>
 						<smoothly-item value="2">February</smoothly-item>

--- a/src/components/input/select/index.tsx
+++ b/src/components/input/select/index.tsx
@@ -189,13 +189,13 @@ export class SmoothlyInputSelect implements Input {
 			}
 		}
 		this.items = items
-		if (this.menuHeight?.endsWith("items") && this.items.length)
+		if (this.menuHeight)
 			this.element?.style.setProperty(
 				"--menu-height",
-				`${this.items[0].clientHeight * +this.menuHeight.replace(/[a-z]/g, "")}px`
+				!this.menuHeight.endsWith("items") || !this.items.length
+					? this.menuHeight
+					: `${this.items[0].clientHeight * +(this.menuHeight.match(/^(\d+(\.\d+)?|\.\d+)/g)?.[0] ?? "10")}px`
 			)
-		else if (this.menuHeight)
-			this.element?.style.setProperty("--menu-height", this.menuHeight)
 	}
 }
 function isItem(value: HTMLSmoothlyItemElement | any): value is HTMLSmoothlyItemElement {

--- a/src/components/input/select/index.tsx
+++ b/src/components/input/select/index.tsx
@@ -16,6 +16,7 @@ export class SmoothlyInputSelect implements Input {
 	@Prop({ reflect: true, mutable: true }) showSelected?: boolean = true
 	@Prop() initialPrompt?: string
 	@Prop() initialValue?: unknown
+	@Prop() menuHeight?: `${number}${"items" | "rem" | "px" | "vh"}`
 	@State() opened = false
 	items: HTMLSmoothlyItemElement[] = []
 	@State() selectedElement?: HTMLSmoothlyItemElement
@@ -188,6 +189,13 @@ export class SmoothlyInputSelect implements Input {
 			}
 		}
 		this.items = items
+		if (this.menuHeight?.endsWith("items") && this.items.length)
+			this.element?.style.setProperty(
+				"--menu-height",
+				`${this.items[0].clientHeight * +this.menuHeight.replace(/[a-z]/g, "")}px`
+			)
+		else if (this.menuHeight)
+			this.element?.style.setProperty("--menu-height", this.menuHeight)
 	}
 }
 function isItem(value: HTMLSmoothlyItemElement | any): value is HTMLSmoothlyItemElement {


### PR DESCRIPTION
Add Prop to set menuHeight
Menu height can be specified with number of items that should be visible, e.g. 
```tsx
<smoothly-input-select menuHeight="6.5items"`>
```
It can also set height in regular css units , like `rem`, `px`, or `vh`.

[Screencast from 2024-04-05 11:59:36.webm](https://github.com/utily/smoothly/assets/14332757/04682162-0540-4863-b1d6-3c880d06e5cf)
