### PR TITLE
smoothly-Input-submit: fix disabled property

### DIFF
--- a/src/components/input/submit/index.tsx
+++ b/src/components/input/submit/index.tsx
@@ -27,7 +27,7 @@ export class SmoothlyInputSubmit implements ComponentWillLoad {
 				this.parent = parent
 				parent.listen("changed", async p => {
 					this.display = !p.readonly
-					this.disabled &&
+					this.disabled =
 						!this.delete &&
 						(p.readonly
 							? true

--- a/src/components/input/submit/index.tsx
+++ b/src/components/input/submit/index.tsx
@@ -27,9 +27,13 @@ export class SmoothlyInputSubmit implements ComponentWillLoad {
 				this.parent = parent
 				parent.listen("changed", async p => {
 					this.display = !p.readonly
-					this.disabled =
+					this.disabled &&
 						!this.delete &&
-						(p.readonly ? true : Object.values(p.value).filter(val => val).length < 1 ? true : !p.changed)
+						(p.readonly
+							? true
+							: Object.values(p.value).filter(val => val).length < 1
+							? true
+							: !p.changed || this.disabled)
 				})
 			}
 		})

--- a/src/components/input/submit/index.tsx
+++ b/src/components/input/submit/index.tsx
@@ -29,11 +29,7 @@ export class SmoothlyInputSubmit implements ComponentWillLoad {
 					this.display = !p.readonly
 					this.disabled =
 						!this.delete &&
-						(p.readonly
-							? true
-							: Object.values(p.value).filter(val => val).length < 1
-							? true
-							: !p.changed || this.disabled)
+						(p.readonly || Object.values(p.value).filter(val => val).length < 1 || !p.changed || this.disabled)
 				})
 			}
 		})


### PR DESCRIPTION
disabled property doesn't work
looks like the value of `this.disabled` is overwritten in line 32
it checks readonly, the length of form value and if the form has changed, which are fine but forgot to check `this.disabled` that is set externally