### PR TITLE
Fix input-select bug for multiple and singe using Enter key

### DIFF
--- a/src/components/input/select/index.tsx
+++ b/src/components/input/select/index.tsx
@@ -230,7 +230,6 @@ export class SmoothlyInputSelect implements Input, Editable, Clearable, Componen
 						const result = this.items.find(item => item.marked)
 						if (result?.value)
 							result.selected = !result.selected
-						this.smoothlyItemSelect.emit(result)
 						if (!this.multiple) {
 							this.open = false
 							this.filter = ""


### PR DESCRIPTION
`<select multiple>` was adding the item twice.
`<select>` (single) was not adding the item at all.

Turns out the bug in both was caused by the same issue. When selecting with Enter, the item was selected twice. In the single select this mean that is was selected and and deselected.

## Bug (before)
[Screencast from 2024-07-23 14:20:45.webm](https://github.com/user-attachments/assets/b430ddd2-96e2-4768-83fa-96ae105923a5)
