### PR TITLE
Consistent naming convention on css mapping variables

### DIFF
--- a/src/assets/style/mapping.css
+++ b/src/assets/style/mapping.css
@@ -2,36 +2,36 @@
 *[color],
 smoothly-color {
 	/* smoothly-next-table */
-	--smoothly-table-contrast: var(--smoothly-default-contrast);
-	--smoothly-table-color: var(--smoothly-default-color);
+	--smoothly-table-foreground: var(--smoothly-default-contrast);
+	--smoothly-table-background: var(--smoothly-default-color);
 
-	--smoothly-table-header-contrast: var(--smoothly-dark-contrast);
-	--smoothly-table-header-color: var(--smoothly-dark-color);
+	--smoothly-table-header-foreground: var(--smoothly-dark-contrast);
+	--smoothly-table-header-background: var(--smoothly-dark-color);
 
-	--smoothly-table-footer-contrast: var(--smoothly-light-contrast);
-	--smoothly-table-footer-color: var(--smoothly-light-color);
+	--smoothly-table-footer-foreground: var(--smoothly-light-contrast);
+	--smoothly-table-footer-background: var(--smoothly-light-color);
 
-	--smoothly-table-hover-contrast: var(--smoothly-color-contrast);
-	--smoothly-table-hover-color: var(--smoothly-color-tint);
+	--smoothly-table-hover-foreground: var(--smoothly-color-contrast);
+	--smoothly-table-hover-background: var(--smoothly-color-tint);
 
 	--smoothly-table-border: var(--smoothly-color-shade);
 
-	--smoothly-table-expanded-contrast: var(--smoothly-default-contrast);
-	--smoothly-table-expanded-color: var(--smoothly-default-tint);
+	--smoothly-table-expanded-foreground: var(--smoothly-default-contrast);
+	--smoothly-table-expanded-background: var(--smoothly-default-tint);
 	/* smoothly input */
 	--smoothly-input-foreground: var(--smoothly-default-contrast);
 	--smoothly-input-background: var(--smoothly-default-tint);
 	--smoothly-input-border: var(--smoothly-default-shade);
 
-	--smoothly-input-hover: var(--smoothly-primary-tint);
+	--smoothly-input-hover-background: var(--smoothly-primary-tint);
 	--smoothly-input-hover-foreground: var(--smoothly-primary-contrast);
 
-	--smoothly-input-selected: var(--smoothly-primary-color);
+	--smoothly-input-selected-background: var(--smoothly-primary-color);
 	--smoothly-input-selected-border: var(--smoothly-primary-shade);
-	--smoothly-input-selected-contrast: var(--smoothly-primary-contrast);
+	--smoothly-input-selected-foreground: var(--smoothly-primary-contrast);
 	/* smoothly-button */
 	--smoothly-button-background: var(--smoothly-color);
 	--smoothly-button-foreground: var(--smoothly-color-shade);
-	--smoothly-button-hover: var(--smoothly-color-tint);
+	--smoothly-button-hover-background: var(--smoothly-color-tint);
 	--smoothly-button-focus-border: var(--smoothly-color-shade);
 }

--- a/src/components/button/style.css
+++ b/src/components/button/style.css
@@ -136,7 +136,7 @@
 :host(:not([fill=clear]):not([fill=outline]):hover),
 :host(:not([fill=clear]):not([fill=outline]):focus-visible),
 :host(:not([fill=clear]):not([fill=outline]):active) {
-	background: rgb(var(--smoothly-button-hover));
+	background: rgb(var(--smoothly-button-hover-background));
 }
 
 :host>button,

--- a/src/components/input/file/style.css
+++ b/src/components/input/file/style.css
@@ -15,7 +15,7 @@
 	position: absolute;
 	inset: 0;
 	color: rgb(var(--smoothly-hover-contrast));
