### PR TITLE
Add smoothly-input-demo-standard

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -335,6 +335,8 @@ export namespace Components {
     }
     interface SmoothlyInputDemo {
     }
+    interface SmoothlyInputDemoStandard {
+    }
     interface SmoothlyInputEdit {
         "color"?: Color;
         "disabled": boolean;
@@ -1406,6 +1408,12 @@ declare global {
         prototype: HTMLSmoothlyInputDemoElement;
         new (): HTMLSmoothlyInputDemoElement;
     };
+    interface HTMLSmoothlyInputDemoStandardElement extends Components.SmoothlyInputDemoStandard, HTMLStencilElement {
+    }
+    var HTMLSmoothlyInputDemoStandardElement: {
+        prototype: HTMLSmoothlyInputDemoStandardElement;
+        new (): HTMLSmoothlyInputDemoStandardElement;
+    };
     interface HTMLSmoothlyInputEditElementEventMap {
         "smoothlyInputLoad": (parent: HTMLElement) => void;
     }
@@ -2193,6 +2201,7 @@ declare global {
         "smoothly-input-date": HTMLSmoothlyInputDateElement;
         "smoothly-input-date-range": HTMLSmoothlyInputDateRangeElement;
         "smoothly-input-demo": HTMLSmoothlyInputDemoElement;
+        "smoothly-input-demo-standard": HTMLSmoothlyInputDemoStandardElement;
         "smoothly-input-edit": HTMLSmoothlyInputEditElement;
         "smoothly-input-file": HTMLSmoothlyInputFileElement;
         "smoothly-input-month": HTMLSmoothlyInputMonthElement;
@@ -2576,6 +2585,8 @@ declare namespace LocalJSX {
         "start"?: isoly.Date | undefined;
     }
     interface SmoothlyInputDemo {
+    }
+    interface SmoothlyInputDemoStandard {
     }
     interface SmoothlyInputEdit {
         "color"?: Color;
@@ -3007,6 +3018,7 @@ declare namespace LocalJSX {
         "smoothly-input-date": SmoothlyInputDate;
         "smoothly-input-date-range": SmoothlyInputDateRange;
         "smoothly-input-demo": SmoothlyInputDemo;
+        "smoothly-input-demo-standard": SmoothlyInputDemoStandard;
         "smoothly-input-edit": SmoothlyInputEdit;
         "smoothly-input-file": SmoothlyInputFile;
         "smoothly-input-month": SmoothlyInputMonth;
@@ -3126,6 +3138,7 @@ declare module "@stencil/core" {
             "smoothly-input-date": LocalJSX.SmoothlyInputDate & JSXBase.HTMLAttributes<HTMLSmoothlyInputDateElement>;
             "smoothly-input-date-range": LocalJSX.SmoothlyInputDateRange & JSXBase.HTMLAttributes<HTMLSmoothlyInputDateRangeElement>;
             "smoothly-input-demo": LocalJSX.SmoothlyInputDemo & JSXBase.HTMLAttributes<HTMLSmoothlyInputDemoElement>;
+            "smoothly-input-demo-standard": LocalJSX.SmoothlyInputDemoStandard & JSXBase.HTMLAttributes<HTMLSmoothlyInputDemoStandardElement>;
             "smoothly-input-edit": LocalJSX.SmoothlyInputEdit & JSXBase.HTMLAttributes<HTMLSmoothlyInputEditElement>;
             "smoothly-input-file": LocalJSX.SmoothlyInputFile & JSXBase.HTMLAttributes<HTMLSmoothlyInputFileElement>;
             "smoothly-input-month": LocalJSX.SmoothlyInputMonth & JSXBase.HTMLAttributes<HTMLSmoothlyInputMonthElement>;

--- a/src/components/input/checkbox/style.css
+++ b/src/components/input/checkbox/style.css
@@ -5,10 +5,12 @@
 	align-items: center;
 	flex-direction: row;
 	position: relative;
-	gap: .5em;
-	padding: .6em;
+	gap: .5rem;
+	padding: .5rem;
 	box-sizing: border-box;
 	background-color: rgb(var(--smoothly-input-background));
+	box-sizing: border-box;
+	min-height: 3rem;
 }
 
 :host>smoothly-icon {
@@ -20,8 +22,8 @@
 	-webkit-appearance: none;
 	-moz-appearance: none;
 	appearance: none;
-	height: 1.2em;
-	width: 1.2em;
+	height: 1.25rem;
+	width: 1.25rem;
 	border: 1px solid black;
 	display: block;
 }

--- a/src/components/input/date/style.css
+++ b/src/components/input/date/style.css
@@ -6,6 +6,8 @@
 	cursor: pointer;
 	max-width: 100vw;
 	background-color: rgb(var(--smoothly-input-background));
+	box-sizing: border-box;
+	min-height: 3rem;
 }
 
 :host>smoothly-input {

--- a/src/components/input/demo/index.tsx
+++ b/src/components/input/demo/index.tsx
@@ -12,6 +12,7 @@ export class SmoothlyInputDemo {
 	render() {
 		return (
 			<Host>
+				<smoothly-input-demo-standard />
 				<div class="inputs">
 					<h2>Calendar</h2>
 					<smoothly-input-date name="some-date">Calendar</smoothly-input-date>

--- a/src/components/input/demo/standard/index.tsx
+++ b/src/components/input/demo/standard/index.tsx
@@ -145,7 +145,8 @@ export class SmoothlyInputDemoStandard {
 					<smoothly-input-date-range
 						looks={this.options.looks}
 						readonly={this.options.readonly}
-						color={this.options.color}>
+						color={this.options.color}
+						showLabel={this.options.showLabel}>
 						{this.options.showLabel && <span>Date Range</span>}
 						<smoothly-input-clear slot="end" />
 					</smoothly-input-date-range>

--- a/src/components/input/demo/standard/index.tsx
+++ b/src/components/input/demo/standard/index.tsx
@@ -29,11 +29,7 @@ export class SmoothlyInputDemoStandard {
 						Height of input should be <code>3rem</code> including border. This is should result in a 48 pixel height at
 						100% zoom, assuming a root font-size of 16 pixels.
 					</p>
-					<smoothly-form
-						looks={"grid"}
-						onSmoothlyFormInput={(e: CustomEvent<Options>) => {
-							this.options = e.detail
-						}}>
+					<smoothly-form looks={"grid"} onSmoothlyFormInput={(e: CustomEvent<Options>) => (this.options = e.detail)}>
 						<smoothly-input-select name="looks">
 							<span slot="label">Looks</span>
 							{Looks.types.map(l => (
@@ -50,7 +46,7 @@ export class SmoothlyInputDemoStandard {
 							))}
 							<smoothly-input-clear slot="end" />
 						</smoothly-input-select>
-						<smoothly-input-checkbox name="vertical">vertical</smoothly-input-checkbox>
+						<smoothly-input-checkbox name="vertical">Vertical Layout</smoothly-input-checkbox>
 						<smoothly-input-checkbox name="showLabel" checked={this.options.showLabel}>
 							Show Label
 						</smoothly-input-checkbox>

--- a/src/components/input/demo/standard/index.tsx
+++ b/src/components/input/demo/standard/index.tsx
@@ -1,0 +1,155 @@
+import { Component, h, Host, State } from "@stencil/core"
+import { isoly } from "isoly"
+import { Color } from "../../../../model"
+import { Looks } from "../../Looks"
+
+type Options = {
+	looks?: Looks
+	readonly?: boolean
+	color?: Color
+	vertical?: boolean
+	showLabel?: boolean
+}
+
+@Component({
+	tag: "smoothly-input-demo-standard",
+	styleUrl: "style.css",
+	scoped: true,
+})
+export class SmoothlyInputDemoStandard {
+	@State() duration: isoly.TimeSpan = { hours: 8 }
+	@State() options: Options = { showLabel: true }
+
+	render() {
+		return (
+			<Host class={{ vertical: !!this.options.vertical }}>
+				<div class="description">
+					<h2>Input Standard</h2>
+					<p>
+						Height of input should be <code>3rem</code> including border. This is should result in a 48 pixel height at
+						100% zoom, assuming a root font-size of 16 pixels.
+					</p>
+					<smoothly-form
+						looks={"grid"}
+						onSmoothlyFormInput={(e: CustomEvent<Options>) => {
+							this.options = e.detail
+						}}>
+						<smoothly-input-select name="looks">
+							<span slot="label">Looks</span>
+							{Looks.types.map(l => (
+								<smoothly-item value={l}>{l}</smoothly-item>
+							))}
+						</smoothly-input-select>
+						<smoothly-input-checkbox name="readonly">Readonly</smoothly-input-checkbox>
+						<smoothly-input-select name="color">
+							<span slot="label">Color</span>
+							{Color.types.map(c => (
+								<smoothly-item value={c}>
+									<span color={c}>{c}</span>
+								</smoothly-item>
+							))}
+							<smoothly-input-clear slot="end" />
+						</smoothly-input-select>
+						<smoothly-input-checkbox name="vertical">vertical</smoothly-input-checkbox>
+						<smoothly-input-checkbox name="showLabel" checked={this.options.showLabel}>
+							Show Label
+						</smoothly-input-checkbox>
+					</smoothly-form>
+				</div>
+				<div class="input-wrapper">
+					<div class="width">100%</div>
+					<div class="left-padding">0.5rem - left padding</div>
+					<smoothly-input
+						name="text"
+						looks={this.options.looks}
+						color={this.options.color}
+						showLabel={this.options.showLabel}>
+						{this.options.showLabel && <span>Text</span>}
+						<smoothly-input-clear slot="end" />
+					</smoothly-input>
+					<div class="height">3rem</div>
+
+					<smoothly-input-select
+						name="month"
+						looks={this.options.looks}
+						readonly={this.options.readonly}
+						color={this.options.color}>
+						{this.options.showLabel && <label slot="label">Select</label>}
+						<smoothly-item value="1">January</smoothly-item>
+						<smoothly-item value="2">February</smoothly-item>
+						<smoothly-item value="3">March</smoothly-item>
+						<smoothly-item value="4">April</smoothly-item>
+						<smoothly-item value="5">May</smoothly-item>
+						<smoothly-item value="6">June</smoothly-item>
+						<smoothly-item value="7">July</smoothly-item>
+						<smoothly-item value="8">August</smoothly-item>
+						<smoothly-item value="9">September</smoothly-item>
+						<smoothly-item value="10">October</smoothly-item>
+						<smoothly-item value="11">November</smoothly-item>
+						<smoothly-item value="12">December</smoothly-item>
+						<smoothly-input-clear slot="end" />
+					</smoothly-input-select>
+					<div class="height">3rem</div>
+
+					<smoothly-input-checkbox
+						looks={this.options.looks}
+						readonly={this.options.readonly}
+						color={this.options.color}>
+						Check
+					</smoothly-input-checkbox>
+					<div class="height">3rem</div>
+
+					<smoothly-input-radio looks={this.options.looks} readonly={this.options.readonly} color={this.options.color}>
+						{this.options.showLabel && <label slot="label">Radio</label>}
+						<smoothly-input-radio-item value={"first"}>Label 1</smoothly-input-radio-item>
+						<smoothly-input-radio-item selected value={"second"}>
+							Label 2
+						</smoothly-input-radio-item>
+						<smoothly-input-radio-item value={"third"}>Label 3</smoothly-input-radio-item>
+						<smoothly-input-clear slot="end" />
+					</smoothly-input-radio>
+					<div class="height">3rem</div>
+
+					<smoothly-input-file looks={this.options.looks} readonly={this.options.readonly} color={this.options.color}>
+						{this.options.showLabel && <span slot={"label"}>File</span>}
+						<smoothly-input-clear slot="end" />
+					</smoothly-input-file>
+					<div class="height">3rem</div>
+
+					<smoothly-input-range
+						label={this.options.showLabel ? "Range" : undefined}
+						looks={this.options.looks}
+						readonly={this.options.readonly}
+						color={this.options.color}>
+						<smoothly-input-clear slot="end" />
+					</smoothly-input-range>
+					<div class="height">3rem</div>
+
+					<smoothly-input-color looks={this.options.looks} readonly={this.options.readonly} color={this.options.color}>
+						{this.options.showLabel && <span>Color</span>}
+						<smoothly-input-clear slot="end" />
+					</smoothly-input-color>
+					<div class="height">3rem</div>
+
+					<smoothly-input-date looks={this.options.looks} readonly={this.options.readonly} color={this.options.color}>
+						{this.options.showLabel && <span>Date</span>}
+						<smoothly-input-clear slot="end" />
+					</smoothly-input-date>
+					<div class="height">3rem</div>
+
+					<smoothly-input-date-range
+						looks={this.options.looks}
+						readonly={this.options.readonly}
+						color={this.options.color}>
+						{this.options.showLabel && <span>Date Range</span>}
+						<smoothly-input-clear slot="end" />
+					</smoothly-input-date-range>
+					<div class="height">3rem</div>
+					<div class={{ "guide-lines": true, "show-label": !!this.options.showLabel }}>
+						{this.options.showLabel ? "Aligned labels & values" : "Center values"}
+					</div>
+				</div>
+			</Host>
+		)
+	}
+}

--- a/src/components/input/demo/standard/index.tsx
+++ b/src/components/input/demo/standard/index.tsx
@@ -1,4 +1,4 @@
-import { Component, h, Host, State } from "@stencil/core"
+import { Component, Element, h, Host, State } from "@stencil/core"
 import { isoly } from "isoly"
 import { Color } from "../../../../model"
 import { Looks } from "../../Looks"
@@ -17,8 +17,17 @@ type Options = {
 	scoped: true,
 })
 export class SmoothlyInputDemoStandard {
+	@Element() element: HTMLElement
 	@State() duration: isoly.TimeSpan = { hours: 8 }
 	@State() options: Options = { showLabel: true }
+
+	componentDidRender() {
+		const rootFontSize = Number(getComputedStyle(document.documentElement).fontSize.replace("px", ""))
+		this.element.querySelectorAll(".height").forEach((el: HTMLDivElement) => {
+			const height = el.clientHeight
+			el.innerHTML = `<b>${height / rootFontSize}rem</b> (${height}pixels)`
+		})
+	}
 
 	render() {
 		return (
@@ -63,7 +72,7 @@ export class SmoothlyInputDemoStandard {
 						{this.options.showLabel && <span>Text</span>}
 						<smoothly-input-clear slot="end" />
 					</smoothly-input>
-					<div class="height">3rem</div>
+					<div class="height"></div>
 
 					<smoothly-input-select
 						name="month"
@@ -85,7 +94,7 @@ export class SmoothlyInputDemoStandard {
 						<smoothly-item value="12">December</smoothly-item>
 						<smoothly-input-clear slot="end" />
 					</smoothly-input-select>
-					<div class="height">3rem</div>
+					<div class="height"></div>
 
 					<smoothly-input-checkbox
 						looks={this.options.looks}
@@ -93,7 +102,7 @@ export class SmoothlyInputDemoStandard {
 						color={this.options.color}>
 						Check
 					</smoothly-input-checkbox>
-					<div class="height">3rem</div>
+					<div class="height"></div>
 
 					<smoothly-input-radio looks={this.options.looks} readonly={this.options.readonly} color={this.options.color}>
 						{this.options.showLabel && <label slot="label">Radio</label>}
@@ -104,13 +113,13 @@ export class SmoothlyInputDemoStandard {
 						<smoothly-input-radio-item value={"third"}>Label 3</smoothly-input-radio-item>
 						<smoothly-input-clear slot="end" />
 					</smoothly-input-radio>
-					<div class="height">3rem</div>
+					<div class="height"></div>
 
 					<smoothly-input-file looks={this.options.looks} readonly={this.options.readonly} color={this.options.color}>
 						{this.options.showLabel && <span slot={"label"}>File</span>}
 						<smoothly-input-clear slot="end" />
 					</smoothly-input-file>
-					<div class="height">3rem</div>
+					<div class="height"></div>
 
 					<smoothly-input-range
 						label={this.options.showLabel ? "Range" : undefined}
@@ -119,19 +128,19 @@ export class SmoothlyInputDemoStandard {
 						color={this.options.color}>
 						<smoothly-input-clear slot="end" />
 					</smoothly-input-range>
-					<div class="height">3rem</div>
+					<div class="height"></div>
 
 					<smoothly-input-color looks={this.options.looks} readonly={this.options.readonly} color={this.options.color}>
 						{this.options.showLabel && <span>Color</span>}
 						<smoothly-input-clear slot="end" />
 					</smoothly-input-color>
-					<div class="height">3rem</div>
+					<div class="height"></div>
 
 					<smoothly-input-date looks={this.options.looks} readonly={this.options.readonly} color={this.options.color}>
 						{this.options.showLabel && <span>Date</span>}
 						<smoothly-input-clear slot="end" />
 					</smoothly-input-date>
-					<div class="height">3rem</div>
+					<div class="height"></div>
 
 					<smoothly-input-date-range
 						looks={this.options.looks}
@@ -140,7 +149,7 @@ export class SmoothlyInputDemoStandard {
 						{this.options.showLabel && <span>Date Range</span>}
 						<smoothly-input-clear slot="end" />
 					</smoothly-input-date-range>
-					<div class="height">3rem</div>
+					<div class="height"></div>
 					<div class={{ "guide-lines": true, "show-label": !!this.options.showLabel }}>
 						{this.options.showLabel ? "Aligned labels & values" : "Center values"}
 					</div>

--- a/src/components/input/demo/standard/style.css
+++ b/src/components/input/demo/standard/style.css
@@ -1,0 +1,106 @@
+:host {
+	width: 50%;
+	margin: auto;
+}
+
+:host h2,
+:host p {
+	margin: .5rem 0;
+}
+div.input-wrapper {
+	display: grid;
+	margin-top: 1rem;
+	grid-template-columns: 2fr 1fr;
+	gap: 1rem;
+	position: relative;
+	justify-content: space-around;
+}
+div.input-wrapper > [name] {
+	grid-column: 1 / 2;
+}
+div.input-wrapper > .width {
+	width: 100%;
+	text-align: center;
+	border-bottom: 1px dashed black;
+}
+div.input-wrapper > .height {
+	align-content: center;
+	grid-column: 2 / 3;
+	border-left: 1px dashed black;
+	padding-left: 1rem;
+	content: "hello";
+}
+div.input-wrapper > .left-padding {
+	width: 0.5rem;
+	grid-column: 1 / 2;
+	white-space: nowrap;
+	overflow: visible;
+	position: relative;
+	cursor: default;
+}
+div.input-wrapper > .left-padding::before {
+	content: "";
+	position: absolute;
+	width: 100%;
+	top: 1.5rem;
+	bottom: -1rem;
+	border: 1px  dashed black;
+	z-index: 2;
+}
+div.input-wrapper > .left-padding:hover::before { 
+	bottom: -100vh;
+}
+
+
+/* --- vertical --- */
+
+:host.vertical {
+	width: 100%;
+	row-gap: 0;
+	position: relative;
+}
+:host.vertical > div.input-wrapper {
+	display: grid;
+	grid-template-columns: repeat(auto-fill, 14rem);
+	gap: .5rem;
+}
+:host.vertical > div.input-wrapper > .width,
+:host.vertical > div.input-wrapper > .height,
+:host.vertical > div.input-wrapper > .left-padding {
+	display: none;
+}
+
+
+:host.vertical > div.input-wrapper > .guide-lines::before,
+:host.vertical > div.input-wrapper > .guide-lines::after {
+	content: "";
+	pointer-events: none;
+	right: 0;
+	width: 100vw;
+	position: absolute;
+	z-index: 2;
+	border-top: 1px dotted black;
+}
+
+:host:not(.vertical) .guide-lines {
+	display: none;
+}
+
+.guide-lines {
+	text-align: end;
+	justify-self: center;
+  align-content: center;
+}
+
+.guide-lines::before {
+	top: 1rem;
+}
+.guide-lines::after {
+	top: 2rem;
+}
+.guide-lines.show-label::before {
+	top: 1.05rem;
+}
+.guide-lines.show-label::after {
+	top: 2.3rem;
+}

--- a/src/components/input/demo/style.css
+++ b/src/components/input/demo/style.css
@@ -1,7 +1,12 @@
 :host {
 	display: flex;
+	flex-direction: column;
 	margin-top: 2em;
 	margin-bottom: 10rem;
+}
+
+smoothly-input-demo-standard {
+	margin-bottom: 2rem;
 }
 
 div.inputs {

--- a/src/components/input/file/style.css
+++ b/src/components/input/file/style.css
@@ -7,8 +7,10 @@
 	overflow: hidden;
 	position: relative;
 	width: 100%;
-	padding-left: 0.4rem;
+	padding-left: 0.5rem;
 	background-color: rgb(var(--smoothly-input-background));
+	box-sizing: border-box;
+	min-height: 3rem;
 }
 
 :host>div>div.mask {
@@ -55,7 +57,7 @@
 :host>label::slotted(*) {
 	display: block;
 	width: 100%;
-	font-size: 0.65em;
+	font-size: 0.8rem;
 	opacity: 0.8;
 }
 

--- a/src/components/input/radio/style.css
+++ b/src/components/input/radio/style.css
@@ -5,10 +5,12 @@
 	display: flex;
 	align-items: center;
 	padding: 0 .5em;
+	box-sizing: border-box;
+	min-height: 3rem;
 }
 :host>div {
 	position: relative;
-	padding: 1.2em 0 .1em 0;
+	padding: 1.25rem 0 .25rem 0;
 }
 :host>div>label {
 	left: 0;
@@ -20,7 +22,7 @@
 :host>div,
 :host>div>div.options {
 	display: flex;
-	gap: 1.5em;
+	gap: 1.5rem;
 }
 :host::slotted([slot=end]) {
 	margin-right: 0;

--- a/src/components/input/range/style.css
+++ b/src/components/input/range/style.css
@@ -11,6 +11,8 @@
 	display: flex;
 	background-color: rgb(var(--smoothly-input-background));
 	padding-right: .5em;
+	box-sizing: border-box;
+	min-height: 3rem;
 }
 :host>div {
 	position: relative;

--- a/src/components/input/select/style.css
+++ b/src/components/input/select/style.css
@@ -10,6 +10,7 @@
 	fill: rgb(var(--smoothly-input-foreground));
 	stroke: rgb(var(--smoothly-input-foreground));
 	padding: 0 0.5em;
+	min-height: 3rem;
 }
 
 :host.open {

--- a/src/components/input/style.css
+++ b/src/components/input/style.css
@@ -8,6 +8,7 @@
 	overflow: hidden;
 	background-color: rgb(var(--smoothly-input-background));
 	color: rgb(var(--smoothly-input-foreground));
+	min-height: 3rem;
 }
 
 :host[hidden] {
@@ -22,8 +23,8 @@
 
 :host>div>label {
 	position: absolute;
-	left: 0.5em;
-	top: 0.6em;
+	left: 0.5rem;
+	top: 0.6rem;
 	opacity: 0.8;
 	user-select: none;
 	cursor: inherit;
@@ -36,11 +37,11 @@
 }
 
 :host:not([show-label])>div>input {
-	padding: 0.7em .5em;
+	padding: 0.75em .5em;
 }
 
 :host>div>input {
-	padding: 1.2em .5em 0.2em .5em;
+	padding: 1.25rem .5rem 0.25rem .5rem;
 	box-sizing: border-box;
 	width: 100%;
 	height: 100%;

--- a/src/components/item/style.css
+++ b/src/components/item/style.css
@@ -11,6 +11,8 @@
 	color: rgb(var(--smoothly-input-foreground));
 	fill: rgb(var(--smoothly-input-foreground));
 	stroke: rgb(var(--smoothly-input-foreground));
+	box-sizing: border-box;
+	min-height: 3rem;
 }
 
 :host::slotted(*) {


### PR DESCRIPTION
This component is intended to work as the guide line for how inputs should be styled.

Also fix `min-height: 3rem` on several inputs.
![Screenshot from 2024-08-21 09-36-26](https://github.com/user-attachments/assets/5320abba-98f1-42ce-8286-dccb8e5bad52)



Vertical Layout with guide lines.
![Screenshot from 2024-08-20 16-57-07](https://github.com/user-attachments/assets/358e725b-d6aa-47ba-9f45-573e25074b6f)
![Screenshot from 2024-08-20 16-57-00](https://github.com/user-attachments/assets/a643d77f-f95b-41ce-b0fa-32fbe5f99efb)
