### PR TITLE
Let click event propagate

### DIFF
--- a/src/components/input/select/index.tsx
+++ b/src/components/input/select/index.tsx
@@ -169,9 +169,9 @@ export class SmoothlyInputSelect implements Input, Editable, Clearable, Componen
 			this.selected = event.detail.selected
 				? [...this.selected, event.detail]
 				: this.selected.filter(item => item.selected)
-		} else {
+		} else if (event.detail.selected || !this.items.some(e => e.selected)) {
 			this.selected[0] && (this.selected[0].hidden = this.selected[0].selected = false)
-			this.selected = !event.detail.selected ? [] : [event.detail]
+			this.selected = !event.detail.selected ? this.selected.filter(item => item.selected) : [event.detail]
 			!this.showSelected && event.detail.selected && (event.detail.hidden = true)
 		}
 		this.displaySelected()

--- a/src/components/input/select/index.tsx
+++ b/src/components/input/select/index.tsx
@@ -186,7 +186,6 @@ export class SmoothlyInputSelect implements Input, Editable, Clearable, Componen
 		}
 	}
 	handleShowOptions(event?: Event): void {
-		event && event.stopPropagation()
 		const wasButtonClicked =
 			event?.composedPath().some(e => e == this.iconsDiv) && !event.composedPath().some(e => e == this.toggle)
 		const clickedItem = event


### PR DESCRIPTION
When the click event is stopped, an opened select would not close if you clicked another select. Also it's a bit weird stopping keyboard or click events.