### PR TITLE
Only add margin-top for when buttons exists in form

### DIFF
--- a/src/components/form/style.css
+++ b/src/components/form/style.css
@@ -37,7 +37,7 @@ smoothly-form[looks="transparent"] > form > fieldset {
 	gap: 2em
 }
 
-smoothly-form > form > div {
+smoothly-form > form > div:not(:empty) {
 	display: flex;
 	justify-content: end;
 	gap: 1em;


### PR DESCRIPTION

## Problem
There is a little bit of margin to separate the edit/reset/clear/submit buttons on a form.
![Screenshot from 2024-06-26 13-20-49](https://github.com/utily/smoothly/assets/14332757/161adfc1-16ac-4afd-a15e-d2888ccad019)
![Screenshot from 2024-06-26 13-19-16](https://github.com/utily/smoothly/assets/14332757/caba58fd-15b5-4db9-a0c4-9f36bbc57a02)


When none of these buttons exists there should be no extra margin, but there is.
![Screenshot from 2024-06-26 13-18-27](https://github.com/utily/smoothly/assets/14332757/80692638-cc7e-4fd2-a463-a4899b370e1b)


## Solution
Check `div:not(:empty)` in css.