### PR TITLE
select bug fix for items with slotted elements

### DIFF
--- a/src/components/input/select/index.tsx
+++ b/src/components/input/select/index.tsx
@@ -187,9 +187,11 @@ export class SmoothlyInputSelect implements Input, Editable, Clearable, Componen
 		event && event.stopPropagation()
 		const wasButtonClicked =
 			event?.composedPath().some(e => e == this.iconsDiv) && !event.composedPath().some(e => e == this.toggle)
-
+		const clickedItem = event
+			?.composedPath()
+			.find((el): el is HTMLSmoothlyItemElement => "tagName" in el && el.tagName == "SMOOTHLY-ITEM")
 		!this.readonly &&
-			!(event?.target && this.items.includes(event.target as HTMLSmoothlyItemElement) && this.multiple) &&
+			!(clickedItem && this.items.includes(clickedItem) && this.multiple) &&
 			!wasButtonClicked &&
 			(this.open = !this.open)
 		this.filter = ""


### PR DESCRIPTION

When an element (e.g. div) inside an item get's clicked then event.target will be the inner div **not the smoothly-item!**.
This causes bugs for `smoothly-input-select`, especially when `multiple` is set, since the the options should remain open when selecting an item, but it will instead close when the code thinks you clicked on a non-item element.

The PR uses `event.composedPath()` to find if any smoothly-item was clicked.

## Example
Code:
![image](https://github.com/user-attachments/assets/d0482d3f-973f-4eba-a755-7982c7f86d16)

### Before
[Screencast from 2024-07-25 12:00:32.webm](https://github.com/user-attachments/assets/d648cff3-294f-4710-98e4-22c1bc77454c)


### After
[Screencast from 2024-07-25 12:00:59.webm](https://github.com/user-attachments/assets/14029a4f-44ed-4266-860b-16c44531a962)