-	background-color: rgb(var(--smoothly-input-hover));
+	background-color: rgb(var(--smoothly-input-hover-background));
 }
 
 :host:not(.dragging)>div>div.mask {

--- a/src/components/item/style.css
+++ b/src/components/item/style.css
@@ -1,6 +1,6 @@
 :host([selected]) {
-	background-color: rgb(var(--smoothly-input-selected));
-	color: rgb(var(--smoothly-input-selected-contrast));
+	background-color: rgb(var(--smoothly-input-selected-background));
+	color: rgb(var(--smoothly-input-selected-foreground));
 	border-left: 5px solid rgb(var(--smoothly-input-selected-border));
 }
 
@@ -21,7 +21,7 @@
 
 :host([marked]),
 :host:hover {
-	background-color: rgb(var(--smoothly-input-hover));
+	background-color: rgb(var(--smoothly-input-hover-background));
 	color: rgb(var(--smoothly-input-hover-foreground));
 	fill: rgb(var(--smoothly-input-hover-foreground));
 	stroke: rgb(var(--smoothly-input-hover-foreground));

--- a/src/components/next/table/body/style.css
+++ b/src/components/next/table/body/style.css
@@ -2,6 +2,6 @@
 	grid-column: 1 / -1;
 	display: grid;
 	grid-template-columns: subgrid;
-	color: rgb(var(--smoothly-table-contrast));
-	background-color: rgb(var(--smoothly-table-color));
+	color: rgb(var(--smoothly-table-foreground));
+	background-color: rgb(var(--smoothly-table-background));
 }

--- a/src/components/next/table/expandable/arrow.css
+++ b/src/components/next/table/expandable/arrow.css
@@ -11,8 +11,8 @@
 	height: 0.4em;
 	width: 0.4em;
 	left: 0.3em;
-	border-bottom: 1px solid rgb(var(--smoothly-table-contrast));
-	border-right: 1px solid rgb(var(--smoothly-table-contrast));
+	border-bottom: 1px solid rgb(var(--smoothly-table-foreground));
+	border-right: 1px solid rgb(var(--smoothly-table-foreground));
 	transition: transform 200ms ease-in-out;
 	transform: rotate(-45deg);
 	opacity: 0.3;

--- a/src/components/next/table/expandable/arrow.scss
+++ b/src/components/next/table/expandable/arrow.scss
@@ -10,8 +10,8 @@
 		height: 0.4em;
 		width: 0.4em;
 		left: 0.3em;
-		border-bottom: 1px solid rgb(var(--smoothly-table-contrast));
-		border-right: 1px solid rgb(var(--smoothly-table-contrast));
+		border-bottom: 1px solid rgb(var(--smoothly-table-foreground));
+		border-right: 1px solid rgb(var(--smoothly-table-foreground));
 		transition: rotate 200ms ease-in-out;
 		rotate: -45deg;
 		opacity: 0.3;
@@ -20,8 +20,8 @@
 
 @mixin arrow-hover {
 	&::before {
-		border-bottom: 1px solid rgb(var(--smoothly-table-hover-contrast));
-		border-right: 1px solid rgb(var(--smoothly-table-hover-contrast));
+		border-bottom: 1px solid rgb(var(--smoothly-table-hover-foreground));
+		border-right: 1px solid rgb(var(--smoothly-table-hover-foreground));
 		opacity: 1;
 	}
 }

--- a/src/components/next/table/expandable/cell/style.scss
+++ b/src/components/next/table/expandable/cell/style.scss
@@ -26,10 +26,10 @@
 }
 
 :host>div.content:hover {
-	background-color: rgb(var(--smoothly-table-hover-color));
-	color: rgb(var(--smoothly-table-hover-contrast));
-	stroke: rgb(var(--smoothly-table-hover-contrast));
-	fill: rgb(var(--smoothly-table-hover-contrast));
+	background-color: rgb(var(--smoothly-table-hover-background));
+	color: rgb(var(--smoothly-table-hover-foreground));
+	stroke: rgb(var(--smoothly-table-hover-foreground));
+	fill: rgb(var(--smoothly-table-hover-foreground));
 }
 
 :host>div:first-child {
@@ -48,10 +48,10 @@
 }
 
 :host[open]>div {
-	background-color: rgb(var(--smoothly-table-expanded-color));
-	color: rgb(var(--smoothly-table-expanded-contrast));
-	stroke: rgb(var(--smoothly-table-expanded-contrast));
-	fill: rgb(var(--smoothly-table-expanded-contrast));
+	background-color: rgb(var(--smoothly-table-expanded-background));
+	color: rgb(var(--smoothly-table-expanded-foreground));
+	stroke: rgb(var(--smoothly-table-expanded-foreground));
+	fill: rgb(var(--smoothly-table-expanded-foreground));
 }
 
 :host:not([open])>div.detail {
@@ -67,9 +67,9 @@
 	bottom: 0;
 	left: -1em;
 	width: 1em;
-	background-color: rgb(var(--smoothly-table-expanded-color));
+	background-color: rgb(var(--smoothly-table-expanded-background));
 	border-left: 0.3em solid rgb(var(--smoothly-table-border));
-	box-shadow: 2px 0px 0px 0px rgb(var(--smoothly-table-expanded-color)),
+	box-shadow: 2px 0px 0px 0px rgb(var(--smoothly-table-expanded-background)),
 		0px 0px 1px 0px rgb(var(--smoothly-table-border));
 }
 
@@ -81,7 +81,7 @@
 	bottom: 0;
 	right: -1em;
 	width: 1em;
-	background-color: rgb(var(--smoothly-table-expanded-color));
-	box-shadow: -2px 0px 0px 0px rgb(var(--smoothly-table-expanded-color)),
+	background-color: rgb(var(--smoothly-table-expanded-background));
+	box-shadow: -2px 0px 0px 0px rgb(var(--smoothly-table-expanded-background)),
 		0px 0px 1px 0px rgb(var(--smoothly-table-border));
 }

