### PR TITLE
Show app-room label in narrow/mobile view

### DIFF
--- a/src/components/app/room/index.tsx
+++ b/src/components/app/room/index.tsx
@@ -48,7 +48,8 @@ export class SmoothlyAppRoom {
 			<Host>
 				<li>
 					<a href={typeof this.path == "string" ? this.path : this.path.pathname} onClick={e => this.clickHandler(e)}>
-						{this.icon ? <smoothly-icon name={this.icon} toolTip={this.label}></smoothly-icon> : this.label}
+						{this.icon && <smoothly-icon name={this.icon} toolTip={this.label}></smoothly-icon>}
+						{this.label && <span class="label">{this.label}</span>}
 					</a>
 				</li>
 				<div ref={e => (this.contentElement = e)}>

--- a/src/components/app/room/style.css
+++ b/src/components/app/room/style.css
@@ -44,12 +44,18 @@
 
 :host>li>a>smoothly-icon {
 	align-self: inherit;
-	margin-bottom: 1em;
+}
+:host[icon]>li>a>.label {
+	display: none;
 }
 
 @media screen and (max-width: 900px) {
 	:host>li>a {
 		padding: 0;
+	}
+	:host[icon]>li>a>.label {
+		display: unset;
+		padding: 0 1rem;
 	}
 
 	:host>li>a {

--- a/src/components/app/style.css
+++ b/src/components/app/style.css
@@ -62,10 +62,6 @@ smoothly-app>smoothly-notifier>header>h1>a {
 	white-space: nowrap;
 }
 
-smoothly-app>smoothly-notifier>header>nav>ul li a {
-	line-height: 1.6cm;
-}
-
 smoothly-app>smoothly-notifier>header>nav>ul {
 	width: 100%;
 }
@@ -101,8 +97,8 @@ smoothly-app>smoothly-notifier>header>nav>ul li a {
 
 @media screen and (max-width: 900px) {
 	smoothly-app>smoothly-notifier>header>nav {
-		width: 50dvw;
-		max-width: 15rem;
+		width: fit-content;
+		max-width: 100%;
 		top: 100%;
 		position: absolute;
 		max-height: calc(100dvh - var(--header-height));
@@ -124,7 +120,6 @@ smoothly-app>smoothly-notifier>header>nav>ul li a {
 
 	smoothly-app>smoothly-notifier>header>nav>ul li {
 		margin-right: 0;
-		margin-bottom: 1em;
 		width: 100%;
 	}
 


### PR DESCRIPTION
Also removed some whack styling.


## Looks the same in wide screen
![image](https://github.com/user-attachments/assets/cdccc4e4-8d07-4b6b-85f3-295a677fdbd7)


## Narrow/mobile view - example
<table>
  <tr>
    <td> Before</td>
    <td>After</td>
   </tr> 
   <tr>
      <td><img src="https://github.com/user-attachments/assets/06b53567-76ff-45b5-9140-d3afa0098d77" ></td>
      <td><img src="https://github.com/user-attachments/assets/7d20d531-b9ff-465b-b92b-4f84544a2c6a" ></td>
  </tr>
</table>

