### PR TITLE
Fancy room tooltip

### DIFF
--- a/src/components/app/room/index.tsx
+++ b/src/components/app/room/index.tsx
@@ -48,7 +48,7 @@ export class SmoothlyAppRoom {
 			<Host>
 				<li>
 					<a href={typeof this.path == "string" ? this.path : this.path.pathname} onClick={e => this.clickHandler(e)}>
-						{this.icon && <smoothly-icon name={this.icon} toolTip={this.label}></smoothly-icon>}
+						{this.icon && <smoothly-icon name={this.icon}></smoothly-icon>}
 						{this.label && <span class="label">{this.label}</span>}
 					</a>
 				</li>

--- a/src/components/app/room/style.css
+++ b/src/components/app/room/style.css
@@ -4,6 +4,7 @@
 	text-align: center;
 	cursor: pointer;
 	height: 100%;
+	position: relative;
 }
 
 :host>div {
@@ -48,6 +49,29 @@
 :host[icon]>li>a>.label {
 	display: none;
 }
+:host([icon][label]):hover::before,
+:host([icon][label]):hover::after {
+	position: absolute;
+	color: rgb(var(--smoothly-color-contrast));
+	background-color: rgb(var(--smoothly-color-tint));
+	border-radius: 0.25rem;
+	pointer-events: none;
+}
+:host([icon][label]):hover::before {
+	content: "";
+  bottom: -1.75rem;
+  transform: rotate(45deg);
+  width: 1.25em;
+  height: 1.25em;
+}
+:host([icon][label]):hover::after {
+	content: attr(label);
+	white-space: nowrap;
+	bottom: -3.25rem;
+	padding: .5rem 1rem;
+	border-radius: .25rem;
+}
+
 
 @media screen and (max-width: 900px) {
 	:host>li>a {
@@ -63,5 +87,9 @@
 		margin-right: -1.5rem;
 		padding-left: 1.5rem;
 		padding-right: 1.5rem;
+	}
+	:host([icon][label]):hover::before,
+	:host([icon][label]):hover::after {
+		content: unset;
 	}
 }


### PR DESCRIPTION
Replaced regular title tooltip with something fancier.

I could have done this with the regular `span.label` which I was originally gonna do. 
But I needed to unset so many attributes in the narrow view (`@media screen and (max-width: 900px)`) that it seemed simpler just to add this all with pseudo elements. 
Maybe it would have been simpler to switch the desktop view to be in the media query.


![image](https://github.com/user-attachments/assets/22e7ff1e-8920-4123-8cdb-05dc7bf7ec9f)

[Screencast from 2024-08-19 15:34:38.webm](https://github.com/user-attachments/assets/63752322-efc0-4ee9-8bcd-327e012c2ecd)

![Screenshot from 2024-08-19 15-40-17](https://github.com/user-attachments/assets/413f6921-5586-425f-97ea-009aa054762b)

