### PR TITLE
Input clear same layout and style as reset

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -255,6 +255,7 @@ export namespace Components {
         "fill"?: Fill;
         "shape"?: "rounded";
         "size": "small" | "large" | "icon" | "flexible";
+        "tooltip": string;
         "type": "form" | "input";
     }
     interface SmoothlyInputColor {
@@ -2393,6 +2394,7 @@ declare namespace LocalJSX {
         "onSmoothlyInputLoad"?: (event: SmoothlyInputClearCustomEvent<(parent: HTMLElement) => void>) => void;
         "shape"?: "rounded";
         "size"?: "small" | "large" | "icon" | "flexible";
+        "tooltip"?: string;
         "type"?: "form" | "input";
     }
     interface SmoothlyInputColor {

--- a/src/components/form/index.tsx
+++ b/src/components/form/index.tsx
@@ -195,6 +195,7 @@ export class SmoothlyForm implements ComponentWillLoad, Clearable, Submittable, 
 						<slot></slot>
 					</fieldset>
 					<div>
+						<slot name="clear" />
 						<slot name="edit" />
 						<slot name="reset" />
 						<slot name="delete" />

--- a/src/components/input/clear/index.tsx
+++ b/src/components/input/clear/index.tsx
@@ -1,6 +1,5 @@
-import { Component, Event, EventEmitter, h, Listen, Prop } from "@stencil/core"
+import { Component, Event, EventEmitter, h, Host, Listen, Prop } from "@stencil/core"
 import { Color, Fill } from "../../../model"
-import { Button } from "../../button/Button"
 import { SmoothlyForm } from "../../form"
 import { Clearable } from "../Clearable"
 import { Editable } from "../Editable"
@@ -20,6 +19,7 @@ export class SmoothlyInputClear {
 	@Prop({ reflect: true }) shape?: "rounded"
 	@Prop({ reflect: true, mutable: true }) display = true
 	@Prop({ reflect: true }) type: "form" | "input" = "input"
+	@Prop() tooltip = "Clear"
 	private parent?: Clearable | (Clearable & Editable)
 	@Event() smoothlyInputLoad: EventEmitter<(parent: HTMLElement) => void>
 
@@ -47,9 +47,19 @@ export class SmoothlyInputClear {
 	}
 	render() {
 		return (
-			<Button disabled={this.disabled} type="button">
-				<slot />
-			</Button>
+			<Host title={this.tooltip}>
+				<smoothly-button
+					disabled={this.disabled}
+					size={this.size}
+					type={"button"}
+					shape={this.shape}
+					expand={this.expand}
+					color={this.color}
+					fill={this.fill ?? (this.type == "input" ? "clear" : undefined)}>
+					<slot />
+					<smoothly-icon name="close" size="tiny" />
+				</smoothly-button>
+			</Host>
 		)
 	}
 }

--- a/src/components/input/clear/style.css
+++ b/src/components/input/clear/style.css
@@ -1,38 +1,29 @@
 @import "../../button/style.css";
 
+:host {
+	display: flex;
+}
+
 :host(:not([display])) {
 	display: none;
 }
 
-:host() {
-	margin: 0rem;
-	min-width: 0rem;
-	display: flex;
-}
-
-:host([type="input"]) {
-	line-height: 1;
-}
-
-:host([type="form"]) {
-	margin: 1em 0em;
-}
-
-:host([type="input"]) ::slotted(smoothly-icon) {
+:host([type="input"])::slotted(smoothly-button>button) {
+	cursor: pointer;
 	filter: opacity(60%);
-	font-size: 70%;
-	color: rgb(var(--smoothly-input-foreground));
-	fill: rgb(var(--smoothly-input-foreground));
-	stroke: rgb(var(--smoothly-input-foreground));
+	--smoothly-button-foreground: var(--smoothly-input-foreground);
+	background-color: transparent;
+}
+
+:host::slotted(smoothly-button>button > * > * + smoothly-icon) {
+	display: none;
+}
+
+:host([disabled]) {
+	cursor: not-allowed
 }
 
 :host([type="input"]):hover ::slotted(smoothly-icon) {
 	cursor: pointer;
 	filter: opacity(100%);
-}
-
-:host([type="input"])>button {
-	padding: 0rem;
-	margin: 0rem;
-	min-width: 0rem;
 }

--- a/src/components/input/demo/index.tsx
+++ b/src/components/input/demo/index.tsx
@@ -64,9 +64,7 @@ export class SmoothlyInputDemo {
 						<smoothly-item value="3">Cookie</smoothly-item>
 						<smoothly-item value="4">Croissant</smoothly-item>
 						<smoothly-item value="5">Chocolate fondue</smoothly-item>
-						<smoothly-input-clear size="icon" slot="end">
-							<smoothly-icon name="close" />
-						</smoothly-input-clear>
+						<smoothly-input-clear size="icon" slot="end"></smoothly-input-clear>
 					</smoothly-input-select>
 					<smoothly-input-select
 						multiple
@@ -121,15 +119,11 @@ export class SmoothlyInputDemo {
 					</smoothly-input>
 					<smoothly-input name="Last name" value="Doe">
 						Last name
-						<smoothly-input-clear size="icon" slot="end">
-							<smoothly-icon name="close" />
-						</smoothly-input-clear>
+						<smoothly-input-clear size="icon" slot="end"></smoothly-input-clear>
 					</smoothly-input>
 					<smoothly-input type="phone" name="Phone" value={"777888999"}>
 						Phone
-						<smoothly-input-reset size="icon" slot="end">
-							<smoothly-icon name="refresh-outline" />
-						</smoothly-input-reset>
+						<smoothly-input-reset size="icon" slot="end"></smoothly-input-reset>
 					</smoothly-input>
 					<smoothly-input-radio clearable name="radioFirstInput">
 						<p slot="label">Clearable</p>
@@ -160,9 +154,7 @@ export class SmoothlyInputDemo {
 						<smoothly-item value="10">October</smoothly-item>
 						<smoothly-item value="11">November</smoothly-item>
 						<smoothly-item value="12">December</smoothly-item>
-						<smoothly-input-clear size="icon" slot="end">
-							<smoothly-icon name="close" />
-						</smoothly-input-clear>
+						<smoothly-input-clear size="icon" slot="end"></smoothly-input-clear>
 					</smoothly-input-select>
 					<smoothly-input-select name="select-icon" clearable={false} showSelected={false}>
 						<smoothly-item value="folder" selected>
@@ -184,7 +176,7 @@ export class SmoothlyInputDemo {
 						<span slot={"label"}>Profile</span>
 						<smoothly-icon slot={"button"} name={"person-circle-outline"} size={"tiny"} fill={"default"} />
 					</smoothly-input-file>
-					<smoothly-input-clear fill="default" type="form" color="danger" slot="clear" size="icon" shape="rounded" />
+					<smoothly-input-clear fill="default" type="form" color="warning" slot="clear" size="icon" shape="rounded" />
 					<smoothly-input-edit fill="default" type="button" color="tertiary" slot="edit" size="icon" shape="rounded" />
 					<smoothly-input-reset fill="default" type="form" color="warning" slot="reset" size="icon" shape="rounded" />
 					<smoothly-input-submit delete slot="delete" color="danger" size="icon" shape="rounded" />
@@ -206,15 +198,11 @@ export class SmoothlyInputDemo {
 					</smoothly-input>
 					<smoothly-input name="Last name" value="Doe">
 						Last name
-						<smoothly-input-clear size="icon" slot="end">
-							<smoothly-icon name="close" />
-						</smoothly-input-clear>
+						<smoothly-input-clear size="icon" slot="end"></smoothly-input-clear>
 					</smoothly-input>
 					<smoothly-input type="phone" name="Phone" value={"777888999"}>
 						Phone
-						<smoothly-input-reset size="icon" slot="end">
-							<smoothly-icon name="refresh-outline" />
-						</smoothly-input-reset>
+						<smoothly-input-reset size="icon" slot="end"></smoothly-input-reset>
 					</smoothly-input>
 					<smoothly-input-radio clearable name="radioFirstInput">
 						<p slot="label">Clearable</p>
@@ -297,9 +285,7 @@ export class SmoothlyInputDemo {
 					<smoothly-input-range step={1} name="range2">
 						Select with really really long label
 						<smoothly-icon name="checkmark-circle" slot="start" />
-						<smoothly-input-clear size="icon" slot="end">
-							<smoothly-icon name="close" />
-						</smoothly-input-clear>
+						<smoothly-input-clear size="icon" slot="end"></smoothly-input-clear>
 					</smoothly-input-range>
 					<smoothly-input-range step={1} name="range3">
 						Select
@@ -400,15 +386,11 @@ export class SmoothlyInputDemo {
 					</smoothly-input>
 					<smoothly-input name="Last name" value="Doe">
 						Last name
-						<smoothly-input-clear size="icon" slot="end">
-							<smoothly-icon name="close" />
-						</smoothly-input-clear>
+						<smoothly-input-clear size="icon" slot="end"></smoothly-input-clear>
 					</smoothly-input>
 					<smoothly-input type="phone" name="Phone">
 						Phone
-						<smoothly-input-clear size="icon" slot="end">
-							<smoothly-icon name="close" />
-						</smoothly-input-clear>
+						<smoothly-input-clear size="icon" slot="end"></smoothly-input-clear>
 					</smoothly-input>
 					<smoothly-input-reset type="form" color="warning" slot="reset"></smoothly-input-reset>
 				</smoothly-form>
@@ -572,9 +554,7 @@ export class SmoothlyInputDemo {
 						<smoothly-input-checkbox name="second-checkbox" checked>
 							<smoothly-icon name="checkmark-circle" slot="start" size="tiny" />
 							second
-							<smoothly-input-clear size="icon" slot="end">
-								<smoothly-icon name="close" />
-							</smoothly-input-clear>
+							<smoothly-input-clear size="icon" slot="end"></smoothly-input-clear>
 						</smoothly-input-checkbox>
 						<smoothly-input-checkbox name="third-checkbox">3rd</smoothly-input-checkbox>
 					</div>
@@ -583,9 +563,7 @@ export class SmoothlyInputDemo {
 				<smoothly-form onSmoothlyFormSubmit={e => console.log(e.detail)} looks="border">
 					<smoothly-input-radio clearable name="radioFirstInput">
 						<smoothly-icon name="checkmark-circle" slot="start" />
-						<smoothly-input-clear size="icon" slot="end">
-							<smoothly-icon name="close" />
-						</smoothly-input-clear>
+						<smoothly-input-clear size="icon" slot="end"></smoothly-input-clear>
 						<p slot="label">Clearable</p>
 						<smoothly-input-radio-item slot="options" value={"first"}>
 							Label 1

--- a/src/components/input/demo/index.tsx
+++ b/src/components/input/demo/index.tsx
@@ -29,11 +29,21 @@ export class SmoothlyInputDemo {
 				</smoothly-form>
 				<smoothly-input-date name="some-date">Calendar</smoothly-input-date>
 				<h2>input-date-range outside from</h2>
-				<smoothly-input-date-range onSmoothlyInput={e => console.log("dateRange: ", e)}>
+				<smoothly-input-date-range
+					looks="border"
+					start={isoly.Date.now()}
+					end={isoly.Date.now()}
+					onSmoothlyInput={e => console.log("dateRange: ", e)}>
 					Date Range
-					<smoothly-input-clear slot="end" size="icon">
-						<smoothly-icon name="close"></smoothly-icon>
-					</smoothly-input-clear>
+					<smoothly-input-clear slot="end" size="icon"></smoothly-input-clear>
+				</smoothly-input-date-range>
+				<smoothly-input-date-range
+					looks="border"
+					start={isoly.Date.now()}
+					end={isoly.Date.now()}
+					onSmoothlyInput={e => console.log("dateRange: ", e)}>
+					Date Range
+					<smoothly-input-reset slot="end" size="icon"></smoothly-input-reset>
 				</smoothly-input-date-range>
 				<h2>Controlled form</h2>
 				<smoothly-input-demo-controlled-form />
@@ -104,7 +114,7 @@ export class SmoothlyInputDemo {
 				<smoothly-input name="Delayed" delay={2}>
 					Delayed
 				</smoothly-input>
-				<h2>Editable form and Input with Clear and Reset - Readonly</h2>
+				<h2>Editable form and Input with Clear, Reset and Delete - Readonly</h2>
 				<smoothly-form looks="grid" readonly action="https://api.toiletapi.com/6b12fd2f-e896-46f9-b38f-25cf42cee4b4">
 					<smoothly-input readonly name="First Name" value="John">
 						First name
@@ -174,6 +184,7 @@ export class SmoothlyInputDemo {
 						<span slot={"label"}>Profile</span>
 						<smoothly-icon slot={"button"} name={"person-circle-outline"} size={"tiny"} fill={"default"} />
 					</smoothly-input-file>
+					<smoothly-input-clear fill="default" type="form" color="danger" slot="clear" size="icon" shape="rounded" />
 					<smoothly-input-edit fill="default" type="button" color="tertiary" slot="edit" size="icon" shape="rounded" />
 					<smoothly-input-reset fill="default" type="form" color="warning" slot="reset" size="icon" shape="rounded" />
 					<smoothly-input-submit delete slot="delete" color="danger" size="icon" shape="rounded" />

--- a/src/components/input/reset/style.css
+++ b/src/components/input/reset/style.css
@@ -1,3 +1,5 @@
+@import "../../button/style.css";
+
 :host {
 	display: flex;
 }
@@ -6,23 +8,22 @@
 	display: none;
 }
 
-:host([type="input"])>smoothly-button>button {
+:host([type="input"])::slotted(smoothly-button>button) {
+	cursor: pointer;
 	filter: opacity(60%);
 	--smoothly-button-foreground: var(--smoothly-input-foreground);
 	background-color: transparent;
-	
 }
 
-:host([type="input"]):hover>smoothly-button>button {
-	cursor: pointer;
-	filter: opacity(100%);
-	background-color: transparent;
-}
-
-:host::slotted(smoothly-button button > * > * + smoothly-icon) {
+:host::slotted(smoothly-button>button > * > * + smoothly-icon) {
 	display: none;
 }
 
 :host([disabled]) {
 	cursor: not-allowed
+}
+
+:host([type="input"]):hover ::slotted(smoothly-icon) {
+	cursor: pointer;
+	filter: opacity(100%);
 }


### PR DESCRIPTION
input-clear mirrors input-reset in layout and styling.

This way they will work the same when used in an input or a form.

Also add slot for clear in form.

![image](https://github.com/user-attachments/assets/c6f47987-bacf-4bd9-ab34-be8e24238cbe)
