### PR TITLE
Fix input clear

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -377,6 +377,7 @@ export namespace Components {
         "clear": () => Promise<void>;
         "clearable": boolean;
         "color"?: Color;
+        "defined": boolean;
         "edit": (editable: boolean) => Promise<void>;
         "inCalendar": boolean;
         "listen": (property: "changed", listener: (parent: Editable) => Promise<void>) => Promise<void>;
@@ -2453,6 +2454,7 @@ declare namespace LocalJSX {
         "changed"?: boolean;
         "clearable"?: boolean;
         "color"?: Color;
+        "defined"?: boolean;
         "inCalendar"?: boolean;
         "looks"?: Looks;
         "menuHeight"?: `${number}${"items" | "rem" | "px" | "vh"}`;

--- a/src/components/input/Input.ts
+++ b/src/components/input/Input.ts
@@ -14,6 +14,7 @@ export namespace Input {
 		color?: Color
 		name: string
 		looks: Looks
+		defined?: boolean
 		binary?: Binary
 	}
 	export namespace Element {
@@ -22,6 +23,7 @@ export namespace Input {
 			color: Color.type.optional(),
 			name: isly.string(),
 			looks: Looks.type,
+			defined: isly.boolean().optional(),
 			binary: isly.function<Binary>().optional(),
 		})
 		export const is = type.is

--- a/src/components/input/clear/index.tsx
+++ b/src/components/input/clear/index.tsx
@@ -30,11 +30,10 @@ export class SmoothlyInputClear {
 				if (Editable.Element.is(parent)) {
 					parent.listen("changed", async p => {
 						if (Input.is(p)) {
-							this.disabled = p.readonly ? true : p.value ? !p.value : !p.changed
-							this.display = p.readonly ? false : p.value ? Boolean(p.value) : p.changed
+							this.display = !p.readonly && (typeof p.defined == "boolean" ? p.defined : Boolean(p.value))
 						}
 						if (p instanceof SmoothlyForm) {
-							this.disabled = p.readonly ? true : Object.values(p.value).filter(val => val).length < 1
+							this.disabled = p.readonly || Object.values(p.value).filter(val => val).length < 1
 							this.display = !p.readonly
 						}
 					})

--- a/src/components/input/range/index.tsx
+++ b/src/components/input/range/index.tsx
@@ -1,4 +1,17 @@
-import { Component, ComponentWillLoad, Event, EventEmitter, h, Host, Method, Prop, VNode, Watch } from "@stencil/core"
+import {
+	Component,
+	ComponentWillLoad,
+	Element,
+	Event,
+	EventEmitter,
+	h,
+	Host,
+	Listen,
+	Method,
+	Prop,
+	VNode,
+	Watch,
+} from "@stencil/core"
 import { Color } from "../../../model"
 import { Clearable } from "../Clearable"
 import { Editable } from "../Editable"
@@ -11,6 +24,7 @@ import { Looks } from "../Looks"
 	scoped: true,
 })
 export class SmoothlyInputRange implements Input, Clearable, Editable, ComponentWillLoad {
+	@Element() element: HTMLSmoothlyInputRangeElement
 	private listener: { changed?: (parent: Editable) => Promise<void> } = {}
 	@Prop({ mutable: true }) value: number | undefined = undefined
 	private initialValue = this.value
@@ -19,7 +33,7 @@ export class SmoothlyInputRange implements Input, Clearable, Editable, Component
 	@Prop({ reflect: true, mutable: true }) readonly = false
 	@Prop() min = 0
 	@Prop() max = 100000
-	@Prop() name: string
+	@Prop() name = "range"
 	@Prop() labelText?: string
 	@Prop() step: number | "any" = "any"
 	@Prop() outputSide: "right" | "left" = "left"
@@ -67,6 +81,13 @@ export class SmoothlyInputRange implements Input, Clearable, Editable, Component
 		event.target instanceof HTMLInputElement &&
 			(this.value =
 				this.step !== "any" ? event.target.valueAsNumber : Math.round(event.target.valueAsNumber * 100) / 100)
+	}
+	@Listen("smoothlyInputLoad")
+	smoothlyInputLoadHandler(event: CustomEvent<(parent: unknown) => void>) {
+		if (event.target != this.element) {
+			event.stopPropagation()
+			event.detail(this)
+		}
 	}
 
 	render(): VNode | VNode[] {

--- a/src/components/input/select/index.tsx
+++ b/src/components/input/select/index.tsx
@@ -44,6 +44,7 @@ export class SmoothlyInputSelect implements Input, Editable, Clearable, Componen
 	@Prop() multiple = false
 	@Prop() clearable = true
 	@Prop({ mutable: true }) changed = false
+	@Prop({ mutable: true }) defined = false
 	@Prop({ reflect: true }) placeholder?: string | any
 	@Prop() menuHeight?: `${number}${"items" | "rem" | "px" | "vh"}`
 	@Prop() required = false
@@ -119,6 +120,7 @@ export class SmoothlyInputSelect implements Input, Editable, Clearable, Componen
 	@Watch("selected")
 	onSelectedChange() {
 		this.initialValueHandled && (this.changed = !this.areValuesEqual(this.selected, this.initialValue))
+		this.defined = this.selected.length > 0
 		const value =
 			!this.multiple && this.selected[0]
 				? this.selected[0].value


### PR DESCRIPTION
Input now has optional `defined` property. 
Useful for inputs without `value` like `smoothly-input-select`.
Also fixed internal clear for `smoothly-input-range`.