### PR TITLE
Padding distribution for table

### DIFF
--- a/src/components/table/cell/style.css
+++ b/src/components/table/cell/style.css
@@ -2,7 +2,7 @@
 	display: table-cell;
 	line-height: 1.5rem;
 	white-space: nowrap;
-	padding: 0.3rem 0 0.3rem 1rem;
+	padding: 0.3rem .5rem;
 	box-shadow: 0 1px 0 0 rgb(var(--smoothly-color-shade));
 }
 :host smoothly-icon {

--- a/src/components/table/expandable/cell/style.css
+++ b/src/components/table/expandable/cell/style.css
@@ -1,6 +1,6 @@
 :host {
 	display: table-cell;
-	padding: 0.3rem 0 0.3rem 0;
+	padding: 0.3rem 0.5rem 0.3rem 0.2rem;
 	cursor: pointer;
 	line-height: 1.5rem;
 }
@@ -15,7 +15,7 @@
 }
 :host smoothly-icon {
 	width: 1em;
-	padding: 0 0.3rem;
+	padding-right: 0.3rem;
 	transition: transform 0.2s, opacity 0.1s;
 	display: flex;
 	height: auto;
@@ -27,7 +27,7 @@
 	opacity: 1;
 }
 :host[open] smoothly-icon {
-	transform: rotate(90deg);
+	transform: rotate(90deg) translateX(3px);
 }
 :host > div {
 	display: grid;

--- a/src/components/table/header/style.css
+++ b/src/components/table/header/style.css
@@ -3,7 +3,7 @@
 	line-height: 2.5rem;
 	border-top: 1px solid rgb(var(--smoothly-color-shade));
 	box-shadow: 0 1px 0 0 rgb(var(--smoothly-color-shade));
-	padding-left: 1rem;
+	padding: 0 .5rem;
 	font-weight: bold;
 }
 


### PR DESCRIPTION
This commit contains a re-distribution of padding on cells and headers in table. This is to make cells and headers with right aligned text look good. I've basically taken the 1 em padding on one side and put half of it on each side