### PR TITLE
smoothly-load-more improvements

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -487,7 +487,6 @@ export namespace Components {
     interface SmoothlyLoadMore {
         "multiple": boolean;
         "name": string;
-        "offset": string;
         "triggerMode": "scroll" | "intersection";
     }
     interface SmoothlyNextDemo {
@@ -2730,7 +2729,6 @@ declare namespace LocalJSX {
     interface SmoothlyLoadMore {
         "multiple"?: boolean;
         "name"?: string;
-        "offset"?: string;
         "onSmoothlyLoadMore"?: (event: SmoothlyLoadMoreCustomEvent<string>) => void;
         "triggerMode"?: "scroll" | "intersection";
     }

--- a/src/components/load-more/index.tsx
+++ b/src/components/load-more/index.tsx
@@ -3,13 +3,11 @@ import { isScrollable } from "./isScrollable"
 
 @Component({
 	tag: "smoothly-load-more",
-	styleUrl: "style.css",
 	scoped: true,
 })
 export class LoadMore implements ComponentWillLoad {
 	private scrollableParent?: HTMLElement
 	@Element() element: HTMLSmoothlyLoadMoreElement
-	@Prop() offset = "0"
 	@Prop() triggerMode: "scroll" | "intersection" = "intersection"
 	@Prop() name = ""
 	@Prop() multiple = false
@@ -53,6 +51,6 @@ export class LoadMore implements ComponentWillLoad {
 	}
 
 	render(): VNode | VNode[] {
-		return <Host style={{ "--offset": `${this.offset}` }} />
+		return <Host />
 	}
 }

--- a/src/components/load-more/index.tsx
+++ b/src/components/load-more/index.tsx
@@ -19,7 +19,6 @@ export class LoadMore implements ComponentWillLoad {
 	checkInView() {
 		if (this.inView) {
 			this.smoothlyLoadMore.emit(this.name)
-			!this.multiple && this.scrollableParent?.removeEventListener("scroll", this.checkInView.bind(this))
 		}
 	}
 
@@ -40,7 +39,7 @@ export class LoadMore implements ComponentWillLoad {
 			this.inView && this.smoothlyLoadMore.emit(this.name)
 			if (this.multiple || (!this.multiple && !this.inView)) {
 				this.findScrollableParent()
-				this.scrollableParent?.addEventListener("scroll", this.checkInView.bind(this))
+				this.scrollableParent?.addEventListener("scroll", this.checkInView.bind(this), { once: !this.multiple })
 			}
 		}
 	}

--- a/src/components/load-more/isScrollable.ts
+++ b/src/components/load-more/isScrollable.ts
@@ -1,7 +1,7 @@
 export function isScrollable(element: HTMLElement) {
 	const overflow = window.getComputedStyle(element).overflowY
 	return (
-		element.scrollHeight > element.clientHeight &&
-		(overflow == "auto" || overflow == "scroll" || document.documentElement == element)
+		overflow == "scroll" ||
+		((overflow == "auto" || document.documentElement == element) && element.scrollHeight > element.clientHeight)
 	)
 }

--- a/src/components/load-more/style.css
+++ b/src/components/load-more/style.css
@@ -1,5 +1,0 @@
-:host {
-	display: block;
-	position: relative;
-	top: var(--offset,)
-}


### PR DESCRIPTION
- Use `once` on scroll event listener, instead of removing event listener.
- Fix `isScrollable` by accepting any parent will `overflow-y: scroll`
- Remove all styling from `smoothly-load-more` - I don't see any point of it.
  - the only way I've seen `offset` used is to set it to `"100"` which just removes the default value `"0"`, so that it's not stuck at the top. `"100"` in it self is just a invalid value since it has no unit.