### PR TITLE
Add smoothly-input-border-radius.

### DIFF
--- a/src/assets/style/mapping.css
+++ b/src/assets/style/mapping.css
@@ -22,6 +22,7 @@ smoothly-color {
 	--smoothly-input-foreground: var(--smoothly-default-contrast);
 	--smoothly-input-background: var(--smoothly-default-tint);
 	--smoothly-input-border: var(--smoothly-default-shade);
+	--smoothly-input-border-radius: 0.5rem;
 
 	--smoothly-input-hover-background: var(--smoothly-primary-tint);
 	--smoothly-input-hover-foreground: var(--smoothly-primary-contrast);

--- a/src/assets/style/mapping.css
+++ b/src/assets/style/mapping.css
@@ -22,7 +22,7 @@ smoothly-color {
 	--smoothly-input-foreground: var(--smoothly-default-contrast);
 	--smoothly-input-background: var(--smoothly-default-tint);
 	--smoothly-input-border: var(--smoothly-default-shade);
-	--smoothly-input-border-radius: 0.5rem;
+	--smoothly-input-border-radius: 0;
 
 	--smoothly-input-hover-background: var(--smoothly-primary-tint);
 	--smoothly-input-hover-foreground: var(--smoothly-primary-contrast);

--- a/src/components/calendar/style.css
+++ b/src/components/calendar/style.css
@@ -3,7 +3,6 @@
 	--other-month-opacity: 0.5;
 	padding: 0.5em;
 	border: 1px solid rgb(var(--smoothly-input-border));
-	border-radius: var(--smoothly-input-border-radius);
 }
 
 :host>smoothly-input-month {

--- a/src/components/calendar/style.css
+++ b/src/components/calendar/style.css
@@ -3,6 +3,7 @@
 	--other-month-opacity: 0.5;
 	padding: 0.5em;
 	border: 1px solid rgb(var(--smoothly-input-border));
+	border-radius: var(--smoothly-input-border-radius);
 }
 
 :host>smoothly-input-month {

--- a/src/components/input/select/index.tsx
+++ b/src/components/input/select/index.tsx
@@ -308,7 +308,7 @@ export class SmoothlyInputSelect implements Input, Editable, Clearable, Componen
 		return (
 			<Host
 				tabIndex={0}
-				class={{ "has-value": this.selected.length !== 0 }}
+				class={{ "has-value": this.selected.length !== 0, open: this.open }}
 				onClick={(event: Event) => this.handleShowOptions(event)}>
 				<div class="select-display" ref={element => (this.displaySelectedElement = element)}>
 					{this.placeholder}

--- a/src/components/input/select/style.css
+++ b/src/components/input/select/style.css
@@ -9,7 +9,6 @@
 	color: rgb(var(--smoothly-input-foreground));
 	fill: rgb(var(--smoothly-input-foreground));
 	stroke: rgb(var(--smoothly-input-foreground));
-	border-radius: var(--smoothly-input-border-radius);
 }
 :host.open {
 	border-radius: var(--smoothly-input-border-radius) var(--smoothly-input-border-radius) 0 0;

--- a/src/components/input/select/style.css
+++ b/src/components/input/select/style.css
@@ -9,6 +9,10 @@
 	color: rgb(var(--smoothly-input-foreground));
 	fill: rgb(var(--smoothly-input-foreground));
 	stroke: rgb(var(--smoothly-input-foreground));
+	border-radius: var(--smoothly-input-border-radius);
+}
+:host.open {
+	border-radius: var(--smoothly-input-border-radius) var(--smoothly-input-border-radius) 0 0;
 }
 
 :host.icon {
@@ -103,6 +107,7 @@
 	background-color: rgb(var(--smoothly-input-background));
 	left: 0;
 	right: 0;
+	border-radius: 0 0 var(--smoothly-input-border-radius) var(--smoothly-input-border-radius);
 }
 
 :host[looks=border]>div.options {

--- a/src/components/input/shared.css
+++ b/src/components/input/shared.css
@@ -1,5 +1,6 @@
 :host {
 	box-sizing: border-box;
+	border-radius: var(--smoothly-input-border-radius);
 }
 :host[readonly] {
 	color: rgba(var(--smoothly-input-foreground), 0.7);


### PR DESCRIPTION
Adding 
`--smoothly-input-border-radius` attribute to `mapping.css`.
Technically this is not a mapping, but the name convention fits best here. 

### Example 
![image](https://github.com/user-attachments/assets/a7e2a222-59db-4cc8-9b60-0d520af5e91e)

