### PR TITLE
fix input-submit disabled bug

### DIFF
--- a/src/components/input/submit/index.tsx
+++ b/src/components/input/submit/index.tsx
@@ -28,8 +28,7 @@ export class SmoothlyInputSubmit implements ComponentWillLoad {
 				parent.listen("changed", async p => {
 					this.display = !p.readonly
 					this.disabled =
-						!this.delete &&
-						(p.readonly || Object.values(p.value).filter(val => val).length < 1 || !p.changed || this.disabled)
+						!this.delete && (p.readonly || Object.values(p.value).filter(val => val).length < 1 || !p.changed)
 				})
 			}
 		})


### PR DESCRIPTION
[This](https://github.com/utily/smoothly/pull/778/files) change from 1.1.1-alpha.50 -> 1.1.1-alpha.51 broke the submit button so it's always disabled.