### PR TITLE
Improve select options div position

### DIFF
--- a/src/components/input/select/style.css
+++ b/src/components/input/select/style.css
@@ -97,19 +97,22 @@
 	overflow-x: hidden;
 	overflow-y: auto;
 	background-color: rgb(var(--smoothly-input-background));
-	width: 100%;
+	left: 0;
+	right: 0;
 }
 
 :host[looks=border]>div.options {
-	transform: translateX(-1px);
 	border: rgb(var(--smoothly-input-border, var(--smoothly-color-contrast))) solid 1px;
 	border-top: rgba(var(--smoothly-input-border, var(--smoothly-color-contrast)), .4) solid 1px;
+	left: -1px;
+	right: -1px;
 }
 
 :host[looks="grid"]>div.options {
-	transform: translateX(-2px);
 	border: rgba(var(--smoothly-input-border, var(--smoothly-color-contrast)), .5) solid 2px;
 	border-top: rgba(var(--smoothly-input-border, var(--smoothly-color-contrast)), .2) solid 2px;
+	left: -2px;
+	right: -2px;
 }
 
 :host>div.options::slotted(smoothly-item) {


### PR DESCRIPTION

## The Issue
The options div is relative to the padding area (inside the border) of smoothly-input-select, so the position is off.
Here I've put big borders to demonstrate this.
![Screenshot from 2024-07-26 09-20-49](https://github.com/user-attachments/assets/d494ab24-2490-4496-a6b5-9e8a4a3ac4eb)


## Before Example
To compensate for this I use the `left` and `right` inset instead of `translateX` which just moves the div.
![image](https://github.com/user-attachments/assets/cffc3a3c-e39d-4475-8b51-d0e41465ced6)


## After Example
![image](https://github.com/user-attachments/assets/05c7f83c-2b03-449f-920a-01a6db6c8fed)

How ever this is still not perfect since at some scales the options div might be off by a pixel.
The really fix this we should put the border on an element inside Host (smoothly-input-select) instead of on the host. 
This way both divs are be placed relative to the same parent.
But this was the quickest an easiest fix for now.