### PR TITLE
always clickable if its a delete button

### DIFF
--- a/src/components/input/submit/index.tsx
+++ b/src/components/input/submit/index.tsx
@@ -27,7 +27,9 @@ export class SmoothlyInputSubmit implements ComponentWillLoad {
 				this.parent = parent
 				parent.listen("changed", async p => {
 					this.display = !p.readonly
-					this.disabled = p.readonly ? true : Object.values(p.value).filter(val => val).length < 1 ? true : !p.changed
+					this.disabled =
+						!this.delete &&
+						(p.readonly ? true : Object.values(p.value).filter(val => val).length < 1 ? true : !p.changed)
 				})
 			}
 		})


### PR DESCRIPTION
if the submit button is a delete button it is never disabled the form.

Without this change the "trash" button was only clickable when the form data was changed.