### PR TITLE
Styling tweaks for confirm button, color picker and icon

### DIFF
--- a/src/components/button/demo/index.tsx
+++ b/src/components/button/demo/index.tsx
@@ -14,7 +14,10 @@ export class SmoothlyButtonDemo {
 						Delete
 					</smoothly-button-confirm>
 					<smoothly-button-confirm name="confirm-icon" shape="rounded" color="success" size="icon">
-						<smoothly-icon name="checkmark-outline" size="small" />
+						<smoothly-icon name="checkmark-outline" size="tiny" />
+					</smoothly-button-confirm>
+					<smoothly-button-confirm name="confirm-icon" shape="rounded" color="danger" size="icon" fill="outline">
+						<smoothly-icon name="trash-outline" size="tiny" fill="outline" />
 					</smoothly-button-confirm>
 				</div>
 				<h4>Toggle button</h4>

--- a/src/components/confirm/index.tsx
+++ b/src/components/confirm/index.tsx
@@ -45,7 +45,12 @@ export class SmoothlyButtonConfirm {
 					disabled={this.disabled}
 					type={"button"}
 					onClick={event => this.clickHandler(event)}>
-					<smoothly-icon name={"alert-outline"} fill="solid" color="warning" size="tiny" />
+					<smoothly-icon
+						name={"alert-outline"}
+						fill={this.fill}
+						color="warning"
+						size={this.size === "icon" ? "tiny" : "small"}
+					/>
 				</smoothly-button>
 				<smoothly-button
 					fill={this.fill}

--- a/src/components/icon/style.css
+++ b/src/components/icon/style.css
@@ -2,7 +2,9 @@
 	background: none;
 }
 :host {
-	display: block;
+	display: flex;
+	align-items: center;
+	justify-content: center;
 }
 :host[rotate] {
 	--rotate: rotate(var(--rotation, 0deg));

--- a/src/components/input/color/style.css
+++ b/src/components/input/color/style.css
@@ -19,6 +19,9 @@
 	outline: 1px solid rgb(var(--smoothly-input-border));
 	border-radius: 3px;
 }
+:host[readonly] smoothly-icon[name=options-outline] {
+	filter: opacity(60%)
+}
 :host>div.rgb-sliders {
 	background-color: rgb(var(--smoothly-input-background));
 	position: absolute;


### PR DESCRIPTION
This commit contains; 
- making sure that smoothly-button-confirm has the same size in both modes
- color picker styling when readonly
- displaying smoothly-icon as flex to make sure that the icon within is centered if smoothly-icon is stretched in any direction to fit a parent element