### PR TITLE
Items register in select input with event

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -1848,6 +1848,7 @@ declare namespace LocalJSX {
     }
     interface SmoothlyItem {
         "marked"?: boolean;
+        "onSmoothlyInputLoad"?: (event: SmoothlyItemCustomEvent<(parent: HTMLElement) => void>) => void;
         "onSmoothlyItemSelect"?: (event: SmoothlyItemCustomEvent<void>) => void;
         "selectable"?: boolean;
         "selected"?: boolean;

--- a/src/components/input/select/style.css
+++ b/src/components/input/select/style.css
@@ -30,7 +30,6 @@
 	padding-right: .4em;
 }
 :host>.icons::slotted(smoothly-input-reset) {
-	transform: translateY(.15em);
 	padding-right: .2em;
 }
 

--- a/src/components/input/select/style.css
+++ b/src/components/input/select/style.css
@@ -4,7 +4,6 @@
 	display: flex;
 	justify-content: space-between;
 	flex-direction: row;
-	flex-wrap: wrap;
 	position: relative;
 	background-color: rgb(var(--background-color, var(--smoothly-color-shade)));
 }
@@ -58,13 +57,10 @@
 }
 
 :host>.options {
-	width: 100%;
-}
-
-:host>.options>nav {
 	display: flex;
 	flex-direction: column;
 	position: absolute;
+	top: 2.8em;
 	z-index: 10;
 	max-height: var(--menu-height, unset);
 	width: 100%;
@@ -72,39 +68,39 @@
 	background-color: rgb(var(--smoothly-default-shade));
 }
 
-:host[looks=border] nav {
+:host[looks=border] .options {
 	transform: translateX(-1px);
 	border: rgb(var(--text-color, var(--smoothly-color-contrast))) solid 1px;
 	border-top: rgba(var(--text-color, var(--smoothly-color-contrast)), .4) solid 1px;
 }
 
-:host[looks="grid"] nav {
+:host[looks="grid"] .options {
 	transform: translateX(-2px);
 	border: rgba(var(--text-color, var(--smoothly-color-contrast)), .5) solid 2px;
 	border-top: rgba(var(--text-color, var(--smoothly-color-contrast)), .2) solid 2px;
 }
 
-:host>.options>nav::slotted(smoothly-item){
+:host>.options::slotted(smoothly-item){
 	padding: .7em .9em;
 }
 
-:host>.options>nav::slotted(smoothly-item.non-selectable) {
+:host>.options::slotted(smoothly-item.non-selectable) {
 	display: flex;
 	gap: 1em;
 	background-color: rgba(var(--smoothly-primary-tint), .3);
 	color: var(--smoothly-color-contrast)
 }
 
-:host>.options>nav>smoothly-item.non-selectable>smoothly-icon[name="backspace-outline"] {
+:host>.options>smoothly-item.non-selectable>smoothly-icon[name="backspace-outline"] {
 	margin-left: auto;
 	margin-right: 0;
 }
 
-:host.has-value:has(:not([slot=label])) nav::slotted(smoothly-item) {
+:host.has-value:has(:not([slot=label])) ::slotted(smoothly-item) {
 	padding: .7em;
 }
 
-.hidden {
+:host>.options.hidden {
 	display: none;
 }
 

--- a/src/components/item/Item.ts
+++ b/src/components/item/Item.ts
@@ -1,0 +1,16 @@
+import { isly } from "isly"
+
+export interface Item {
+	value: any
+	selected?: boolean
+	filter: (filter: string) => Promise<void>
+}
+
+export namespace Item {
+	export const type = isly.object<Item>({
+		value: isly.any(),
+		selected: isly.boolean().optional(),
+		filter: isly.function(),
+	})
+	export const is = type.is
+}

--- a/src/components/item/index.tsx
+++ b/src/components/item/index.tsx
@@ -1,17 +1,32 @@
-import { Component, Element, Event, EventEmitter, h, Host, Listen, Method, Prop, Watch } from "@stencil/core"
+import {
+	Component,
+	ComponentDidLoad,
+	ComponentWillLoad,
+	Element,
+	Event,
+	EventEmitter,
+	h,
+	Host,
+	Listen,
+	Method,
+	Prop,
+	Watch,
+} from "@stencil/core"
+import { Item } from "./Item"
 
 @Component({
 	tag: "smoothly-item",
 	styleUrl: "style.css",
 	scoped: true,
 })
-export class Item {
+export class SmoothlyItem implements Item, ComponentWillLoad, ComponentDidLoad {
 	@Element() element: HTMLSmoothlyItemElement
 	@Prop() value: any
 	@Prop({ reflect: true, mutable: true }) selected: boolean
 	@Prop({ reflect: true, mutable: true }) marked: boolean
 	@Prop() selectable = true
 	@Event() smoothlyItemSelect: EventEmitter<void>
+	@Event() smoothlyInputLoad: EventEmitter<(parent: HTMLElement) => void>
 	@Watch("selected")
 	onSelectedChanged(value: boolean, old: boolean) {
 		if (value && !old && this.selectable)
@@ -24,6 +39,11 @@ export class Item {
 			this.smoothlyItemSelect.emit()
 		}
 	}
+	componentWillLoad() {
+		this.smoothlyInputLoad.emit(() => {
+			return
+		})
+	}
 	componentDidLoad() {
 		if (this.selected && this.selectable)
 			this.smoothlyItemSelect.emit()
@@ -31,9 +51,10 @@ export class Item {
 	@Method()
 	async filter(filter: string): Promise<void> {
 		const value = typeof this.value === "string" ? this.value : JSON.stringify(this.value ?? "")
-		this.element.hidden = filter
-			? !(value.includes(filter) || this.element.innerText.toLowerCase().includes(filter))
-			: false
+		this.element.hidden =
+			filter && this.selectable
+				? !(value.includes(filter) || this.element.innerText.toLowerCase().includes(filter))
+				: false
 	}
 	render() {
 		return (


### PR DESCRIPTION
This commit makes items register on Load with parent (in this case the select) contrary to being "querySelectored" as it was
And some bug-crushing and fine-tuning in Select: 
- navigation with arrow key in select dropdown is now only possible when there are visible items (page broke without this fix)
- height of item (that can be used to set heigth of dropdpwn) is set once when component is rendered 
- nav tag in dropdown is removed