--- a/src/components/next/table/expandable/row/style.scss
+++ b/src/components/next/table/expandable/row/style.scss
@@ -13,13 +13,13 @@
 }
 
 :host:has(>:not(:last-child):hover)> :not(:last-child) {
-	background-color: rgb(var(--smoothly-table-hover-color));
-	color: rgb(var(--smoothly-table-hover-contrast));
+	background-color: rgb(var(--smoothly-table-hover-background));
+	color: rgb(var(--smoothly-table-hover-foreground));
 }
 
 :host[open] {
-	background-color: rgb(var(--smoothly-table-expanded-color));
-	color: rgb(var(--smoothly-table-expanded-contrast));
+	background-color: rgb(var(--smoothly-table-expanded-background));
+	color: rgb(var(--smoothly-table-expanded-foreground));
 	grid-template-rows: auto 1fr;
 	box-shadow: 0px 1px 1px -1px rgb(var(--smoothly-table-border)),
 		0px 0px 1px rgb(var(--smoothly-table-border)) inset;
@@ -31,8 +31,8 @@
 	cursor: default;
 	position: relative;
 	overflow: hidden;
-	background-color: rgb(var(--smoothly-table-expanded-color));
-	color: rgb(var(--smoothly-table-expanded-contrast));
+	background-color: rgb(var(--smoothly-table-expanded-background));
+	color: rgb(var(--smoothly-table-expanded-foreground));
 }
 
 :host> :first-child:not(:last-child) {
@@ -62,9 +62,9 @@
 	bottom: 0;
 	left: -1em;
 	width: 1em;
-	background-color: rgb(var(--smoothly-table-expanded-color));
+	background-color: rgb(var(--smoothly-table-expanded-background));
 	border-left: 0.3em solid rgb(var(--smoothly-table-border));
-	box-shadow: 2px 0px 0px 0px rgb(var(--smoothly-table-expanded-color)),
+	box-shadow: 2px 0px 0px 0px rgb(var(--smoothly-table-expanded-background)),
 		0px 0px 1px 0px rgb(var(--smoothly-table-border));
 }
 
@@ -76,7 +76,7 @@
 	bottom: 0;
 	right: -1em;
 	width: 1em;
-	background-color: rgb(var(--smoothly-table-expanded-color));
-	box-shadow: -2px 0px 0px 0px rgb(var(--smoothly-table-expanded-color)),
+	background-color: rgb(var(--smoothly-table-expanded-background));
+	box-shadow: -2px 0px 0px 0px rgb(var(--smoothly-table-expanded-background)),
 		0px 0px 1px 0px rgb(var(--smoothly-table-border));
 }

--- a/src/components/next/table/foot/style.css
+++ b/src/components/next/table/foot/style.css
@@ -5,8 +5,8 @@
 	position: sticky;
 	z-index: 1;
 	bottom: 0;
-	background-color: rgb(var(--smoothly-table-footer-color));
-	color: rgb(var(--smoothly-table-footer-contrast));
-	stroke: rgb(var(--smoothly-table-footer-contrast));
-	fill: rgb(var(--smoothly-table-footer-contrast));
+	background-color: rgb(var(--smoothly-table-footer-background));
+	color: rgb(var(--smoothly-table-footer-foreground));
+	stroke: rgb(var(--smoothly-table-footer-foreground));
+	fill: rgb(var(--smoothly-table-footer-foreground));
 }

--- a/src/components/next/table/head/style.css
+++ b/src/components/next/table/head/style.css
@@ -5,11 +5,11 @@
 	top: 0;
 	position: sticky;
 	z-index: 1;
-	--smoothly-color: var(--smoothly-table-header-color);
-	--smoothly-color-contrast: var(--smoothly-table-header-contrast);
-	background-color: rgb(var(--smoothly-table-header-color));
-	color: rgb(var(--smoothly-table-header-contrast));
-	stroke: rgb(var(--smoothly-table-header-contrast));
-	fill: rgb(var(--smoothly-table-header-contrast));
+	--smoothly-color: var(--smoothly-table-header-background);
+	--smoothly-color-contrast: var(--smoothly-table-header-foreground);
+	background-color: rgb(var(--smoothly-table-header-background));
+	color: rgb(var(--smoothly-table-header-foreground));
+	stroke: rgb(var(--smoothly-table-header-foreground));
+	fill: rgb(var(--smoothly-table-header-foreground));
 	font-weight: bold;
 }

--- a/src/components/next/table/style.css
+++ b/src/components/next/table/style.css
@@ -1,7 +1,7 @@
 :host {
 	display: grid;
 	grid-template-columns: repeat(var(--columns), auto);
-	color: rgb(var(--smoothly-table-contrast));
-	stroke: rgb(var(--smoothly-table-contrast));
-	fill: rgb(var(--smoothly-table-contrast));
+	color: rgb(var(--smoothly-table-foreground));
+	stroke: rgb(var(--smoothly-table-foreground));
+	fill: rgb(var(--smoothly-table-foreground));
 }


### PR DESCRIPTION
Setting all css mapping colors to have have suffix `background`, `foreground` or `border`