### PR TITLE
smoothly-item - style marked slotted content same as hover

### DIFF
--- a/src/components/item/style.css
+++ b/src/components/item/style.css
@@ -27,6 +27,7 @@
 	stroke: rgb(var(--smoothly-input-hover-foreground));
 }
 
+:host([marked])::slotted(*),
 :host:hover::slotted(*) {
 	color: rgb(var(--smoothly-input-hover-foreground));
 	fill: rgb(var(--smoothly-input-hover-foreground));


### PR DESCRIPTION
## Before
![Screenshot from 2024-07-24 16-30-23](https://github.com/user-attachments/assets/92b4827d-5373-44b5-97e5-02a548403aee)

## After
![Screenshot from 2024-07-24 16-30-01](https://github.com/user-attachments/assets/aecaf85c-3924-444d-b2cc-f4d191a09d3d)
