### PR TITLE
select emits after load

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,4 +58,4 @@ jobs:
         with:
           node-version: 20
           cache: 'npm'
-      - run: npm audit
+      - run: npm audit --prod

--- a/src/components/input/demo/controlled-form/index.tsx
+++ b/src/components/input/demo/controlled-form/index.tsx
@@ -1,4 +1,5 @@
 import { Component, h, Host, State, VNode, Watch } from "@stencil/core"
+import { isoly } from "isoly"
 import { SmoothlyFormCustomEvent } from "../../../../components"
 import { Data } from "../../../../model"
 
@@ -9,6 +10,8 @@ import { Data } from "../../../../model"
 })
 export class SmoothlyInputDemoControlledForm {
 	@State() name = "Initial name"
+	@State() currency: isoly.Currency = "EUR"
+	private currencies: isoly.Currency[] = ["GBP", "SEK", "EUR", "USD"]
 
 	@Watch("name")
 	nameChanged(current: string, previous: string): void {
@@ -19,7 +22,7 @@ export class SmoothlyInputDemoControlledForm {
 		event: SmoothlyFormCustomEvent<{ result: (result: boolean) => void; value: Data }>
 	): Promise<void> {
 		event.stopPropagation()
-		console.log("Received event. Processing...")
+		console.log("Received event. Processing...", event.detail)
 		if (!(typeof event.detail.value.name == "string")) {
 			console.error("Bad input. Resolving false")
 			event.detail.result(false)
@@ -38,6 +41,13 @@ export class SmoothlyInputDemoControlledForm {
 					<smoothly-input type={"text"} name={"name"} value={this.name}>
 						Name
 					</smoothly-input>
+					<smoothly-input-select name={"currency"}>
+						{this.currencies.map(currency => (
+							<smoothly-item selected={currency == this.currency} value={currency}>
+								{currency}
+							</smoothly-item>
+						))}
+					</smoothly-input-select>
 					<smoothly-input-edit slot={"edit"} type={"button"} size={"icon"} color={"primary"} fill={"default"} />
 					<smoothly-input-reset slot={"reset"} type={"form"} size={"icon"} color={"warning"} fill={"default"} />
 					<smoothly-input-submit slot={"submit"} size={"icon"} color={"success"} />

--- a/src/components/input/demo/controlled-form/index.tsx
+++ b/src/components/input/demo/controlled-form/index.tsx
@@ -42,6 +42,7 @@ export class SmoothlyInputDemoControlledForm {
 						Name
 					</smoothly-input>
 					<smoothly-input-select name={"currency"}>
+						<span slot={"label"}>Currency</span>
 						{this.currencies.map(currency => (
 							<smoothly-item selected={currency == this.currency} value={currency}>
 								{currency}

--- a/src/components/input/demo/controlled-form/index.tsx
+++ b/src/components/input/demo/controlled-form/index.tsx
@@ -33,6 +33,7 @@ export class SmoothlyInputDemoControlledForm {
 			event.detail.result(true)
 		}
 	}
+
 	render(): VNode | VNode[] {
 		return (
 			<Host>

--- a/src/components/input/demo/controlled-form/index.tsx
+++ b/src/components/input/demo/controlled-form/index.tsx
@@ -33,7 +33,6 @@ export class SmoothlyInputDemoControlledForm {
 			event.detail.result(true)
 		}
 	}
-
 	render(): VNode | VNode[] {
 		return (
 			<Host>

--- a/src/components/input/select/index.tsx
+++ b/src/components/input/select/index.tsx
@@ -66,6 +66,7 @@ export class SmoothlyInputSelect implements Input, Editable, Clearable, Componen
 	componentDidLoad(): void | Promise<void> {
 		this.selected && !this.initialValueHandled && (this.initialValue = [...this.selected])
 		this.initialValueHandled = true
+		this.onSelectedChange()
 	}
 	componentDidRender(): void | Promise<void> {
 		this.itemHeight === undefined && (this.itemHeight = this.items.find(item => item.clientHeight > 0)?.clientHeight)


### PR DESCRIPTION
`smoothly-input-select` now always emits its initial value to the form properly.

If one item was pre selected it was not reflected in a submit event but now it is.