### PR TITLE
display duration of 0

### DIFF
--- a/src/components/display-demo/index.tsx
+++ b/src/components/display-demo/index.tsx
@@ -19,12 +19,13 @@ export class SmoothlyDisplayDemo {
 						<dt>Duration</dt>
 						<dd>
 							<div>
-								<smoothly-display type="duration" value={{ hours: 13, minutes: 100 }} />
-								<smoothly-display type="duration" value={{ hours: 8 }} />
-								<smoothly-display type="duration" value={{ minutes: 3 }} />
-								<smoothly-display type="duration" value={{ hours: -13, minutes: 100 }} />
-								<smoothly-display type="duration" value={{ hours: -8 }} />
-								<smoothly-display type="duration" value={{ minutes: -3 }} />
+								<div><smoothly-display style={{display: "inline"}} type="duration" value={{ hours: 13, minutes: 100 }} />{" h"}</div>
+								<div><smoothly-display style={{display: "inline"}} type="duration" value={{ hours: 8 }} />{" h"}</div>
+								<div><smoothly-display style={{display: "inline"}} type="duration" value={{ minutes: 3 }} />{" h"}</div>
+								<div><smoothly-display style={{display: "inline"}} type="duration" value={{ hours: -13, minutes: 100 }} />{" h"}</div>
+								<div><smoothly-display style={{display: "inline"}} type="duration" value={{ hours: -8 }} />{" h"}</div>
+								<div><smoothly-display style={{display: "inline"}} type="duration" value={{}} />{" h"}</div>
+								<div><smoothly-display style={{display: "inline"}} type="duration" value={{ minutes: -3 }} />{" h"}</div>
 							</div>
 						</dd>
 						<dt>text</dt>

--- a/src/components/display/index.tsx
+++ b/src/components/display/index.tsx
@@ -36,7 +36,7 @@ export class SmoothlyDisplay {
 				result = get(this.type as Type, getLocale())?.toString(this.value)
 				break
 			case "duration":
-				result = format(this.value, type)
+				result = format(this.value, type) || "0"
 				break
 			case "date-time":
 				result = this.format


### PR DESCRIPTION
Smoothly display can now display a timespan with no time as 0.

The fix to this issue is not added to tidily as this behaviour is not wanted in the input formatting. If everything in the input is erased it should be nothing left in the input. It should not be formatted to 0.

It could be moved into tidily in the future when tidily would know about "final" and "ongoing" formatting.

Before:
![image](https://github.com/utily/smoothly/assets/25643315/85d8404b-2900-477e-bfe2-12cc20378c14)
After:
![image](https://github.com/utily/smoothly/assets/25643315/9162270f-3c48-41ec-8366-e1d6803834e5)

