### PR TITLE
input-date-range implements Editable

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -270,6 +270,7 @@ export namespace Components {
         "max"?: isoly.Date;
         "min"?: isoly.Date;
         "name": string;
+        "placeholder": string;
         "readonly": boolean;
         "reset": () => Promise<void>;
         "setInitialValue": () => Promise<void>;
@@ -2349,6 +2350,7 @@ declare namespace LocalJSX {
         "onSmoothlyInput"?: (event: SmoothlyInputDateRangeCustomEvent<{ [name: string]: isoly.DateRange | undefined }>) => void;
         "onSmoothlyInputLoad"?: (event: SmoothlyInputDateRangeCustomEvent<(parent: HTMLElement) => void>) => void;
         "onSmoothlyInputLooks"?: (event: SmoothlyInputDateRangeCustomEvent<(looks: Looks, color: Color) => void>) => void;
+        "placeholder"?: string;
         "readonly"?: boolean;
         "showLabel"?: boolean;
         "start"?: isoly.Date | undefined;

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -260,13 +260,19 @@ export namespace Components {
         "value"?: Date;
     }
     interface SmoothlyInputDateRange {
+        "changed": boolean;
         "clear": () => Promise<void>;
         "color"?: Color;
+        "edit": (editable: boolean) => Promise<void>;
         "end": isoly.Date | undefined;
+        "listen": (property: "changed", listener: (parent: Editable) => Promise<void>) => Promise<void>;
         "looks": Looks;
         "max"?: isoly.Date;
         "min"?: isoly.Date;
         "name": string;
+        "readonly": boolean;
+        "reset": () => Promise<void>;
+        "setInitialValue": () => Promise<void>;
         "showLabel": boolean;
         "start": isoly.Date | undefined;
     }
@@ -1226,6 +1232,7 @@ declare global {
         "smoothlyInput": { [name: string]: isoly.DateRange | undefined };
         "smoothlyInputLoad": (parent: HTMLElement) => void;
         "smoothlyInputLooks": (looks: Looks, color: Color) => void;
+        "smoothlyFormDisable": (disabled: boolean) => void;
     }
     interface HTMLSmoothlyInputDateRangeElement extends Components.SmoothlyInputDateRange, HTMLStencilElement {
         addEventListener<K extends keyof HTMLSmoothlyInputDateRangeElementEventMap>(type: K, listener: (this: HTMLSmoothlyInputDateRangeElement, ev: SmoothlyInputDateRangeCustomEvent<HTMLSmoothlyInputDateRangeElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -2331,15 +2338,18 @@ declare namespace LocalJSX {
         "value"?: Date;
     }
     interface SmoothlyInputDateRange {
+        "changed"?: boolean;
         "color"?: Color;
         "end"?: isoly.Date | undefined;
         "looks"?: Looks;
         "max"?: isoly.Date;
         "min"?: isoly.Date;
         "name"?: string;
+        "onSmoothlyFormDisable"?: (event: SmoothlyInputDateRangeCustomEvent<(disabled: boolean) => void>) => void;
         "onSmoothlyInput"?: (event: SmoothlyInputDateRangeCustomEvent<{ [name: string]: isoly.DateRange | undefined }>) => void;
         "onSmoothlyInputLoad"?: (event: SmoothlyInputDateRangeCustomEvent<(parent: HTMLElement) => void>) => void;
         "onSmoothlyInputLooks"?: (event: SmoothlyInputDateRangeCustomEvent<(looks: Looks, color: Color) => void>) => void;
+        "readonly"?: boolean;
         "showLabel"?: boolean;
         "start"?: isoly.Date | undefined;
     }

--- a/src/components/input/clear/index.tsx
+++ b/src/components/input/clear/index.tsx
@@ -27,7 +27,7 @@ export class SmoothlyInputClear {
 		this.smoothlyInputLoad.emit(parent => {
 			if (Clearable.is(parent)) {
 				this.parent = parent
-				if (Editable.Element.type.is(parent)) {
+				if (Editable.Element.is(parent)) {
 					parent.listen("changed", async p => {
 						if (Input.is(p)) {
 							this.disabled = p.readonly ? true : p.value ? !p.value : !p.changed

--- a/src/components/input/date/range/index.tsx
+++ b/src/components/input/date/range/index.tsx
@@ -1,6 +1,7 @@
-import { Component, Element, Event, EventEmitter, h, Host, Listen, Method, Prop, State } from "@stencil/core"
+import { Component, Element, Event, EventEmitter, h, Host, Listen, Method, Prop, State, Watch } from "@stencil/core"
 import { isoly } from "isoly"
 import { Clearable } from "../../Clearable"
+import { Editable } from "../../Editable"
 import { Input } from "../../Input"
 import { Looks } from "../../Looks"
 import { Color, Data } from "./../../../../model"
@@ -10,25 +11,35 @@ import { Color, Data } from "./../../../../model"
 	styleUrl: "style.scss",
 	scoped: true,
 })
-export class SmoothlyInputDateRange implements Clearable, Input {
+export class SmoothlyInputDateRange implements Clearable, Input, Editable {
 	@Element() element: HTMLElement
 	@Prop() name: string = "dateRange"
 	@Prop({ reflect: true, mutable: true }) color?: Color
 	@Prop({ reflect: true, mutable: true }) looks: Looks = "plain"
+	@Prop({ reflect: true, mutable: true }) readonly = false
 	@Prop({ reflect: true }) showLabel = true
 	@Prop({ mutable: true }) start: isoly.Date | undefined
 	@Prop({ mutable: true }) end: isoly.Date | undefined
 	@Prop() max?: isoly.Date
 	@Prop() min?: isoly.Date
+	@Prop({ mutable: true }) changed = false // TODO
+	private listener: { changed?: (parent: Editable) => Promise<void> } = {}
+	private initialStart?: isoly.Date
+	private initialEnd?: isoly.Date
+	@State() value?: isoly.DateRange
 	@State() open: boolean
 	@Event() smoothlyInput: EventEmitter<{ [name: string]: isoly.DateRange | undefined }>
 	@Event() smoothlyInputLoad: EventEmitter<(parent: HTMLElement) => void>
 	@Event() smoothlyInputLooks: EventEmitter<(looks: Looks, color: Color) => void>
+	@Event() smoothlyFormDisable: EventEmitter<(disabled: boolean) => void> // TODO
 
 	componentWillLoad() {
+		this.setInitialValue()
+		this.updateValue()
 		this.smoothlyInputLoad.emit(_ => {})
 		this.smoothlyInputLooks.emit((looks, color) => ((this.looks = looks), !this.color && (this.color = color)))
 		this.start && this.end && this.smoothlyInput.emit({ [this.name]: { start: this.start, end: this.end } })
+		!this.readonly && this.smoothlyFormDisable.emit(readonly => (this.readonly = readonly))
 	}
 	// TODO: disable search fields in month selectors so that the input becomes typeable and then fix input handler
 	inputHandler(data: Data) {
@@ -37,6 +48,16 @@ export class SmoothlyInputDateRange implements Clearable, Input {
 			this.start = split[0]
 			this.end = split[1]
 		}
+	}
+	@Watch("start")
+	@Watch("end")
+	updateValue() {
+		this.value = this.start && this.end ? { start: this.start, end: this.end } : undefined
+	}
+	@Watch("value")
+	valueChanged() {
+		this.changed = this.initialStart != this.start || this.initialEnd != this.end
+		this.listener.changed?.(this)
 	}
 	@Listen("smoothlyInputLoad")
 	SmoothlyInputLoadHandler(event: CustomEvent<(parent: SmoothlyInputDateRange) => void>): void {
@@ -51,6 +72,26 @@ export class SmoothlyInputDateRange implements Clearable, Input {
 			event.stopPropagation()
 	}
 	@Method()
+	async listen(property: "changed", listener: (parent: Editable) => Promise<void>) {
+		this.listener[property] = listener
+		listener(this)
+	}
+	@Method()
+	async edit(editable: boolean) {
+		this.readonly = !editable
+	}
+	@Method()
+	async reset() {
+		this.start = this.initialStart
+		this.end = this.initialEnd
+	}
+	@Method()
+	async setInitialValue() {
+		this.initialStart = this.start
+		this.initialEnd = this.end
+		this.changed = false
+	}
+	@Method()
 	async clear(): Promise<void> {
 		this.start = undefined
 		this.end = undefined
@@ -59,10 +100,11 @@ export class SmoothlyInputDateRange implements Clearable, Input {
 	render() {
 		return (
 			<Host tabindex={0}>
-				<section onClick={() => (this.open = !this.open)}>
+				<section onClick={() => !this.readonly && (this.open = !this.open)}>
 					<smoothly-input
 						type="text" // TODO: date-range tidily thing
 						name="dateRangeInput"
+						readonly={this.readonly}
 						value={`${this.start ? this.start : "from "} - ${this.end ? this.end : " to"}`}
 						showLabel={this.showLabel}
 						onSmoothlyInput={e => {

--- a/src/components/input/date/range/index.tsx
+++ b/src/components/input/date/range/index.tsx
@@ -23,7 +23,7 @@ export class SmoothlyInputDateRange implements Clearable, Input, Editable {
 	@Prop() placeholder = "from - to"
 	@Prop() max?: isoly.Date
 	@Prop() min?: isoly.Date
-	@Prop({ mutable: true }) changed = false // TODO
+	@Prop({ mutable: true }) changed = false
 	private listener: { changed?: (parent: Editable) => Promise<void> } = {}
 	private initialStart?: isoly.Date
 	private initialEnd?: isoly.Date
@@ -32,7 +32,7 @@ export class SmoothlyInputDateRange implements Clearable, Input, Editable {
 	@Event() smoothlyInput: EventEmitter<{ [name: string]: isoly.DateRange | undefined }>
 	@Event() smoothlyInputLoad: EventEmitter<(parent: HTMLElement) => void>
 	@Event() smoothlyInputLooks: EventEmitter<(looks: Looks, color: Color) => void>
-	@Event() smoothlyFormDisable: EventEmitter<(disabled: boolean) => void> // TODO
+	@Event() smoothlyFormDisable: EventEmitter<(disabled: boolean) => void>
 
 	componentWillLoad() {
 		this.setInitialValue()

--- a/src/components/input/date/range/index.tsx
+++ b/src/components/input/date/range/index.tsx
@@ -20,7 +20,7 @@ export class SmoothlyInputDateRange implements Clearable, Input, Editable {
 	@Prop({ reflect: true }) showLabel = true
 	@Prop({ mutable: true }) start: isoly.Date | undefined
 	@Prop({ mutable: true }) end: isoly.Date | undefined
-	@Prop() placeholder = "from - to"
+	@Prop() placeholder = "from — to"
 	@Prop() max?: isoly.Date
 	@Prop() min?: isoly.Date
 	@Prop({ mutable: true }) changed = false
@@ -106,7 +106,7 @@ export class SmoothlyInputDateRange implements Clearable, Input, Editable {
 						type="text" // TODO: date-range tidily thing
 						name="dateRangeInput"
 						readonly={this.readonly}
-						value={this.start && this.end ? `${this.start} - ${this.end}` : undefined}
+						value={this.start && this.end ? `${this.start} — ${this.end}` : undefined}
 						placeholder={this.placeholder}
 						showLabel={this.showLabel}
 						onSmoothlyInput={e => {

--- a/src/components/input/date/range/index.tsx
+++ b/src/components/input/date/range/index.tsx
@@ -20,6 +20,7 @@ export class SmoothlyInputDateRange implements Clearable, Input, Editable {
 	@Prop({ reflect: true }) showLabel = true
 	@Prop({ mutable: true }) start: isoly.Date | undefined
 	@Prop({ mutable: true }) end: isoly.Date | undefined
+	@Prop() placeholder = "from - to"
 	@Prop() max?: isoly.Date
 	@Prop() min?: isoly.Date
 	@Prop({ mutable: true }) changed = false // TODO
@@ -105,13 +106,15 @@ export class SmoothlyInputDateRange implements Clearable, Input, Editable {
 						type="text" // TODO: date-range tidily thing
 						name="dateRangeInput"
 						readonly={this.readonly}
-						value={`${this.start ? this.start : "from "} - ${this.end ? this.end : " to"}`}
+						value={this.start && this.end ? `${this.start} - ${this.end}` : undefined}
+						placeholder={this.placeholder}
 						showLabel={this.showLabel}
 						onSmoothlyInput={e => {
 							e.stopPropagation()
 							this.inputHandler(e.detail)
-						}}
-					/>
+						}}>
+						<slot></slot>
+					</smoothly-input>
 				</section>
 				<span class={"icons"}>
 					<slot name={"end"}></slot>

--- a/src/components/input/demo/index.tsx
+++ b/src/components/input/demo/index.tsx
@@ -28,7 +28,11 @@ export class SmoothlyInputDemo {
 					<smoothly-input-submit slot="submit"></smoothly-input-submit>
 				</smoothly-form>
 				<h2>input-date-range outside from</h2>
-				<smoothly-input-date-range onSmoothlyInput={e => console.log("dateRange: ", e)}></smoothly-input-date-range>
+				<smoothly-input-date-range onSmoothlyInput={e => console.log("dateRange: ", e)}>
+					<smoothly-input-clear slot="end" size="icon">
+						<smoothly-icon name="close"></smoothly-icon>
+					</smoothly-input-clear>
+				</smoothly-input-date-range>
 				<h2>Controlled form</h2>
 				<smoothly-input-demo-controlled-form />
 				<h2>Create form defaulting type</h2>
@@ -147,6 +151,7 @@ export class SmoothlyInputDemo {
 					<smoothly-input-checkbox name="checkbox2" checked>
 						Check the box 2
 					</smoothly-input-checkbox>
+					<smoothly-input-date-range start={isoly.Date.now()} end={isoly.Date.now()}></smoothly-input-date-range>
 					<smoothly-input-range step={1} name="range3" value={20000}>
 						Select
 					</smoothly-input-range>

--- a/src/components/input/demo/index.tsx
+++ b/src/components/input/demo/index.tsx
@@ -29,6 +29,7 @@ export class SmoothlyInputDemo {
 				</smoothly-form>
 				<h2>input-date-range outside from</h2>
 				<smoothly-input-date-range onSmoothlyInput={e => console.log("dateRange: ", e)}>
+					Date Range
 					<smoothly-input-clear slot="end" size="icon">
 						<smoothly-icon name="close"></smoothly-icon>
 					</smoothly-input-clear>


### PR DESCRIPTION
input-date-range should now act correctly in smoothly-form, and together with input-clear, input-reset, etc.
![image](https://github.com/user-attachments/assets/880c24de-46b4-46fc-8359-56dda9d5fde0)


## Also 
Fixed the label so it's properly placed

### Before
![image](https://github.com/user-attachments/assets/08fb2883-b43a-45e2-86a9-183fa928bed0)

### After
![image](https://github.com/user-attachments/assets/9960982a-7e20-4e48-823e-98b752c79277)
