### PR TITLE
Lazy

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -9,6 +9,7 @@ import { SmoothlyAccordion } from "./components/accordion";
 import { address } from "./components/address-display";
 import { address as address1 } from "./components/address-display/index";
 import { Color, Data, Fill, Icon, Message, Notice, Option, Trigger } from "./model";
+import { FunctionalComponent, JSX } from "@stencil/core";
 import { Button } from "./components/Button";
 import { CountryCode, Currency, Date, DateRange, DateTime, isoly } from "isoly";
 import { tidily, Type } from "tidily";
@@ -52,6 +53,7 @@ export namespace Components {
         "baseUrl": string;
     }
     interface SmoothlyAppRoom {
+        "content"?: JSX.Element | FunctionalComponent;
         "disabled": boolean;
         "getContent": () => Promise<HTMLElement | undefined>;
         "icon"?: Icon;
@@ -349,6 +351,14 @@ export namespace Components {
         "hue": number;
         "shape": "rectangle" | "rounded";
     }
+    interface SmoothlyLazy {
+        "content"?: JSX.Element | FunctionalComponent;
+        "show": boolean;
+    }
+    interface SmoothlyLoadMore {
+        "name": string;
+        "offset": string;
+    }
     interface SmoothlyNotification {
         "closable": boolean;
         "icon": boolean;
@@ -619,6 +629,10 @@ export interface SmoothlyInputSubmitCustomEvent<T> extends CustomEvent<T> {
 export interface SmoothlyItemCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLSmoothlyItemElement;
+}
+export interface SmoothlyLoadMoreCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLSmoothlyLoadMoreElement;
 }
 export interface SmoothlyNotificationCustomEvent<T> extends CustomEvent<T> {
     detail: T;
@@ -968,6 +982,18 @@ declare global {
         prototype: HTMLSmoothlyLabelElement;
         new (): HTMLSmoothlyLabelElement;
     };
+    interface HTMLSmoothlyLazyElement extends Components.SmoothlyLazy, HTMLStencilElement {
+    }
+    var HTMLSmoothlyLazyElement: {
+        prototype: HTMLSmoothlyLazyElement;
+        new (): HTMLSmoothlyLazyElement;
+    };
+    interface HTMLSmoothlyLoadMoreElement extends Components.SmoothlyLoadMore, HTMLStencilElement {
+    }
+    var HTMLSmoothlyLoadMoreElement: {
+        prototype: HTMLSmoothlyLoadMoreElement;
+        new (): HTMLSmoothlyLoadMoreElement;
+    };
     interface HTMLSmoothlyNotificationElement extends Components.SmoothlyNotification, HTMLStencilElement {
     }
     var HTMLSmoothlyNotificationElement: {
@@ -1255,6 +1281,8 @@ declare global {
         "smoothly-input-submit": HTMLSmoothlyInputSubmitElement;
         "smoothly-item": HTMLSmoothlyItemElement;
         "smoothly-label": HTMLSmoothlyLabelElement;
+        "smoothly-lazy": HTMLSmoothlyLazyElement;
+        "smoothly-load-more": HTMLSmoothlyLoadMoreElement;
         "smoothly-notification": HTMLSmoothlyNotificationElement;
         "smoothly-notifier": HTMLSmoothlyNotifierElement;
         "smoothly-picker": HTMLSmoothlyPickerElement;
@@ -1330,6 +1358,7 @@ declare namespace LocalJSX {
         "baseUrl"?: string;
     }
     interface SmoothlyAppRoom {
+        "content"?: JSX.Element | FunctionalComponent;
         "disabled"?: boolean;
         "icon"?: Icon;
         "label"?: string;
@@ -1656,6 +1685,15 @@ declare namespace LocalJSX {
         "hue"?: number;
         "shape"?: "rectangle" | "rounded";
     }
+    interface SmoothlyLazy {
+        "content"?: JSX.Element | FunctionalComponent;
+        "show"?: boolean;
+    }
+    interface SmoothlyLoadMore {
+        "name"?: string;
+        "offset"?: string;
+        "onSmoothlyLoadMore"?: (event: SmoothlyLoadMoreCustomEvent<string>) => void;
+    }
     interface SmoothlyNotification {
         "closable"?: boolean;
         "icon"?: boolean;
@@ -1903,6 +1941,8 @@ declare namespace LocalJSX {
         "smoothly-input-submit": SmoothlyInputSubmit;
         "smoothly-item": SmoothlyItem;
         "smoothly-label": SmoothlyLabel;
+        "smoothly-lazy": SmoothlyLazy;
+        "smoothly-load-more": SmoothlyLoadMore;
         "smoothly-notification": SmoothlyNotification;
         "smoothly-notifier": SmoothlyNotifier;
         "smoothly-picker": SmoothlyPicker;
@@ -1998,6 +2038,8 @@ declare module "@stencil/core" {
             "smoothly-input-submit": LocalJSX.SmoothlyInputSubmit & JSXBase.HTMLAttributes<HTMLSmoothlyInputSubmitElement>;
             "smoothly-item": LocalJSX.SmoothlyItem & JSXBase.HTMLAttributes<HTMLSmoothlyItemElement>;
             "smoothly-label": LocalJSX.SmoothlyLabel & JSXBase.HTMLAttributes<HTMLSmoothlyLabelElement>;
+            "smoothly-lazy": LocalJSX.SmoothlyLazy & JSXBase.HTMLAttributes<HTMLSmoothlyLazyElement>;
+            "smoothly-load-more": LocalJSX.SmoothlyLoadMore & JSXBase.HTMLAttributes<HTMLSmoothlyLoadMoreElement>;
             "smoothly-notification": LocalJSX.SmoothlyNotification & JSXBase.HTMLAttributes<HTMLSmoothlyNotificationElement>;
             "smoothly-notifier": LocalJSX.SmoothlyNotifier & JSXBase.HTMLAttributes<HTMLSmoothlyNotifierElement>;
             "smoothly-picker": LocalJSX.SmoothlyPicker & JSXBase.HTMLAttributes<HTMLSmoothlyPickerElement>;

--- a/src/components/app-demo/index.tsx
+++ b/src/components/app-demo/index.tsx
@@ -81,9 +81,7 @@ export class SmoothlyAppDemo {
 				<smoothly-app-room path="/select" label="Select">
 					<smoothly-select-demo />
 				</smoothly-app-room>
-				<smoothly-app-room path="/icon" label="Icon">
-					<smoothly-icon-demo />
-				</smoothly-app-room>
+				<smoothly-app-room path="/icon" label="Icon" content={<smoothly-icon-demo />}></smoothly-app-room>
 				<smoothly-app-room path="/old" label="Old" to="select"></smoothly-app-room>
 				<smoothly-app-room path="/redirect" label="Redirect">
 					<smoothly-button type="link" link="/input">

--- a/src/components/app/room/index.tsx
+++ b/src/components/app/room/index.tsx
@@ -1,4 +1,4 @@
-import { Component, Event, EventEmitter, h, Host, Method, Prop } from "@stencil/core"
+import { Component, Event, EventEmitter, FunctionalComponent, h, Host, JSX, Method, Prop } from "@stencil/core"
 import "urlpattern-polyfill"
 import { Icon } from "../../../model"
 
@@ -14,6 +14,7 @@ export class SmoothlyAppRoom {
 	@Prop() path: string | URLPattern = ""
 	@Prop() to?: string
 	@Prop({ reflect: true, mutable: true }) selected?: boolean
+	@Prop() content?: JSX.Element | FunctionalComponent
 	@Event() smoothlyRoomSelected: EventEmitter<{ history: boolean }>
 	@Event() smoothlyRoomLoaded: EventEmitter<{ selected: boolean }>
 	private contentElement?: HTMLElement
@@ -52,6 +53,7 @@ export class SmoothlyAppRoom {
 					</a>
 				</li>
 				<main ref={e => (this.contentElement = e)}>
+					{this.content && <smoothly-lazy content={this.content} />}
 					<slot></slot>
 				</main>
 			</Host>

--- a/src/components/lazy/index.tsx
+++ b/src/components/lazy/index.tsx
@@ -1,4 +1,4 @@
-import { Component, FunctionalComponent, h, Host, JSX, Prop } from "@stencil/core"
+import { Component, FunctionalComponent, h, Host, JSX, Prop, VNode } from "@stencil/core"
 
 @Component({
 	tag: "smoothly-lazy",
@@ -8,18 +8,19 @@ import { Component, FunctionalComponent, h, Host, JSX, Prop } from "@stencil/cor
 export class SmoothlyLazy {
 	@Prop({ mutable: true }) show = false
 	@Prop() content?: JSX.Element | FunctionalComponent
-	render() {
+
+	loadMoreHandler(event: CustomEvent<string>): void {
+		event.stopPropagation()
+		this.show = true
+	}
+
+	render(): VNode | VNode[] {
 		return (
 			<Host>
-				<slot name="before"></slot>
-				<smoothly-load-more
-					onSmoothlyLoadMore={e => {
-						this.show = true
-						e.stopPropagation()
-					}}
-				/>
+				<slot name="before" />
+				<smoothly-load-more onSmoothlyLoadMore={e => this.loadMoreHandler(e)} />
 				{this.show && (typeof this.content == "function" ? <this.content /> : this.content)}
-				<slot></slot>
+				<slot />
 			</Host>
 		)
 	}

--- a/src/components/lazy/index.tsx
+++ b/src/components/lazy/index.tsx
@@ -6,13 +6,19 @@ import { Component, FunctionalComponent, h, Host, JSX, Prop } from "@stencil/cor
 	scoped: true,
 })
 export class SmoothlyLazy {
-	@Prop() hide = false
+	@Prop({ mutable: true }) show = false
 	@Prop() content?: JSX.Element | FunctionalComponent
 	render() {
 		return (
 			<Host>
 				<slot name="before"></slot>
-				{!this.hide && (typeof this.content == "function" ? <this.content /> : this.content)}
+				<smoothly-load-more
+					onSmoothlyLoadMore={e => {
+						this.show = true
+						e.stopPropagation()
+					}}
+				/>
+				{this.show && (typeof this.content == "function" ? <this.content /> : this.content)}
 				<slot></slot>
 			</Host>
 		)

--- a/src/components/lazy/index.tsx
+++ b/src/components/lazy/index.tsx
@@ -1,0 +1,20 @@
+import { Component, FunctionalComponent, h, Host, JSX, Prop } from "@stencil/core"
+
+@Component({
+	tag: "smoothly-lazy",
+	styleUrl: "style.css",
+	scoped: true,
+})
+export class SmoothlyLazy {
+	@Prop() hide = false
+	@Prop() content?: JSX.Element | FunctionalComponent
+	render() {
+		return (
+			<Host>
+				<slot name="before"></slot>
+				{!this.hide && (typeof this.content == "function" ? <this.content /> : this.content)}
+				<slot></slot>
+			</Host>
+		)
+	}
+}

--- a/src/components/lazy/style.css
+++ b/src/components/lazy/style.css
@@ -1,0 +1,3 @@
+:host {
+	display: block;
+}

--- a/src/components/load-more/index.tsx
+++ b/src/components/load-more/index.tsx
@@ -1,0 +1,29 @@
+import { Component, Element, Event, EventEmitter, h, Host, Prop } from "@stencil/core"
+
+@Component({
+	tag: "smoothly-load-more",
+	styleUrl: "style.css",
+	scoped: true,
+})
+export class LoadMore {
+	@Prop() offset = "0"
+	@Prop() name = ""
+	@Event() smoothlyLoadMore: EventEmitter<string>
+	@Element() element: HTMLSmoothlyLoadMoreElement
+	observer?: IntersectionObserver // possibly keep reference for GC
+	componentDidLoad() {
+		this.observer = new IntersectionObserver(
+			entries => {
+				if (entries.find(entry => entry.target == this.element)?.intersectionRatio ?? 0)
+					this.smoothlyLoadMore.emit(this.name)
+			},
+			{
+				threshold: 0,
+			}
+		)
+		this.observer.observe(this.element)
+	}
+	render() {
+		return <Host style={{ position: "relative", top: this.offset }}></Host>
+	}
+}

--- a/src/components/load-more/index.tsx
+++ b/src/components/load-more/index.tsx
@@ -27,6 +27,6 @@ export class LoadMore implements ComponentWillLoad {
 	}
 
 	render(): VNode | VNode[] {
-		return <Host style={{ position: "relative", top: this.offset }} />
+		return <Host style={{ "--offset": `${this.offset}` }} />
 	}
 }

--- a/src/components/load-more/style.css
+++ b/src/components/load-more/style.css
@@ -1,0 +1,3 @@
+:host {
+	display: block;
+}

--- a/src/components/load-more/style.css
+++ b/src/components/load-more/style.css
@@ -1,3 +1,5 @@
 :host {
 	display: block;
+	position: relative;
+	top: var(--offset,)
 }

--- a/src/components/table/demo/index.tsx
+++ b/src/components/table/demo/index.tsx
@@ -315,9 +315,9 @@ export class TableDemo {
 						<smoothly-table-cell>Pax2Pay</smoothly-table-cell>
 						<smoothly-lazy
 							slot={"detail"}
-							content={
+							content={() => (
 								<img src={"https://dash.pax2pay.app/assets/pax2pay-dark-horizontal.svg"} alt={"Pax2Pay Logotype."} />
-							}
+							)}
 						/>
 					</smoothly-table-expandable-row>
 				</smoothly-table>
@@ -340,9 +340,9 @@ export class TableDemo {
 							Pax2Pay
 							<smoothly-lazy
 								slot={"detail"}
-								content={
+								content={() => (
 									<img src={"https://dash.pax2pay.app/assets/pax2pay-dark-horizontal.svg"} alt={"Pax2Pay Logotype."} />
-								}
+								)}
 							/>
 						</smoothly-table-expandable-cell>
 					</smoothly-table-row>

--- a/src/components/table/demo/index.tsx
+++ b/src/components/table/demo/index.tsx
@@ -1,4 +1,4 @@
-import { Component, h } from "@stencil/core"
+import { Component, h, Host } from "@stencil/core"
 
 @Component({
 	tag: "smoothly-table-demo",
@@ -7,189 +7,229 @@ import { Component, h } from "@stencil/core"
 })
 export class TableDemo {
 	render() {
-		return [
-			<h4>Demo table 1: Filtered & Checked Table</h4>,
-			<smoothly-lazy content={<smoothly-table-demo-filtered />} />,
-			<h4>Demo table 2</h4>,
-			<smoothly-table-testing></smoothly-table-testing>,
-			<h4>Demo table 3</h4>,
-			<smoothly-table>
-				<smoothly-table-row>
-					<smoothly-table-header>Header A</smoothly-table-header>
-					<smoothly-table-header>Header B</smoothly-table-header>
-					<smoothly-table-header>Header C</smoothly-table-header>
-					<smoothly-table-header>Header D</smoothly-table-header>
-				</smoothly-table-row>
-				<smoothly-table-row>
-					<smoothly-table-expandable-cell>
-						normal row (exp.cell)
-						<div slot="detail">expandable cell 1 content</div>
-					</smoothly-table-expandable-cell>
-					<smoothly-table-expandable-cell>
-						expandable cell
-						<div slot="detail">expandable cell 2 content</div>
-					</smoothly-table-expandable-cell>
-					<smoothly-table-expandable-cell>
-						expandable cell
-						<div slot="detail">expandable cell 3 content</div>
-					</smoothly-table-expandable-cell>
-					<smoothly-table-expandable-cell>
-						expandable cell
-						<div slot="detail">expandable cell 4 content</div>
-					</smoothly-table-expandable-cell>
-				</smoothly-table-row>
-
-				<smoothly-table-row>
-					<smoothly-table-cell>normal row (nor.cell)"</smoothly-table-cell>
-					<smoothly-table-cell>normal cell</smoothly-table-cell>
-					<smoothly-table-expandable-cell>
-						expandable cell
-						<div slot="detail">expandable cell details.</div>
-					</smoothly-table-expandable-cell>
-					<smoothly-table-expandable-cell>
-						expandable cell
-						<div slot="detail">expandable cell details.</div>
-					</smoothly-table-expandable-cell>
-				</smoothly-table-row>
-
-				<smoothly-table-expandable-row>
-					<smoothly-table-cell>expandable row (nor.cell)</smoothly-table-cell>
-					<smoothly-table-cell>Normal cell</smoothly-table-cell>
-					<smoothly-table-cell>normal cell</smoothly-table-cell>
-					<smoothly-table-cell>Normal cell</smoothly-table-cell>
-					<div slot="detail">expandable row content</div>
-				</smoothly-table-expandable-row>
-			</smoothly-table>,
-			<h4>Demo table 4</h4>,
-			<smoothly-table>
-				<smoothly-table-row>
-					<smoothly-table-header>Header A</smoothly-table-header>
-					<smoothly-table-expandable-cell>
-						Header expansion
-						<div slot="detail">Expansion content</div>
-					</smoothly-table-expandable-cell>
-				</smoothly-table-row>
-				<smoothly-table-expandable-row>
-					<smoothly-table-cell>A Content</smoothly-table-cell>
-					<smoothly-table-cell>Expansion cell</smoothly-table-cell>
-					<div slot="detail">
-						<smoothly-tab-switch>
-							<smoothly-tab label="innertable 1" open={true}>
-								<smoothly-table>
-									<smoothly-table-row>
-										<smoothly-table-header>Header B</smoothly-table-header>
-									</smoothly-table-row>
-									<smoothly-table-expandable-row>B Content</smoothly-table-expandable-row>
-								</smoothly-table>
-							</smoothly-tab>
-							<smoothly-tab label="innertable 2">
-								<smoothly-table>
-									<smoothly-table-row>
-										<smoothly-table-header>Header C</smoothly-table-header>
-									</smoothly-table-row>
-									<smoothly-table-expandable-row>
-										<smoothly-table-cell>C Content</smoothly-table-cell>
-									</smoothly-table-expandable-row>
-								</smoothly-table>
-							</smoothly-tab>
-						</smoothly-tab-switch>
-					</div>
-				</smoothly-table-expandable-row>
-				<smoothly-table-row>
-					<smoothly-table-cell>A Content</smoothly-table-cell>
-					<smoothly-table-expandable-cell>
-						Expandable cell
-						<div slot="detail">Expansion content</div>
-					</smoothly-table-expandable-cell>
-				</smoothly-table-row>
-			</smoothly-table>,
-			<h4>Demo table 5</h4>,
-			<smoothly-table>
-				<smoothly-table-row>
-					<smoothly-table-header>A</smoothly-table-header>
-					<smoothly-table-header>B</smoothly-table-header>
-				</smoothly-table-row>
-				<smoothly-table-expandable-row>
-					<smoothly-table-cell>nested expandable row</smoothly-table-cell>
-					<smoothly-table-cell>b row</smoothly-table-cell>
-					<div slot="detail">
-						<smoothly-table>
-							<smoothly-table-row>
-								<smoothly-table-header>C</smoothly-table-header>
-								<smoothly-table-header>D</smoothly-table-header>
-							</smoothly-table-row>
-							<smoothly-table-expandable-row>
-								<smoothly-table-cell>c</smoothly-table-cell>
-								<smoothly-table-cell>d</smoothly-table-cell>
-								<div slot="detail">
+		return (
+			<Host>
+				<h4>Demo table 1: Filtered & Checked Table</h4> <smoothly-lazy content={<smoothly-table-demo-filtered />} />
+				<h4>Demo table 2</h4> <smoothly-table-testing></smoothly-table-testing> <h4>Demo table 3</h4>
+				<smoothly-table>
+					<smoothly-table-row>
+						<smoothly-table-header>Header A</smoothly-table-header>
+						<smoothly-table-header>Header B</smoothly-table-header>
+						<smoothly-table-header>Header C</smoothly-table-header>
+						<smoothly-table-header>Header D</smoothly-table-header>
+					</smoothly-table-row>
+					<smoothly-table-row>
+						<smoothly-table-expandable-cell>
+							normal row (exp.cell)
+							<div slot="detail">expandable cell 1 content</div>
+						</smoothly-table-expandable-cell>
+						<smoothly-table-expandable-cell>
+							expandable cell
+							<div slot="detail">expandable cell 2 content</div>
+						</smoothly-table-expandable-cell>
+						<smoothly-table-expandable-cell>
+							expandable cell
+							<div slot="detail">expandable cell 3 content</div>
+						</smoothly-table-expandable-cell>
+						<smoothly-table-expandable-cell>
+							expandable cell
+							<div slot="detail">expandable cell 4 content</div>
+						</smoothly-table-expandable-cell>
+					</smoothly-table-row>
+					<smoothly-table-row>
+						<smoothly-table-cell>normal row (nor.cell)"</smoothly-table-cell>
+						<smoothly-table-cell>normal cell</smoothly-table-cell>
+						<smoothly-table-expandable-cell>
+							expandable cell
+							<div slot="detail">expandable cell details.</div>
+						</smoothly-table-expandable-cell>
+						<smoothly-table-expandable-cell>
+							expandable cell
+							<div slot="detail">expandable cell details.</div>
+						</smoothly-table-expandable-cell>
+					</smoothly-table-row>
+					<smoothly-table-expandable-row>
+						<smoothly-table-cell>expandable row (nor.cell)</smoothly-table-cell>
+						<smoothly-table-cell>Normal cell</smoothly-table-cell>
+						<smoothly-table-cell>normal cell</smoothly-table-cell>
+						<smoothly-table-cell>Normal cell</smoothly-table-cell>
+						<div slot="detail">expandable row content</div>
+					</smoothly-table-expandable-row>
+				</smoothly-table>
+				<h4>Demo table 4</h4>
+				<smoothly-table>
+					<smoothly-table-row>
+						<smoothly-table-header>Header A</smoothly-table-header>
+						<smoothly-table-expandable-cell>
+							Header expansion
+							<div slot="detail">Expansion content</div>
+						</smoothly-table-expandable-cell>
+					</smoothly-table-row>
+					<smoothly-table-expandable-row>
+						<smoothly-table-cell>A Content</smoothly-table-cell>
+						<smoothly-table-cell>Expansion cell</smoothly-table-cell>
+						<div slot="detail">
+							<smoothly-tab-switch>
+								<smoothly-tab label="innertable 1" open={true}>
 									<smoothly-table>
 										<smoothly-table-row>
-											<smoothly-table-header>E</smoothly-table-header>
-											<smoothly-table-header>F</smoothly-table-header>
+											<smoothly-table-header>Header B</smoothly-table-header>
+										</smoothly-table-row>
+										<smoothly-table-expandable-row>B Content</smoothly-table-expandable-row>
+									</smoothly-table>
+								</smoothly-tab>
+								<smoothly-tab label="innertable 2">
+									<smoothly-table>
+										<smoothly-table-row>
+											<smoothly-table-header>Header C</smoothly-table-header>
 										</smoothly-table-row>
 										<smoothly-table-expandable-row>
-											<smoothly-table-cell>e row</smoothly-table-cell>
-											<smoothly-table-cell>f row</smoothly-table-cell>
-											<div slot="detail">nested expandable row expansion e f</div>
+											<smoothly-table-cell>C Content</smoothly-table-cell>
 										</smoothly-table-expandable-row>
 									</smoothly-table>
-								</div>
-							</smoothly-table-expandable-row>
-						</smoothly-table>
-					</div>
-				</smoothly-table-expandable-row>
-				<smoothly-table-expandable-row>
-					<smoothly-table-cell>
-						<span>one</span>
-						<span>two</span>
-						<span>three</span>
-					</smoothly-table-cell>
-					<smoothly-table-cell>
-						five<smoothly-icon name="paper-plane-sharp" size="small"></smoothly-icon>
-					</smoothly-table-cell>
-					<div slot="detail">four</div>
-				</smoothly-table-expandable-row>
-				<smoothly-table-row>
-					<smoothly-table-expandable-cell>
-						<span>nested expandable cells</span>
+								</smoothly-tab>
+							</smoothly-tab-switch>
+						</div>
+					</smoothly-table-expandable-row>
+					<smoothly-table-row>
+						<smoothly-table-cell>A Content</smoothly-table-cell>
+						<smoothly-table-expandable-cell>
+							Expandable cell
+							<div slot="detail">Expansion content</div>
+						</smoothly-table-expandable-cell>
+					</smoothly-table-row>
+				</smoothly-table>
+				<h4>Demo table 5</h4>
+				<smoothly-table>
+					<smoothly-table-row>
+						<smoothly-table-header>A</smoothly-table-header>
+						<smoothly-table-header>B</smoothly-table-header>
+					</smoothly-table-row>
+					<smoothly-table-expandable-row>
+						<smoothly-table-cell>nested expandable row</smoothly-table-cell>
+						<smoothly-table-cell>b row</smoothly-table-cell>
 						<div slot="detail">
 							<smoothly-table>
 								<smoothly-table-row>
-									<smoothly-table-header>E</smoothly-table-header>
-									<smoothly-table-header>F</smoothly-table-header>
+									<smoothly-table-header>C</smoothly-table-header>
+									<smoothly-table-header>D</smoothly-table-header>
 								</smoothly-table-row>
-								<smoothly-table-row>
-									<smoothly-table-expandable-cell>
-										e cell
-										<div slot="detail">
-											<smoothly-table>
-												<smoothly-table-row>
-													<smoothly-table-header>G</smoothly-table-header>
-													<smoothly-table-header>H</smoothly-table-header>
-												</smoothly-table-row>
-												<smoothly-table-row>
-													<smoothly-table-expandable-cell>
-														g cell
-														<div slot="detail">nested expandable cell expansion g</div>
-													</smoothly-table-expandable-cell>
-													<smoothly-table-expandable-cell>
-														h cell
-														<div slot="detail">nested expandable cell expansion h</div>
-													</smoothly-table-expandable-cell>
-												</smoothly-table-row>
-											</smoothly-table>
-										</div>
-									</smoothly-table-expandable-cell>
-									<smoothly-table-expandable-cell>
-										f cell
-										<div slot="detail">nested expandable cell expansion f</div>
-									</smoothly-table-expandable-cell>
-								</smoothly-table-row>
+								<smoothly-table-expandable-row>
+									<smoothly-table-cell>c</smoothly-table-cell>
+									<smoothly-table-cell>d</smoothly-table-cell>
+									<div slot="detail">
+										<smoothly-table>
+											<smoothly-table-row>
+												<smoothly-table-header>E</smoothly-table-header>
+												<smoothly-table-header>F</smoothly-table-header>
+											</smoothly-table-row>
+											<smoothly-table-expandable-row>
+												<smoothly-table-cell>e row</smoothly-table-cell>
+												<smoothly-table-cell>f row</smoothly-table-cell>
+												<div slot="detail">nested expandable row expansion e f</div>
+											</smoothly-table-expandable-row>
+										</smoothly-table>
+									</div>
+								</smoothly-table-expandable-row>
 							</smoothly-table>
 						</div>
-					</smoothly-table-expandable-cell>
-					<smoothly-table-expandable-cell>
-						b cell
+					</smoothly-table-expandable-row>
+					<smoothly-table-expandable-row>
+						<smoothly-table-cell>
+							<span>one</span>
+							<span>two</span>
+							<span>three</span>
+						</smoothly-table-cell>
+						<smoothly-table-cell>
+							five<smoothly-icon name="paper-plane-sharp" size="small"></smoothly-icon>
+						</smoothly-table-cell>
+						<div slot="detail">four</div>
+					</smoothly-table-expandable-row>
+					<smoothly-table-row>
+						<smoothly-table-expandable-cell>
+							<span>nested expandable cells</span>
+							<div slot="detail">
+								<smoothly-table>
+									<smoothly-table-row>
+										<smoothly-table-header>E</smoothly-table-header>
+										<smoothly-table-header>F</smoothly-table-header>
+									</smoothly-table-row>
+									<smoothly-table-row>
+										<smoothly-table-expandable-cell>
+											e cell
+											<div slot="detail">
+												<smoothly-table>
+													<smoothly-table-row>
+														<smoothly-table-header>G</smoothly-table-header>
+														<smoothly-table-header>H</smoothly-table-header>
+													</smoothly-table-row>
+													<smoothly-table-row>
+														<smoothly-table-expandable-cell>
+															g cell
+															<div slot="detail">nested expandable cell expansion g</div>
+														</smoothly-table-expandable-cell>
+														<smoothly-table-expandable-cell>
+															h cell
+															<div slot="detail">nested expandable cell expansion h</div>
+														</smoothly-table-expandable-cell>
+													</smoothly-table-row>
+												</smoothly-table>
+											</div>
+										</smoothly-table-expandable-cell>
+										<smoothly-table-expandable-cell>
+											f cell
+											<div slot="detail">nested expandable cell expansion f</div>
+										</smoothly-table-expandable-cell>
+									</smoothly-table-row>
+								</smoothly-table>
+							</div>
+						</smoothly-table-expandable-cell>
+						<smoothly-table-expandable-cell>
+							b cell
+							<div slot="detail">
+								<smoothly-table>
+									<smoothly-table-row>
+										<smoothly-table-header>C</smoothly-table-header>
+										<smoothly-table-header>D</smoothly-table-header>
+									</smoothly-table-row>
+									<smoothly-table-row>
+										<smoothly-table-expandable-cell>
+											c cell
+											<div slot="detail">nested expandable cell expansion c</div>
+										</smoothly-table-expandable-cell>
+										<smoothly-table-expandable-cell>
+											d cell
+											<div slot="detail">nested expandable cell expansion d</div>
+										</smoothly-table-expandable-cell>
+									</smoothly-table-row>
+								</smoothly-table>
+							</div>
+						</smoothly-table-expandable-cell>
+					</smoothly-table-row>
+				</smoothly-table>
+				<h4>Demo table 6</h4>
+				<smoothly-table>
+					<smoothly-table-row>
+						<smoothly-table-header>display</smoothly-table-header>
+						<smoothly-table-header>contents</smoothly-table-header>
+					</smoothly-table-row>
+					<smoothly-table-expandable-row>
+						<div class={"content"}>
+							<smoothly-table-cell>A</smoothly-table-cell>
+							<smoothly-table-cell>B</smoothly-table-cell>
+						</div>
+						<div slot="detail">expansion</div>
+					</smoothly-table-expandable-row>
+				</smoothly-table>
+				<h4>Demo table 7</h4> <span>nested 1 then normal</span>
+				<smoothly-table>
+					<smoothly-table-row>
+						<smoothly-table-header>A</smoothly-table-header>
+						<smoothly-table-header>B</smoothly-table-header>
+					</smoothly-table-row>
+					<smoothly-table-expandable-row>
+						<smoothly-table-cell>a</smoothly-table-cell>
+						<smoothly-table-cell>b</smoothly-table-cell>
 						<div slot="detail">
 							<smoothly-table>
 								<smoothly-table-row>
@@ -197,114 +237,117 @@ export class TableDemo {
 									<smoothly-table-header>D</smoothly-table-header>
 								</smoothly-table-row>
 								<smoothly-table-row>
-									<smoothly-table-expandable-cell>
-										c cell
-										<div slot="detail">nested expandable cell expansion c</div>
-									</smoothly-table-expandable-cell>
-									<smoothly-table-expandable-cell>
-										d cell
-										<div slot="detail">nested expandable cell expansion d</div>
-									</smoothly-table-expandable-cell>
+									<smoothly-table-cell>c</smoothly-table-cell>
+									<smoothly-table-cell>d</smoothly-table-cell>
 								</smoothly-table-row>
+								<smoothly-table-row>
+									<smoothly-table-cell>ccc</smoothly-table-cell>
+									<smoothly-table-cell>ddd</smoothly-table-cell>
+								</smoothly-table-row>
+								<smoothly-table-expandable-row>
+									<smoothly-table-cell>cccc</smoothly-table-cell>
+									<smoothly-table-cell>dddd</smoothly-table-cell>
+									<div slot="detail">CONTENT</div>
+								</smoothly-table-expandable-row>
+								<smoothly-table-row>
+									<smoothly-table-cell>ccccc</smoothly-table-cell>
+									<smoothly-table-cell>ddd</smoothly-table-cell>
+								</smoothly-table-row>
+								<smoothly-table-expandable-row>
+									<smoothly-table-cell>cccc</smoothly-table-cell>
+									<smoothly-table-cell>dddd</smoothly-table-cell>
+									<div slot="detail">CONTENT</div>
+								</smoothly-table-expandable-row>
 							</smoothly-table>
 						</div>
-					</smoothly-table-expandable-cell>
-				</smoothly-table-row>
-			</smoothly-table>,
-			<h4>Demo table 6</h4>,
-			<smoothly-table>
-				<smoothly-table-row>
-					<smoothly-table-header>display</smoothly-table-header>
-					<smoothly-table-header>contents</smoothly-table-header>
-				</smoothly-table-row>
-				<smoothly-table-expandable-row>
-					<div class={"content"}>
-						<smoothly-table-cell>A</smoothly-table-cell>
-						<smoothly-table-cell>B</smoothly-table-cell>
-					</div>
-					<div slot="detail">expansion</div>
-				</smoothly-table-expandable-row>
-			</smoothly-table>,
-			<h4>Demo table 7</h4>,
-			<span>nested 1 then normal</span>,
-			<smoothly-table>
-				<smoothly-table-row>
-					<smoothly-table-header>A</smoothly-table-header>
-					<smoothly-table-header>B</smoothly-table-header>
-				</smoothly-table-row>
-				<smoothly-table-expandable-row>
-					<smoothly-table-cell>a</smoothly-table-cell>
-					<smoothly-table-cell>b</smoothly-table-cell>
-					<div slot="detail">
-						<smoothly-table>
-							<smoothly-table-row>
-								<smoothly-table-header>C</smoothly-table-header>
-								<smoothly-table-header>D</smoothly-table-header>
-							</smoothly-table-row>
-							<smoothly-table-row>
-								<smoothly-table-cell>c</smoothly-table-cell>
-								<smoothly-table-cell>d</smoothly-table-cell>
-							</smoothly-table-row>
-							<smoothly-table-row>
-								<smoothly-table-cell>ccc</smoothly-table-cell>
-								<smoothly-table-cell>ddd</smoothly-table-cell>
-							</smoothly-table-row>
-							<smoothly-table-expandable-row>
-								<smoothly-table-cell>cccc</smoothly-table-cell>
-								<smoothly-table-cell>dddd</smoothly-table-cell>
-								<div slot="detail">CONTENT</div>
-							</smoothly-table-expandable-row>
-							<smoothly-table-row>
-								<smoothly-table-cell>ccccc</smoothly-table-cell>
-								<smoothly-table-cell>ddd</smoothly-table-cell>
-							</smoothly-table-row>
-							<smoothly-table-expandable-row>
-								<smoothly-table-cell>cccc</smoothly-table-cell>
-								<smoothly-table-cell>dddd</smoothly-table-cell>
-								<div slot="detail">CONTENT</div>
-							</smoothly-table-expandable-row>
-						</smoothly-table>
-					</div>
-				</smoothly-table-expandable-row>
-			</smoothly-table>,
-			<h4>Demo table 8</h4>,
-			<span>not nested</span>,
-			<smoothly-table>
-				<smoothly-table-row>
-					<smoothly-table-header>C</smoothly-table-header>
-					<smoothly-table-header>D</smoothly-table-header>
-				</smoothly-table-row>
-				<smoothly-table-row>
-					<smoothly-table-cell>c</smoothly-table-cell>
-					<smoothly-table-cell>d</smoothly-table-cell>
-				</smoothly-table-row>
-				<smoothly-table-row>
-					<smoothly-table-cell>cc</smoothly-table-cell>
-					<smoothly-table-cell>dd</smoothly-table-cell>
-				</smoothly-table-row>
-				<smoothly-table-row>
-					<smoothly-table-cell>ccc</smoothly-table-cell>
-					<smoothly-table-cell>ddd</smoothly-table-cell>
-				</smoothly-table-row>
-			</smoothly-table>,
-			<h4>Demo table 9</h4>,
-			<smoothly-table>
-				<smoothly-table-row>
-					<smoothly-table-header>First name</smoothly-table-header>
-					<smoothly-table-header>Last name</smoothly-table-header>
-					<smoothly-table-header style={{ width: "1px" }}>
-						<smoothly-icon name="alert-outline" />
-					</smoothly-table-header>
-				</smoothly-table-row>
-				<smoothly-table-expandable-row>
-					<smoothly-table-cell>Jessie</smoothly-table-cell>
-					<smoothly-table-cell>Doe</smoothly-table-cell>
-					<smoothly-table-cell></smoothly-table-cell>
-					<div slot="detail">
-						<p>This is Jessie</p>
-					</div>
-				</smoothly-table-expandable-row>
-			</smoothly-table>,
-		]
+					</smoothly-table-expandable-row>
+				</smoothly-table>
+				<h4>Demo table 8</h4> <span>not nested</span>
+				<smoothly-table>
+					<smoothly-table-row>
+						<smoothly-table-header>C</smoothly-table-header>
+						<smoothly-table-header>D</smoothly-table-header>
+					</smoothly-table-row>
+					<smoothly-table-row>
+						<smoothly-table-cell>c</smoothly-table-cell>
+						<smoothly-table-cell>d</smoothly-table-cell>
+					</smoothly-table-row>
+					<smoothly-table-row>
+						<smoothly-table-cell>cc</smoothly-table-cell>
+						<smoothly-table-cell>dd</smoothly-table-cell>
+					</smoothly-table-row>
+					<smoothly-table-row>
+						<smoothly-table-cell>ccc</smoothly-table-cell>
+						<smoothly-table-cell>ddd</smoothly-table-cell>
+					</smoothly-table-row>
+				</smoothly-table>
+				<h4>Demo table 9</h4>
+				<smoothly-table>
+					<smoothly-table-row>
+						<smoothly-table-header>First name</smoothly-table-header>
+						<smoothly-table-header>Last name</smoothly-table-header>
+						<smoothly-table-header style={{ width: "1px" }}>
+							<smoothly-icon name="alert-outline" />
+						</smoothly-table-header>
+					</smoothly-table-row>
+					<smoothly-table-expandable-row>
+						<smoothly-table-cell>Jessie</smoothly-table-cell>
+						<smoothly-table-cell>Doe</smoothly-table-cell>
+						<smoothly-table-cell></smoothly-table-cell>
+						<div slot="detail">
+							<p>This is Jessie</p>
+						</div>
+					</smoothly-table-expandable-row>
+				</smoothly-table>
+				<h4>Demo table 9 - Lazy expansion rows</h4>
+				<smoothly-table>
+					<smoothly-table-row>
+						<smoothly-table-header>Company</smoothly-table-header>
+					</smoothly-table-row>
+					<smoothly-table-expandable-row>
+						<smoothly-table-cell>Proquse</smoothly-table-cell>
+						<smoothly-lazy
+							slot={"detail"}
+							content={<img src={"https://brand.proquse.com/logo/proquse-black.svg"} alt={"Proquse Logotype."} />}
+						/>
+					</smoothly-table-expandable-row>
+					<smoothly-table-expandable-row>
+						<smoothly-table-cell>Pax2Pay</smoothly-table-cell>
+						<smoothly-lazy
+							slot={"detail"}
+							content={
+								<img src={"https://dash.pax2pay.app/assets/pax2pay-dark-horizontal.svg"} alt={"Pax2Pay Logotype."} />
+							}
+						/>
+					</smoothly-table-expandable-row>
+				</smoothly-table>
+				<h4>Demo table 10 - Lazy expansion cells</h4>
+				<smoothly-table>
+					<smoothly-table-row>
+						<smoothly-table-header>Company</smoothly-table-header>
+					</smoothly-table-row>
+					<smoothly-table-row>
+						<smoothly-table-expandable-cell>
+							Proquse
+							<smoothly-lazy
+								slot={"detail"}
+								content={<img src={"https://brand.proquse.com/logo/proquse-black.svg"} alt={"Proquse Logotype."} />}
+							/>
+						</smoothly-table-expandable-cell>
+					</smoothly-table-row>
+					<smoothly-table-row>
+						<smoothly-table-expandable-cell>
+							Pax2Pay
+							<smoothly-lazy
+								slot={"detail"}
+								content={
+									<img src={"https://dash.pax2pay.app/assets/pax2pay-dark-horizontal.svg"} alt={"Pax2Pay Logotype."} />
+								}
+							/>
+						</smoothly-table-expandable-cell>
+					</smoothly-table-row>
+				</smoothly-table>
+			</Host>
+		)
 	}
 }

--- a/src/components/table/demo/index.tsx
+++ b/src/components/table/demo/index.tsx
@@ -9,7 +9,7 @@ export class TableDemo {
 	render() {
 		return [
 			<h4>Demo table 1: Filtered & Checked Table</h4>,
-			<smoothly-table-demo-filtered></smoothly-table-demo-filtered>,
+			<smoothly-lazy content={<smoothly-table-demo-filtered />} />,
 			<h4>Demo table 2</h4>,
 			<smoothly-table-testing></smoothly-table-testing>,
 			<h4>Demo table 3</h4>,


### PR DESCRIPTION
* Added `<smoothly-load-more />`: detects when its inside the viewport.
* Added `<smoothly-lazy />`: Can take "slotted" content via a prop to prevent this "slotted" content from immediately calling lifecycle hooks such as `componentWillLoad()`. The "slotted" content is added to the DOM when `<smoothly-lazy />` is inside the browser viewport.
* Added `<smoothly-app-room />`: Can lazy load room by providing its slotted content via its new property `content`
* Added demo for lazy loaded table expansions in the bottom of the `Table` room.
* Changed app demo to lazy load `Icon` room.