### PR TITLE
Align select-display with not label

### DIFF
--- a/src/components/input/select/style.css
+++ b/src/components/input/select/style.css
@@ -36,6 +36,7 @@
 
 :host:not(:has([slot=label]))>div.select-display  {
 	padding: .6em 0;
+	align-items: center;
 }
 
 :host[readonly]>div.select-display {


### PR DESCRIPTION
This is a minor change. 
Center selected value, when there is no label.


## Before
![Screenshot from 2024-08-20 11-51-52](https://github.com/user-attachments/assets/7c72f8e2-d662-4a16-af06-93b7ccf14550)

## After
![Screenshot from 2024-08-20 11-52-01](https://github.com/user-attachments/assets/4d544115-769e-4cc3-b08b-923604b4b87c)