### PR TITLE
fire load when there is a change

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -1846,7 +1846,7 @@ declare namespace LocalJSX {
         "multiple"?: boolean;
         "mutable"?: boolean;
         "onNotice"?: (event: SmoothlyPickerMenuCustomEvent<Notice>) => void;
-        "onSmoothlyPickerMenuLoaded"?: (event: SmoothlyPickerMenuCustomEvent<Controls & { synced: () => boolean }>) => void;
+        "onSmoothlyPickerMenuLoaded"?: (event: SmoothlyPickerMenuCustomEvent<Controls>) => void;
         "open"?: boolean;
         "readonly"?: boolean;
         "validator"?: (value: string) => boolean | { result: boolean; notice: Notice };

--- a/src/components/picker/index.tsx
+++ b/src/components/picker/index.tsx
@@ -25,7 +25,7 @@ export class SmoothlyPicker implements Clearable, Input {
 	@Event() smoothlyInput: EventEmitter<Record<string, any | any[]>> // multiple -> any[]
 	@Event() smoothlyChange: EventEmitter<Record<string, any | any[]>> // multiple -> any[]
 	@Event() smoothlyInputLooks: EventEmitter<(looks: Looks) => void>
-	private controls?: Controls & { synced: () => boolean }
+	private controls?: Controls
 
 	componentWillLoad() {
 		this.smoothlyInputLooks.emit(looks => (this.looks = looks))
@@ -34,10 +34,8 @@ export class SmoothlyPicker implements Clearable, Input {
 	@Watch("selected")
 	selectedChanged() {
 		const selected = Array.from(this.selected.values(), option => option.value)
-		if (this.controls?.synced()) {
-			this.smoothlyInput.emit({ [this.name]: this.multiple ? selected : selected.at(0) })
-			this.smoothlyChange.emit({ [this.name]: this.multiple ? selected : selected.at(0) })
-		}
+		this.smoothlyInput.emit({ [this.name]: this.multiple ? selected : selected.at(0) })
+		this.smoothlyChange.emit({ [this.name]: this.multiple ? selected : selected.at(0) })
 		this.display = Array.from(this.selected.values(), option => {
 			const span = document.createElement("span")
 			option.slotted.forEach(node => span.appendChild(node.cloneNode(true)))
@@ -47,7 +45,7 @@ export class SmoothlyPicker implements Clearable, Input {
 
 	componentDidLoad() {
 		if (this.controls)
-			this.smoothlyPickerLoaded.emit((({ synced, ...controls }) => controls)(this.controls))
+			this.smoothlyPickerLoaded.emit(this.controls)
 	}
 	@Listen("smoothlyInputLooks")
 	smoothlyInputLooksHandler(event: CustomEvent<(looks: Looks) => void>) {

--- a/src/components/picker/menu/index.tsx
+++ b/src/components/picker/menu/index.tsx
@@ -49,11 +49,10 @@ export class SmoothlyPickerMenu {
 	@State() flip = false
 	@State() flipChecked = false
 	@Event() notice: EventEmitter<Notice>
-	@Event() smoothlyPickerMenuLoaded: EventEmitter<Controls & { synced: () => boolean }>
+	@Event() smoothlyPickerMenuLoaded: EventEmitter<Controls>
 	private memory?: { backend: SmoothlyPickerMenu["backend"]; options: SmoothlyPickerMenu["options"] }
 	private listElement?: HTMLElement
 	private searchElement?: HTMLElement
-	private synced = false
 
 	componentWillLoad() {
 		if (!Observers.has(this.element)) {
@@ -69,12 +68,6 @@ export class SmoothlyPickerMenu {
 				)
 			)
 		}
-	}
-	sync() {
-		if (this.backend.size != this.options.size)
-			this.synced = false
-		else
-			this.synced = true
 	}
 	componentDidLoad() {
 		this.smoothlyPickerMenuLoaded.emit({
@@ -109,7 +102,6 @@ export class SmoothlyPickerMenu {
 				this.options = new Map(Array.from(this.options.entries()).filter(([key]) => !this.created.has(key)))
 				this.created = new Map()
 			},
-			synced: () => this.synced,
 		})
 	}
 	disconnectedCallback() {
@@ -140,7 +132,6 @@ export class SmoothlyPickerMenu {
 	optionLoadHandler(event: CustomEvent<Option.Load>) {
 		if (!this.listElement || !event.composedPath().includes(this.listElement)) {
 			event.stopPropagation()
-			this.sync()
 			event.detail.set.readonly(this.readonly)
 
 			const current = this.options.get(event.detail.value)
@@ -163,7 +154,6 @@ export class SmoothlyPickerMenu {
 			)
 		} else
 			this.options.set(event.detail.value, event.detail)
-		this.sync()
 	}
 	@Listen("smoothlyPickerOptionChange")
 	optionChangeHandler(event: CustomEvent<Option>) {


### PR DESCRIPTION
Picker now fire an input events on load. when using multiple=true this may fire multiple events on load until all options have loaded. Before change there was no event at all.

When two options are defined as selected on load two input events will fire
![image](https://github.com/utily/smoothly/assets/25643315/b0e00bae-8607-499a-bc68-c9fe87b1a3e2)

