### PR TITLE
Remove input side padding

### DIFF
--- a/src/components/input/style.css
+++ b/src/components/input/style.css
@@ -8,7 +8,6 @@
 	overflow: hidden;
 	background-color: rgb(var(--smoothly-input-background));
 	color: rgb(var(--smoothly-input-foreground));
-	padding: 0 .5em;
 }
 
 :host[hidden] {
@@ -23,7 +22,7 @@
 
 :host>div>label {
 	position: absolute;
-	left: 0em;
+	left: 0.5em;
 	top: 0.6em;
 	opacity: 0.8;
 	user-select: none;
@@ -37,11 +36,11 @@
 }
 
 :host:not([show-label])>div>input {
-	padding: 0.7em 0;
+	padding: 0.7em .5em;
 }
 
 :host>div>input {
-	padding: 1.2em 0em 0.2em 0em;
+	padding: 1.2em .5em 0.2em .5em;
 	box-sizing: border-box;
 	width: 100%;
 	height: 100%;


### PR DESCRIPTION
This is so slot=start/end can go all the way out to the side. 
But keep label aligned with text, just as before.

![Screenshot from 2024-08-19 09-07-34](https://github.com/user-attachments/assets/55c9ffe8-2033-4db9-84b1-a557c4bb5cd2)


## Example
### Before
![Screenshot from 2024-08-19 09-01-25](https://github.com/user-attachments/assets/a64895d5-69ee-448c-895f-4e5a5cd3e52f)

### After
![Screenshot from 2024-08-19 09-02-02](https://github.com/user-attachments/assets/2f2887a5-b89b-4143-9557-74b2a59aae10)


## Fixes same issue as this old PR
https://github.com/utily/smoothly/pull/723
![image](https://github.com/user-attachments/assets/797cde34-9f5d-478f-bbae-45345f0175fd)
