### PR TITLE
Remove --smoothly-input-hover - hover item show contrasting outline instead

### DIFF
--- a/src/assets/style/mapping.css
+++ b/src/assets/style/mapping.css
@@ -26,8 +26,6 @@ smoothly-color {
 	--smoothly-input-selected: var(--smoothly-primary-color);
 	--smoothly-input-selected-contrast: var(--smoothly-primary-contrast);
 
-	--smoothly-input-hover: var(--smoothly-primary-tint);
-	--smoothly-input-hover-contrast: var(--smoothly-primary-contrast);
 	/* smoothly-button */
 	--smoothly-button-background: var(--smoothly-color);
 	--smoothly-button-foreground: var(--smoothly-color-shade);

--- a/src/components/input/file/style.css
+++ b/src/components/input/file/style.css
@@ -13,9 +13,8 @@
 
 :host>div>div.mask {
 	position: absolute;
-	inset: 0;
-	color: rgb(var(--smoothly-hover-contrast));
-	background-color: rgb(var(--smoothly-input-hover));
+	inset: 2px;
+	border: 2px solid rgb(var(--smoothly-input-foreground));
 }
 
 :host:not(.dragging)>div>div.mask {

--- a/src/components/item/style.css
+++ b/src/components/item/style.css
@@ -1,6 +1,7 @@
 :host([selected]) {
 	background-color: rgb(var(--smoothly-input-selected));
 	color: rgb(var(--smoothly-input-selected-contrast));
+	--marked-color: var(--smoothly-input-selected-contrast);
 }
 
 :host {
@@ -10,6 +11,8 @@
 	color: rgb(var(--smoothly-input-foreground));
 	fill: rgb(var(--smoothly-input-foreground));
 	stroke: rgb(var(--smoothly-input-foreground));
+	position: relative;
+	--marked-color: var(--smoothly-input-foreground);
 }
 
 :host::slotted(*) {
@@ -18,16 +21,13 @@
 	stroke: rgb(var(--smoothly-input-foreground));
 }
 
-:host([marked]),
-:host:hover {
-	background-color: rgb(var(--smoothly-input-hover));
-	color: rgb(var(--smoothly-input-hover-contrast));
-	fill: rgb(var(--smoothly-input-hover-contrast));
-	stroke: rgb(var(--smoothly-input-hover-contrast));
-}
-
-:host:hover::slotted(*) {
-	color: rgb(var(--smoothly-input-hover-contrast));
-	fill: rgb(var(--smoothly-input-hover-contrast));
-	stroke: rgb(var(--smoothly-input-hover-contrast));
+:host([marked])::before,
+:host:hover::before {
+  content: "";
+	position: absolute;
+  height: calc(100% - 4px);
+  width: calc(100% - 4px);
+  border: 2px solid rgb(var(--marked-color));
+  inset: 2px;
+  box-sizing: border-box;
 }


### PR DESCRIPTION
- Outline color set such that contrast is guaranteed for hover/marked items.
- Hover/marked no longer obscures if the item is selected or not.
- The inset on the outline makes the contrast clearer. If the outline was set all the way to the edge then that might make the item/file-input just look smaller in some cases.


## smoothly-input-select

### Before
Here you can't quickly tell if "Crossaint" is selected.
![image](https://github.com/user-attachments/assets/f42c98f0-7980-4e46-8eb5-c2be4feacbb3)


### After
"Crossaint" is NOT selected.
![image](https://github.com/user-attachments/assets/ba483543-a536-4032-86b4-fb335813154b)
"Crossaint" is selected.
![image](https://github.com/user-attachments/assets/33f9a3b2-ef17-4b0b-ad8a-d7eb342d8de0)

## smoothly-input-file
When dragging over a file

### Before
![Screenshot from 2024-07-23 13-45-07](https://github.com/user-attachments/assets/fe20ecee-7d31-476a-9f05-cb1bf100e0c2)

### After
![Screenshot from 2024-07-23 13-44-58](https://github.com/user-attachments/assets/f95938f0-7a58-497e-b992-2f73062f596e)
