### PR TITLE
Bug fixes for input-buttons

### DIFF
--- a/src/components/input/demo/index.tsx
+++ b/src/components/input/demo/index.tsx
@@ -36,11 +36,89 @@ export class SmoothlyInputDemo {
 				<smoothly-input name="Delayed" delay={2}>
 					Delayed
 				</smoothly-input>
-				<h2>Editable form and Input with Clear and Reset</h2>
+				<h2>Editable form and Input with Clear and Reset - Readonly</h2>
 				<smoothly-form
 					looks="grid"
 					type="create"
 					readonly
+					action="https://api.toiletapi.com/upload/6b12fd2f-e896-46f9-b38f-25cf42cee4b4">
+					<smoothly-input readonly name="First Name" value="John">
+						First name
+					</smoothly-input>
+					<smoothly-input name="Last name" value="Doe">
+						Last name
+						<smoothly-input-clear size="icon" slot="end">
+							<smoothly-icon name="close" />
+						</smoothly-input-clear>
+					</smoothly-input>
+					<smoothly-input type="phone" name="Phone" value={"777888999"}>
+						Phone
+						<smoothly-input-reset size="icon" slot="end">
+							<smoothly-icon name="refresh-outline" />
+						</smoothly-input-reset>
+					</smoothly-input>
+					<smoothly-input-radio clearable name="radioFirstInput">
+						<p slot="label">Clearable</p>
+						<smoothly-input-radio-item slot="options" value={"first"}>
+							Label 1
+						</smoothly-input-radio-item>
+						<smoothly-input-radio-item selected slot="options" value={"second"}>
+							Label 2
+						</smoothly-input-radio-item>
+						<smoothly-input-radio-item slot="options" value={"third"}>
+							Label 3
+						</smoothly-input-radio-item>
+					</smoothly-input-radio>
+					<smoothly-input-select menuHeight="7.5items" placeholder="Select..." name="select-month">
+						<label slot="label">Month</label>
+						<smoothly-item value="1">January</smoothly-item>
+						<smoothly-item value="2">February</smoothly-item>
+						<smoothly-item value="3">March</smoothly-item>
+						<smoothly-item value="4">April</smoothly-item>
+						<smoothly-item value="5">May</smoothly-item>
+						<smoothly-item value="6">June</smoothly-item>
+						<smoothly-item value="7">July</smoothly-item>
+						<smoothly-item value="8">August</smoothly-item>
+						<smoothly-item value="9">September</smoothly-item>
+						<smoothly-item value="10">October</smoothly-item>
+						<smoothly-item value="11">November</smoothly-item>
+						<smoothly-item value="12">December</smoothly-item>
+					</smoothly-input-select>
+					<smoothly-input-select name="select-icon" clearable={false} showSelected={false}>
+						<smoothly-item value="folder" selected>
+							<smoothly-icon size="small" name="folder-outline" />
+						</smoothly-item>
+						<smoothly-item value="camera">
+							<smoothly-icon size="small" name="camera-outline" />
+						</smoothly-item>
+					</smoothly-input-select>
+					<smoothly-input-checkbox name="checkbox">Check the box</smoothly-input-checkbox>
+					<smoothly-input-checkbox name="checkbox2" checked>
+						Check the box 2
+					</smoothly-input-checkbox>
+					<smoothly-input-range step={1} name="range3" value={20000}>
+						Select
+					</smoothly-input-range>
+					<smoothly-picker multiple name="animals">
+						<span slot="label">Animals</span>
+						<span slot="search">Search</span>
+						<smoothly-picker-option selected value={"cat"}>
+							Cat
+						</smoothly-picker-option>
+						<smoothly-picker-option value={"dog"}>Dog</smoothly-picker-option>
+						<smoothly-picker-option value={"fish"}>Fish</smoothly-picker-option>
+					</smoothly-picker>
+					<smoothly-input-edit fill="default" type="button" color="tertiary" slot="edit" size="icon" shape="rounded" />
+					<smoothly-input-reset fill="default" type="form" color="warning" slot="reset" size="icon" shape="rounded" />
+					<smoothly-input-submit delete slot="clear" color="danger" size="icon" shape="rounded" />
+					<smoothly-input-submit fill="default" type="button" color="success" slot="submit" size="icon" shape="rounded">
+						<smoothly-icon name="checkmark-outline" fill="solid" size="tiny" />
+					</smoothly-input-submit>
+				</smoothly-form>
+				<h2>Editable form and Input with Clear and Reset - Editable</h2>
+				<smoothly-form
+					looks="grid"
+					type="create"
 					action="https://api.toiletapi.com/upload/6b12fd2f-e896-46f9-b38f-25cf42cee4b4">
 					<smoothly-input readonly name="First Name" value="John">
 						First name

--- a/src/components/input/edit/index.tsx
+++ b/src/components/input/edit/index.tsx
@@ -24,7 +24,6 @@ export class SmoothlyInputEdit implements ComponentWillLoad {
 		this.smoothlyInputLoad.emit(parent => {
 			if (Editable.type.is(parent)) {
 				this.parent = parent
-				parent.readonly = true
 				parent.listen("changed", async p => {
 					this.display = p.readonly
 				})

--- a/src/components/input/reset/index.tsx
+++ b/src/components/input/reset/index.tsx
@@ -35,6 +35,7 @@ export class SmoothlyInputReset {
 					}
 					if (p instanceof SmoothlyForm) {
 						this.display = !p.readonly
+						this.disabled = !this.readonlyAtLoad && !p.changed
 					}
 				})
 			}

--- a/src/components/input/submit/index.tsx
+++ b/src/components/input/submit/index.tsx
@@ -27,7 +27,7 @@ export class SmoothlyInputSubmit implements ComponentWillLoad {
 				this.parent = parent
 				parent.listen("changed", async p => {
 					this.display = !p.readonly
-					this.disabled = p.readonly ? true : this.delete ? false : !p.changed
+					this.disabled = p.readonly ? true : Object.values(p.value).filter(val => val).length < 1 ? true : !p.changed
 				})
 			}
 		})

--- a/src/components/input/submit/index.tsx
+++ b/src/components/input/submit/index.tsx
@@ -27,7 +27,7 @@ export class SmoothlyInputSubmit implements ComponentWillLoad {
 				this.parent = parent
 				parent.listen("changed", async p => {
 					this.display = !p.readonly
-					this.disabled = p.readonly ? true : Object.values(p.value).filter(val => val).length < 1 ? true : !p.changed
+					this.disabled = p.readonly ? true : this.delete ? false : !p.changed
 				})
 			}
 		})


### PR DESCRIPTION
This commit removes edit-button setting parent to readonly and interferring with readonly state of form and itself
It also makes the reset-button disabled when form is and always was in "edit-mode" and form has not been changed by user. 

I also added demo of form that isnt set to readonly so that its easy to see how it works!