### PR TITLE
Add scroll triggerMode to smoothly-load-more

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -490,6 +490,7 @@ export namespace Components {
         "multiple": boolean;
         "name": string;
         "offset": string;
+        "triggerMode": "scroll" | "intersection";
     }
     interface SmoothlyNextDemo {
     }
@@ -2735,6 +2736,7 @@ declare namespace LocalJSX {
         "name"?: string;
         "offset"?: string;
         "onSmoothlyLoadMore"?: (event: SmoothlyLoadMoreCustomEvent<string>) => void;
+        "triggerMode"?: "scroll" | "intersection";
     }
     interface SmoothlyNextDemo {
     }

--- a/src/components/load-more/index.tsx
+++ b/src/components/load-more/index.tsx
@@ -22,6 +22,7 @@ export class LoadMore implements ComponentWillLoad {
 		if (containerRect && rect && rect.top >= containerRect.top && containerRect.bottom >= rect.bottom) {
 			this.smoothlyLoadMore.emit(this.name)
 			result = true
+			!this.multiple && this.scrollableParent?.removeEventListener("scroll", this.checkInView.bind(this))
 		}
 		return result
 	}
@@ -35,9 +36,9 @@ export class LoadMore implements ComponentWillLoad {
 
 	componentWillLoad(): void {
 		if (this.triggerMode == "scroll") {
+			this.findScrollableParent()
 			const triggered = this.checkInView()
 			if (this.multiple || (!this.multiple && !triggered)) {
-				this.findScrollableParent()
 				this.scrollableParent?.addEventListener("scroll", this.checkInView.bind(this))
 			}
 		} else if (this.triggerMode == "intersection") {

--- a/src/components/load-more/isScrollable.ts
+++ b/src/components/load-more/isScrollable.ts
@@ -1,0 +1,7 @@
+export function isScrollable(element: HTMLElement) {
+	const overflow = window.getComputedStyle(element).overflowY
+	return (
+		element.scrollHeight > element.clientHeight &&
+		(overflow == "auto" || overflow == "scroll" || document.documentElement == element)
+	)
+}


### PR DESCRIPTION
## The flaw of using intersection
Using the intersection has the issue that the it only triggers when the element enters view, not while in view.

This means sometimes to trigger the loadMore you have to scroll away and then back again.
This is especially true when the contents that load in don't push the  `smoothly-load-more` component enough to move out of view.


## Scroll

This PR is adding the ability to listen to scroll instead of Intersection.
This will trigger a smoothlyLoadMore event on scroll if the element is in view.

The problems with scroll is that it will trigger a lot of events, so it's not recommended to use if you don't have some debouncing for when listening to the event.

## Alternative triggerMode names
The `triggerMode` could be called something `triggerOn` with valus like

`"enterScreen" | "onScreen"`
or
`"enterView" |  "inView"`
Since this is basically the difference between them.