### PR TITLE
added "colspan" to cells

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -458,6 +458,8 @@ export namespace Components {
     }
     interface SmoothlyNextDemo {
     }
+    interface SmoothlyNextDemoColspan {
+    }
     interface SmoothlyNextDemoNested {
     }
     interface SmoothlyNextDemoNestedInner {
@@ -476,10 +478,12 @@ export namespace Components {
     interface SmoothlyNextTableBody {
     }
     interface SmoothlyNextTableCell {
+        "span": number;
     }
     interface SmoothlyNextTableExpandableCell {
         "close": () => Promise<void>;
         "open": boolean;
+        "span": number;
     }
     interface SmoothlyNextTableExpandableRow {
         "open": boolean;
@@ -1590,6 +1594,12 @@ declare global {
         prototype: HTMLSmoothlyNextDemoElement;
         new (): HTMLSmoothlyNextDemoElement;
     };
+    interface HTMLSmoothlyNextDemoColspanElement extends Components.SmoothlyNextDemoColspan, HTMLStencilElement {
+    }
+    var HTMLSmoothlyNextDemoColspanElement: {
+        prototype: HTMLSmoothlyNextDemoColspanElement;
+        new (): HTMLSmoothlyNextDemoColspanElement;
+    };
     interface HTMLSmoothlyNextDemoNestedElement extends Components.SmoothlyNextDemoNested, HTMLStencilElement {
     }
     var HTMLSmoothlyNextDemoNestedElement: {
@@ -2167,6 +2177,7 @@ declare global {
         "smoothly-lazy": HTMLSmoothlyLazyElement;
         "smoothly-load-more": HTMLSmoothlyLoadMoreElement;
         "smoothly-next-demo": HTMLSmoothlyNextDemoElement;
+        "smoothly-next-demo-colspan": HTMLSmoothlyNextDemoColspanElement;
         "smoothly-next-demo-nested": HTMLSmoothlyNextDemoNestedElement;
         "smoothly-next-demo-nested-inner": HTMLSmoothlyNextDemoNestedInnerElement;
         "smoothly-next-demo-simple": HTMLSmoothlyNextDemoSimpleElement;
@@ -2666,6 +2677,8 @@ declare namespace LocalJSX {
     }
     interface SmoothlyNextDemo {
     }
+    interface SmoothlyNextDemoColspan {
+    }
     interface SmoothlyNextDemoNested {
     }
     interface SmoothlyNextDemoNestedInner {
@@ -2684,11 +2697,13 @@ declare namespace LocalJSX {
     interface SmoothlyNextTableBody {
     }
     interface SmoothlyNextTableCell {
+        "span"?: number;
     }
     interface SmoothlyNextTableExpandableCell {
         "onSmoothlyNextTableExpandableCellOpened"?: (event: SmoothlyNextTableExpandableCellCustomEvent<void>) => void;
         "onSmoothlyNextTableExpandableCellRegister"?: (event: SmoothlyNextTableExpandableCellCustomEvent<void>) => void;
         "open"?: boolean;
+        "span"?: number;
     }
     interface SmoothlyNextTableExpandableRow {
         "open"?: boolean;
@@ -2957,6 +2972,7 @@ declare namespace LocalJSX {
         "smoothly-lazy": SmoothlyLazy;
         "smoothly-load-more": SmoothlyLoadMore;
         "smoothly-next-demo": SmoothlyNextDemo;
+        "smoothly-next-demo-colspan": SmoothlyNextDemoColspan;
         "smoothly-next-demo-nested": SmoothlyNextDemoNested;
         "smoothly-next-demo-nested-inner": SmoothlyNextDemoNestedInner;
         "smoothly-next-demo-simple": SmoothlyNextDemoSimple;
@@ -3072,6 +3088,7 @@ declare module "@stencil/core" {
             "smoothly-lazy": LocalJSX.SmoothlyLazy & JSXBase.HTMLAttributes<HTMLSmoothlyLazyElement>;
             "smoothly-load-more": LocalJSX.SmoothlyLoadMore & JSXBase.HTMLAttributes<HTMLSmoothlyLoadMoreElement>;
             "smoothly-next-demo": LocalJSX.SmoothlyNextDemo & JSXBase.HTMLAttributes<HTMLSmoothlyNextDemoElement>;
+            "smoothly-next-demo-colspan": LocalJSX.SmoothlyNextDemoColspan & JSXBase.HTMLAttributes<HTMLSmoothlyNextDemoColspanElement>;
             "smoothly-next-demo-nested": LocalJSX.SmoothlyNextDemoNested & JSXBase.HTMLAttributes<HTMLSmoothlyNextDemoNestedElement>;
             "smoothly-next-demo-nested-inner": LocalJSX.SmoothlyNextDemoNestedInner & JSXBase.HTMLAttributes<HTMLSmoothlyNextDemoNestedInnerElement>;
             "smoothly-next-demo-simple": LocalJSX.SmoothlyNextDemoSimple & JSXBase.HTMLAttributes<HTMLSmoothlyNextDemoSimpleElement>;

--- a/src/components/next/demo/colspan/index.tsx
+++ b/src/components/next/demo/colspan/index.tsx
@@ -1,4 +1,4 @@
-import { Component, Fragment, h, Host, VNode } from "@stencil/core"
+import { Component, h, Host, VNode } from "@stencil/core"
 
 @Component({
 	tag: "smoothly-next-demo-colspan",
@@ -31,11 +31,7 @@ export class SmoothlyNextDemoColspan {
 								<smoothly-display type={"date"} value={"2024-01-02"} />
 								<smoothly-lazy
 									slot={"detail"}
-									content={
-										<Fragment>
-											<smoothly-display type={"date-time"} value={"2024-01-02T13:37:00.000Z"} />
-										</Fragment>
-									}
+									content={<smoothly-display type={"date-time"} value={"2024-01-02T13:37:00.000Z"} />}
 								/>
 							</smoothly-next-table-expandable-cell>
 							<smoothly-next-table-expandable-cell>
@@ -43,13 +39,11 @@ export class SmoothlyNextDemoColspan {
 								<smoothly-lazy
 									slot={"detail"}
 									content={
-										<Fragment>
-											<span>
-												<smoothly-display type={"price"} value={120} currency={"EUR"} />
-												{" + "}
-												<smoothly-display type={"price"} value={100} currency={"EUR"} />
-											</span>
-										</Fragment>
+										<span>
+											<smoothly-display type={"price"} value={120} currency={"EUR"} />
+											{" + "}
+											<smoothly-display type={"price"} value={100} currency={"EUR"} />
+										</span>
 									}
 								/>
 							</smoothly-next-table-expandable-cell>

--- a/src/components/next/demo/colspan/index.tsx
+++ b/src/components/next/demo/colspan/index.tsx
@@ -1,0 +1,62 @@
+import { Component, Fragment, h, Host, VNode } from "@stencil/core"
+
+@Component({
+	tag: "smoothly-next-demo-colspan",
+	styleUrl: "style.css",
+	scoped: true,
+})
+export class SmoothlyNextDemoColspan {
+	render(): VNode | VNode[] {
+		return (
+			<Host>
+				<smoothly-next-table columns={3}>
+					<smoothly-next-table-head>
+						<smoothly-next-table-row>
+							<smoothly-next-table-cell>Date</smoothly-next-table-cell>
+							<smoothly-next-table-cell>Skip</smoothly-next-table-cell>
+							<smoothly-next-table-cell>Total</smoothly-next-table-cell>
+						</smoothly-next-table-row>
+					</smoothly-next-table-head>
+					<smoothly-next-table-body>
+						<smoothly-next-table-row>
+							<smoothly-next-table-cell span={2}>
+								<smoothly-display type={"date"} value={"2024-01-01"} />
+							</smoothly-next-table-cell>
+							<smoothly-next-table-cell>
+								<smoothly-display type={"price"} value={120} currency={"EUR"} />
+							</smoothly-next-table-cell>
+						</smoothly-next-table-row>
+						<smoothly-next-table-row>
+							<smoothly-next-table-expandable-cell span={2}>
+								<smoothly-display type={"date"} value={"2024-01-02"} />
+								<smoothly-lazy
+									slot={"detail"}
+									content={
+										<Fragment>
+											<smoothly-display type={"date-time"} value={"2024-01-02T13:37:00.000Z"} />
+										</Fragment>
+									}
+								/>
+							</smoothly-next-table-expandable-cell>
+							<smoothly-next-table-expandable-cell>
+								<smoothly-display type={"price"} value={220} currency={"EUR"} />
+								<smoothly-lazy
+									slot={"detail"}
+									content={
+										<Fragment>
+											<span>
+												<smoothly-display type={"price"} value={120} currency={"EUR"} />
+												{" + "}
+												<smoothly-display type={"price"} value={100} currency={"EUR"} />
+											</span>
+										</Fragment>
+									}
+								/>
+							</smoothly-next-table-expandable-cell>
+						</smoothly-next-table-row>
+					</smoothly-next-table-body>
+				</smoothly-next-table>
+			</Host>
+		)
+	}
+}

--- a/src/components/next/demo/colspan/index.tsx
+++ b/src/components/next/demo/colspan/index.tsx
@@ -48,6 +48,15 @@ export class SmoothlyNextDemoColspan {
 								/>
 							</smoothly-next-table-expandable-cell>
 						</smoothly-next-table-row>
+						<smoothly-next-table-row>
+							<smoothly-next-table-cell>
+								<smoothly-display type={"date"} value={"2024-01-02"} />
+							</smoothly-next-table-cell>
+							<smoothly-next-table-cell>Not Skipped</smoothly-next-table-cell>
+							<smoothly-next-table-cell>
+								<smoothly-display type={"price"} value={320} currency={"EUR"} />
+							</smoothly-next-table-cell>
+						</smoothly-next-table-row>
 					</smoothly-next-table-body>
 				</smoothly-next-table>
 			</Host>

--- a/src/components/next/demo/colspan/style.css
+++ b/src/components/next/demo/colspan/style.css
@@ -1,0 +1,6 @@
+:host {
+	display: block;
+}
+:host smoothly-display {
+	display: inline;
+}

--- a/src/components/next/demo/index.tsx
+++ b/src/components/next/demo/index.tsx
@@ -9,6 +9,7 @@ export class SmoothlyNextDemo {
 	render(): VNode | VNode[] {
 		return (
 			<Host>
+				<smoothly-next-demo-colspan />
 				<smoothly-next-demo-simple />
 				<smoothly-next-demo-nested />
 			</Host>

--- a/src/components/next/table/cell/index.tsx
+++ b/src/components/next/table/cell/index.tsx
@@ -10,7 +10,7 @@ export class SmoothlyNextTableCell {
 
 	render(): VNode | VNode[] {
 		return (
-			<Host style={{ "--smoothly-table-colspan": this.span.toString(10) }}>
+			<Host style={{ "--smoothly-table-cell-span": this.span.toString(10) }}>
 				<slot />
 			</Host>
 		)

--- a/src/components/next/table/cell/index.tsx
+++ b/src/components/next/table/cell/index.tsx
@@ -1,4 +1,4 @@
-import { Component, h, Host, VNode } from "@stencil/core"
+import { Component, h, Host, Prop, VNode } from "@stencil/core"
 
 @Component({
 	tag: "smoothly-next-table-cell",
@@ -6,7 +6,13 @@ import { Component, h, Host, VNode } from "@stencil/core"
 	scoped: true,
 })
 export class SmoothlyNextTableCell {
+	@Prop({ reflect: true }) span = 1
+
 	render(): VNode | VNode[] {
-		return <Host></Host>
+		return (
+			<Host style={{ "--smoothly-table-colspan": this.span.toString(10) }}>
+				<slot />
+			</Host>
+		)
 	}
 }

--- a/src/components/next/table/cell/style.css
+++ b/src/components/next/table/cell/style.css
@@ -1,4 +1,5 @@
 :host {
+	grid-column: span var(--smoothly-table-cell-span);
 	display: flex;
 	align-items: center;
 	padding: 0.3rem 1.1rem;

--- a/src/components/next/table/cell/style.css
+++ b/src/components/next/table/cell/style.css
@@ -1,5 +1,5 @@
 :host {
-	grid-column: span var(--smoothly-table-cell-span);
+	grid-column: span var(--smoothly-table-cell-span, 1);
 	display: flex;
 	align-items: center;
 	padding: 0.3rem 1.1rem;

--- a/src/components/next/table/expandable/cell/index.tsx
+++ b/src/components/next/table/expandable/cell/index.tsx
@@ -6,6 +6,7 @@ import { Component, Event, EventEmitter, h, Host, Method, Prop, VNode } from "@s
 	scoped: true,
 })
 export class SmoothlyNextTableExpandableCell {
+	@Prop({ reflect: true }) span = 1
 	@Prop({ mutable: true, reflect: true }) open = false
 	@Event() smoothlyNextTableExpandableCellOpened: EventEmitter<void>
 	@Event() smoothlyNextTableExpandableCellRegister: EventEmitter<void>
@@ -23,7 +24,7 @@ export class SmoothlyNextTableExpandableCell {
 
 	render(): VNode | VNode[] {
 		return (
-			<Host>
+			<Host style={{ "--smoothly-table-cell-span": this.span.toString(10) }}>
 				<div onClick={() => this.clickHandler()} class={"content"}>
 					<slot />
 				</div>

--- a/src/components/next/table/expandable/cell/style.css
+++ b/src/components/next/table/expandable/cell/style.css
@@ -9,9 +9,10 @@
 }
 
 :host>div.content {
+	grid-column: span var(--smoothly-table-cell-span);
 	display: flex;
 	align-items: center;
-	white-space: nowrap
+	white-space: nowrap;
 }
 
 :host>div.content:hover {

--- a/src/components/next/table/expandable/cell/style.css
+++ b/src/components/next/table/expandable/cell/style.css
@@ -9,7 +9,7 @@
 }
 
 :host>div.content {
-	grid-column: span var(--smoothly-table-cell-span);
+	grid-column: span var(--smoothly-table-cell-span, 1);
 	display: flex;
 	align-items: center;
 	white-space: nowrap;


### PR DESCRIPTION
* `<smoothly-table-cell>` now have a property `span` that controls how many columns the cell should span in the table.
* `<smoothly-table-expandable-cell>` now have a property `span` that controls how many columns the cell should span in the table.