### PR TITLE
Toggle switch size and styling

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -37,6 +37,7 @@
 	"javascript.format.enable": false,
 	"typescript.format.enable": false,
 	"cSpell.words": [
+		"checkmark",
 		"clearables",
 		"cloudly",
 		"Colorpoint",

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -632,7 +632,9 @@ export namespace Components {
         "disabled": boolean;
         "fill": Fill;
         "selected": boolean;
-        "size": "small" | "default" | "large";
+        "size": "tiny" | "small" | "default" | "large";
+    }
+    interface SmoothlyToggleSwitchDemo {
     }
     interface SmoothlyTrigger {
         "color": Color | undefined;
@@ -1998,6 +2000,12 @@ declare global {
         prototype: HTMLSmoothlyToggleSwitchElement;
         new (): HTMLSmoothlyToggleSwitchElement;
     };
+    interface HTMLSmoothlyToggleSwitchDemoElement extends Components.SmoothlyToggleSwitchDemo, HTMLStencilElement {
+    }
+    var HTMLSmoothlyToggleSwitchDemoElement: {
+        prototype: HTMLSmoothlyToggleSwitchDemoElement;
+        new (): HTMLSmoothlyToggleSwitchDemoElement;
+    };
     interface HTMLSmoothlyTriggerElementEventMap {
         "trigger": Trigger;
     }
@@ -2139,6 +2147,7 @@ declare global {
         "smoothly-theme-picker": HTMLSmoothlyThemePickerElement;
         "smoothly-toggle": HTMLSmoothlyToggleElement;
         "smoothly-toggle-switch": HTMLSmoothlyToggleSwitchElement;
+        "smoothly-toggle-switch-demo": HTMLSmoothlyToggleSwitchDemoElement;
         "smoothly-trigger": HTMLSmoothlyTriggerElement;
         "smoothly-trigger-sink": HTMLSmoothlyTriggerSinkElement;
         "smoothly-trigger-source": HTMLSmoothlyTriggerSourceElement;
@@ -2787,7 +2796,9 @@ declare namespace LocalJSX {
         "fill"?: Fill;
         "onSmoothlyToggleSwitchChange"?: (event: SmoothlyToggleSwitchCustomEvent<boolean>) => void;
         "selected"?: boolean;
-        "size"?: "small" | "default" | "large";
+        "size"?: "tiny" | "small" | "default" | "large";
+    }
+    interface SmoothlyToggleSwitchDemo {
     }
     interface SmoothlyTrigger {
         "color"?: Color | undefined;
@@ -2908,6 +2919,7 @@ declare namespace LocalJSX {
         "smoothly-theme-picker": SmoothlyThemePicker;
         "smoothly-toggle": SmoothlyToggle;
         "smoothly-toggle-switch": SmoothlyToggleSwitch;
+        "smoothly-toggle-switch-demo": SmoothlyToggleSwitchDemo;
         "smoothly-trigger": SmoothlyTrigger;
         "smoothly-trigger-sink": SmoothlyTriggerSink;
         "smoothly-trigger-source": SmoothlyTriggerSource;
@@ -3016,6 +3028,7 @@ declare module "@stencil/core" {
             "smoothly-theme-picker": LocalJSX.SmoothlyThemePicker & JSXBase.HTMLAttributes<HTMLSmoothlyThemePickerElement>;
             "smoothly-toggle": LocalJSX.SmoothlyToggle & JSXBase.HTMLAttributes<HTMLSmoothlyToggleElement>;
             "smoothly-toggle-switch": LocalJSX.SmoothlyToggleSwitch & JSXBase.HTMLAttributes<HTMLSmoothlyToggleSwitchElement>;
+            "smoothly-toggle-switch-demo": LocalJSX.SmoothlyToggleSwitchDemo & JSXBase.HTMLAttributes<HTMLSmoothlyToggleSwitchDemoElement>;
             "smoothly-trigger": LocalJSX.SmoothlyTrigger & JSXBase.HTMLAttributes<HTMLSmoothlyTriggerElement>;
             "smoothly-trigger-sink": LocalJSX.SmoothlyTriggerSink & JSXBase.HTMLAttributes<HTMLSmoothlyTriggerSinkElement>;
             "smoothly-trigger-source": LocalJSX.SmoothlyTriggerSource & JSXBase.HTMLAttributes<HTMLSmoothlyTriggerSourceElement>;

--- a/src/components/button/demo/index.tsx
+++ b/src/components/button/demo/index.tsx
@@ -27,17 +27,7 @@ export class SmoothlyButtonDemo {
 				<smoothly-toggle>
 					<smoothly-icon name="airplane" slot="icon-slot"></smoothly-icon>
 				</smoothly-toggle>
-				<h4>Toggle switches</h4>
-				<smoothly-toggle-switch
-					checkmark={false}
-					color="primary"
-					disabled={false}
-					size="small"
-					onSmoothlyToggleSwitchChange={e => {
-						console.log("toggleSwitch ", e.detail)
-					}}></smoothly-toggle-switch>
-				<smoothly-toggle-switch disabled={false}></smoothly-toggle-switch>
-				<smoothly-toggle-switch disabled={false} size="large"></smoothly-toggle-switch>
+				<smoothly-toggle-switch-demo />
 				<h4>Links with icons</h4>
 				<smoothly-button type="link">
 					<smoothly-icon name="checkmark-circle" slot="start"></smoothly-icon>

--- a/src/components/input/demo/index.tsx
+++ b/src/components/input/demo/index.tsx
@@ -11,7 +11,7 @@ export class SmoothlyInputDemo {
 	render() {
 		return (
 			<Host>
-				<h2>Array in Form</h2>
+				{/* <h2>Array in Form</h2>
 				<smoothly-form looks="line" onSmoothlyFormSubmit={e => console.log(e.detail)}>
 					<smoothly-input name="pets.0.name">First Pet's Name</smoothly-input>
 					<smoothly-input-range name="pets.0.age" max={100} step={1}>
@@ -273,12 +273,12 @@ export class SmoothlyInputDemo {
 					<smoothly-item value="10">October</smoothly-item>
 					<smoothly-item value="11">November</smoothly-item>
 					<smoothly-item value="12">December</smoothly-item>
-				</smoothly-input-select>
+				</smoothly-input-select> */}
 				<h2>Color</h2>
 				<smoothly-form looks="border" onSmoothlyFormInput={e => console.log(e.detail)}>
 					<smoothly-input-color name="color">Choose color</smoothly-input-color>
 				</smoothly-form>
-				<h2>Range</h2>
+				{/* <h2>Range</h2>
 				<smoothly-form looks="border">
 					<smoothly-input-range step={1} name="range" outputSide="right">
 						Select and so
@@ -732,7 +732,7 @@ export class SmoothlyInputDemo {
 						Date
 					</smoothly-input-date>
 					<smoothly-input-submit slot="submit" color="success" fill="solid" size="icon"></smoothly-input-submit>
-				</smoothly-form>
+				</smoothly-form> */}
 			</Host>
 		)
 	}

--- a/src/components/input/demo/index.tsx
+++ b/src/components/input/demo/index.tsx
@@ -11,7 +11,7 @@ export class SmoothlyInputDemo {
 	render() {
 		return (
 			<Host>
-				{/* <h2>Array in Form</h2>
+				<h2>Array in Form</h2>
 				<smoothly-form looks="line" onSmoothlyFormSubmit={e => console.log(e.detail)}>
 					<smoothly-input name="pets.0.name">First Pet's Name</smoothly-input>
 					<smoothly-input-range name="pets.0.age" max={100} step={1}>
@@ -273,12 +273,12 @@ export class SmoothlyInputDemo {
 					<smoothly-item value="10">October</smoothly-item>
 					<smoothly-item value="11">November</smoothly-item>
 					<smoothly-item value="12">December</smoothly-item>
-				</smoothly-input-select> */}
+				</smoothly-input-select>
 				<h2>Color</h2>
 				<smoothly-form looks="border" onSmoothlyFormInput={e => console.log(e.detail)}>
 					<smoothly-input-color name="color">Choose color</smoothly-input-color>
 				</smoothly-form>
-				{/* <h2>Range</h2>
+				<h2>Range</h2>
 				<smoothly-form looks="border">
 					<smoothly-input-range step={1} name="range" outputSide="right">
 						Select and so
@@ -732,7 +732,7 @@ export class SmoothlyInputDemo {
 						Date
 					</smoothly-input-date>
 					<smoothly-input-submit slot="submit" color="success" fill="solid" size="icon"></smoothly-input-submit>
-				</smoothly-form> */}
+				</smoothly-form>
 			</Host>
 		)
 	}

--- a/src/components/toggle-switch/demo/index.tsx
+++ b/src/components/toggle-switch/demo/index.tsx
@@ -11,9 +11,10 @@ export class SmoothlyToggleSwitchDemo {
 			<Host>
 				<h4>Toggle switches</h4>
 				<div>
+					<p>Checkmark</p>
 					<span>
 						<p>Tiny</p>
-						<smoothly-toggle-switch disabled={false} checkmark={false} size="tiny"></smoothly-toggle-switch>
+						<smoothly-toggle-switch disabled={false} size="tiny"></smoothly-toggle-switch>
 					</span>
 					<span>
 						<p>Small</p>
@@ -27,6 +28,7 @@ export class SmoothlyToggleSwitchDemo {
 						<p>Large</p>
 						<smoothly-toggle-switch disabled={false} size="large"></smoothly-toggle-switch>
 					</span>
+					<p>Colors checkmark</p>
 					<span>
 						<p>Danger</p>
 						<smoothly-toggle-switch color="danger" disabled={false} size="small"></smoothly-toggle-switch>
@@ -39,7 +41,8 @@ export class SmoothlyToggleSwitchDemo {
 						<p>Secondary color</p>
 						<smoothly-toggle-switch color="secondary" disabled={false} size="small"></smoothly-toggle-switch>
 					</span>
-					<span/>
+					<p></p>
+					<p>Colors no checkmark</p>
 					<span>
 						<p>Danger</p>
 						<smoothly-toggle-switch

--- a/src/components/toggle-switch/demo/index.tsx
+++ b/src/components/toggle-switch/demo/index.tsx
@@ -1,0 +1,71 @@
+import { Component, h, Host } from "@stencil/core"
+
+@Component({
+	tag: "smoothly-toggle-switch-demo",
+	styleUrl: "style.css",
+	scoped: true,
+})
+export class SmoothlyToggleSwitchDemo {
+	render() {
+		return (
+			<Host>
+				<h4>Toggle switches</h4>
+				<div>
+					<span>
+						<p>Tiny</p>
+						<smoothly-toggle-switch disabled={false} checkmark={false} size="tiny"></smoothly-toggle-switch>
+					</span>
+					<span>
+						<p>Small</p>
+						<smoothly-toggle-switch disabled={false} size="small"></smoothly-toggle-switch>
+					</span>
+					<span>
+						<p>Standard</p>
+						<smoothly-toggle-switch disabled={false}></smoothly-toggle-switch>
+					</span>
+					<span>
+						<p>Large</p>
+						<smoothly-toggle-switch disabled={false} size="large"></smoothly-toggle-switch>
+					</span>
+					<span>
+						<p>Danger</p>
+						<smoothly-toggle-switch color="danger" disabled={false} size="small"></smoothly-toggle-switch>
+					</span>
+					<span>
+						<p>Primary color</p>
+						<smoothly-toggle-switch color="primary" disabled={false} size="small"></smoothly-toggle-switch>
+					</span>
+					<span>
+						<p>Secondary color</p>
+						<smoothly-toggle-switch color="secondary" disabled={false} size="small"></smoothly-toggle-switch>
+					</span>
+					<span/>
+					<span>
+						<p>Danger</p>
+						<smoothly-toggle-switch
+							checkmark={false}
+							color="danger"
+							disabled={false}
+							size="small"></smoothly-toggle-switch>
+					</span>
+					<span>
+						<p>Primary color</p>
+						<smoothly-toggle-switch
+							checkmark={false}
+							color="primary"
+							disabled={false}
+							size="small"></smoothly-toggle-switch>
+					</span>
+					<span>
+						<p>Secondary color</p>
+						<smoothly-toggle-switch
+							checkmark={false}
+							color="secondary"
+							disabled={false}
+							size="small"></smoothly-toggle-switch>
+					</span>
+				</div>
+			</Host>
+		)
+	}
+}

--- a/src/components/toggle-switch/demo/style.css
+++ b/src/components/toggle-switch/demo/style.css
@@ -1,0 +1,9 @@
+:host>div{
+	display: grid;
+	grid-template-columns: repeat(4, max-content);
+	gap:1em;
+}
+:host>div>span>p {
+	margin: 0;
+}
+

--- a/src/components/toggle-switch/index.tsx
+++ b/src/components/toggle-switch/index.tsx
@@ -4,14 +4,14 @@ import { Color, Fill } from "../../model"
 @Component({
 	tag: "smoothly-toggle-switch",
 	styleUrl: "style.css",
-	shadow: true,
+	scoped: true,
 })
 export class SmoothlyToggleSwitch {
 	@Prop({ reflect: true }) checkmark = true
 	@Prop({ mutable: true, reflect: true }) selected = false
 	@Prop({ reflect: true }) disabled = false
 	@Prop({ reflect: true }) size: "tiny" | "small" | "default" | "large" = "default"
-	@Prop({ reflect: true }) color: Color
+	@Prop({ reflect: true }) color: Color = "medium"
 	@Prop({ reflect: true }) fill: Fill = "clear"
 	@Event() smoothlyToggleSwitchChange: EventEmitter<boolean>
 

--- a/src/components/toggle-switch/index.tsx
+++ b/src/components/toggle-switch/index.tsx
@@ -10,7 +10,7 @@ export class SmoothlyToggleSwitch {
 	@Prop({ reflect: true }) checkmark = true
 	@Prop({ mutable: true, reflect: true }) selected = false
 	@Prop({ reflect: true }) disabled = false
-	@Prop({ reflect: true }) size: "small" | "default" | "large" = "default"
+	@Prop({ reflect: true }) size: "tiny" | "small" | "default" | "large" = "default"
 	@Prop({ reflect: true }) color: Color
 	@Prop({ reflect: true }) fill: Fill = "clear"
 	@Event() smoothlyToggleSwitchChange: EventEmitter<boolean>

--- a/src/components/toggle-switch/style.css
+++ b/src/components/toggle-switch/style.css
@@ -44,6 +44,11 @@
 	transform: translateX(100%);
 }
 
+:host([size=tiny]) {
+	width: 3.05em;
+	height: 1.5em;
+}
+
 :host([size=small]) {
 	width: 3.05em;
 	height: 1.5em;
@@ -54,10 +59,15 @@
 	height: 2.5em;
 }
 
+:host([size=tiny]) > button > smoothly-icon {
+	font-size: 1em;
+}
+
 :host([size=small]) > button > smoothly-icon {
 	font-size: 1em;
 }
 
 :host([size=large]) > button > smoothly-icon {
+	
 	font-size: 1.75em;
 }

--- a/src/components/toggle-switch/style.css
+++ b/src/components/toggle-switch/style.css
@@ -1,6 +1,5 @@
 :host {
 	display: block;
-	margin: 1em 0;
 	width: 3.6em;
 	height: 1.8em;
 }
@@ -15,10 +14,14 @@
 	cursor: pointer;
 	border: none;
 	border-radius: 3em;
-	background-color: rgb(var(--smoothly-light-tint));
+	background-color: rgb(var(--smoothly-color));
 }
 :host > button:hover {
-	background-color: rgb(var(--smoothly-light-color));
+	background-color: rgb(var(--smoothly-color-tint));
+}
+:host > button > smoothly-icon > svg > path {
+	border-radius: 100%;
+	border: 1px solid magenta;
 }
 :host > button > smoothly-icon {
 	display: flex;
@@ -26,18 +29,20 @@
 	align-items: center;
 	position: absolute;
 	left: 0;
-	fill: rgb(var(--smoothly-color));
-	stroke: rgb(var(--smoothly-color));
+	fill: rgb(var(--smoothly-color-contrast));
+	stroke: rgb(var(--smoothly-color-contrast));
 	font-size: 1.2em;
 	transition: 100ms ease-in-out;
 }
-
-:host[checkmark] > button > smoothly-icon {
-	fill: rgb(var(--smoothly-success-color));
-	stroke: rgb(var(--smoothly-success-color));
+:host([selected][checkmark]) > button > smoothly-icon{
+	fill: rgb(var(--smoothly-success-contrast));
+	stroke: rgb(var(--smoothly-success-contrast));
 }
 :host([selected][checkmark]) > button {
 	background-color: rgb(var(--smoothly-success-color));
+}
+:host([selected][checkmark]) > button:hover{
+	background-color: rgb(var(--smoothly-success-tint));
 }
 
 :host([selected]) > button > smoothly-icon {
@@ -45,8 +50,8 @@
 }
 
 :host([size=tiny]) {
-	width: 3.05em;
-	height: 1.5em;
+	width: 2.1em;
+	height: 1.1em;
 }
 
 :host([size=small]) {
@@ -60,7 +65,7 @@
 }
 
 :host([size=tiny]) > button > smoothly-icon {
-	font-size: 1em;
+	font-size: .7em;
 }
 
 :host([size=small]) > button > smoothly-icon {

--- a/src/components/toggle-switch/style.css
+++ b/src/components/toggle-switch/style.css
@@ -3,7 +3,6 @@
 	width: 3.6em;
 	height: 1.8em;
 }
-
 :host > button {
 	width: 100%;
 	height: 100%;
@@ -18,10 +17,6 @@
 }
 :host > button:hover {
 	background-color: rgb(var(--smoothly-color-tint));
-}
-:host > button > smoothly-icon > svg > path {
-	border-radius: 100%;
-	border: 1px solid magenta;
 }
 :host > button > smoothly-icon {
 	display: flex;
@@ -44,34 +39,27 @@
 :host([selected][checkmark]) > button:hover{
 	background-color: rgb(var(--smoothly-success-tint));
 }
-
 :host([selected]) > button > smoothly-icon {
 	transform: translateX(100%);
 }
-
 :host([size=tiny]) {
-	width: 2.1em;
-	height: 1.1em;
+	width: 2.4em;
+	height: 1.2em;
 }
-
 :host([size=small]) {
 	width: 3.05em;
 	height: 1.5em;
 }
-
 :host([size=large]) {
 	width: 5.2em;
 	height: 2.5em;
 }
-
 :host([size=tiny]) > button > smoothly-icon {
-	font-size: .7em;
+	font-size: .8em;
 }
-
 :host([size=small]) > button > smoothly-icon {
 	font-size: 1em;
 }
-
 :host([size=large]) > button > smoothly-icon {
 	font-size: 1.75em;
 }

--- a/src/components/toggle-switch/style.css
+++ b/src/components/toggle-switch/style.css
@@ -68,6 +68,5 @@
 }
 
 :host([size=large]) > button > smoothly-icon {
-	
 	font-size: 1.75em;
 }


### PR DESCRIPTION
Toggle switch gets better contrast between background and foreground in this commit. There is also the option of having a tiny toggle switch now.

![bild](https://github.com/user-attachments/assets/742a7328-9ca3-4cfd-bb38-9f24fd556310)
