### PR TITLE
fix: smoothly-tab

### DIFF
--- a/src/components/tab/index.tsx
+++ b/src/components/tab/index.tsx
@@ -28,7 +28,7 @@ export class SmoothlyTab {
 		return (
 			<Host>
 				<label>{this.label}</label>
-				<div ref={e => (this.expansionElement = e)} class={!this.open ? "hide" : ""}>
+				<div ref={e => (this.expansionElement = e)} hidden={!this.open}>
 					<slot></slot>
 				</div>
 			</Host>

--- a/src/components/tab/style.css
+++ b/src/components/tab/style.css
@@ -3,9 +3,6 @@
 	box-sizing: border-box;
 	margin-bottom: -3px;
 }
-:host > div.hide {
-	display: none;
-}
 :host > label {
 	display: block;
 	padding: .5rem;


### PR DESCRIPTION
because the selected element go after parent element, `this.element.after(event.detail)` 
so `:host > div.hide {
	display: none;
}` doesn't work as div is after host