### PR TITLE
Fill entire input background on auto fill

### DIFF
--- a/src/components/input/style.css
+++ b/src/components/input/style.css
@@ -5,7 +5,6 @@
 	align-items: center;
 	justify-content: center;
 	font-weight: var(--smoothly-font-weight);
-	padding: 0 0.4em;
 	overflow: hidden;
 	background-color: rgb(var(--background-color, var(--smoothly-color-shade)));
 	color: rgb(var(--text-color, var(--smoothly-color-contrast)));
@@ -23,7 +22,7 @@
 }
 label {
 	position: absolute;
-	left: 0;
+	left: 0.4em;
 	top: 0.6em;
 	opacity: 0.8;
 	user-select: none;
@@ -35,10 +34,10 @@ label {
 	display: none;
 }
 :host:not([show-label]) input {
-	padding: 0.7em 0.3em 0.7em 0.4em;
+	padding: 0.7em 0.7em 0.7em 0.8em;
 }
 input {
-	padding: 1.2em 0.3em 0.2em 0.4em;
+	padding: 1.2em 0.7em 0.2em 0.8em;
 	box-sizing: border-box;
 	width: 100%;
 	height: 100%;


### PR DESCRIPTION
When auto-filling the background get set on the `input` element.
So I removed the padding so the `input` will fill the entire `smoothly-input`.
I also compensated for this so the label and everything else still is positioned the same.


Left Before vs. Right After
![Screenshot from 2024-06-13 10-31-23](https://github.com/utily/smoothly/assets/14332757/68940434-4c5b-4244-8eac-2af1628b3f80)
