### PR TITLE
Fix for input with reset button inside

### DIFF
--- a/src/components/input/reset/index.tsx
+++ b/src/components/input/reset/index.tsx
@@ -44,7 +44,7 @@ export class SmoothlyInputReset {
 	@Listen("click")
 	clickHandler() {
 		this.parent?.reset()
-		this.readonlyAtLoad && this.parent?.edit(false)
+		this.parent instanceof SmoothlyForm && this.readonlyAtLoad && this.parent?.edit(false)
 	}
 	render() {
 		return (


### PR DESCRIPTION
With this change an input with a restbutton inside will not be set to readonly after being reset, readonly will only be set on form-level