### PR TITLE
Remove partial opacity for readonly inputs

### DIFF
--- a/src/components/input/demo/standard/index.tsx
+++ b/src/components/input/demo/standard/index.tsx
@@ -67,6 +67,7 @@ export class SmoothlyInputDemoStandard {
 					<smoothly-input
 						name="text"
 						looks={this.options.looks}
+						readonly={this.options.readonly}
 						color={this.options.color}
 						showLabel={this.options.showLabel}>
 						{this.options.showLabel && <span>Text</span>}

--- a/src/components/input/shared.css
+++ b/src/components/input/shared.css
@@ -2,11 +2,6 @@
 	box-sizing: border-box;
 	border-radius: var(--smoothly-input-border-radius);
 }
-:host[readonly] {
-	color: rgba(var(--smoothly-input-foreground), 0.7);
-	fill: rgba(var(--smoothly-input-foreground), 0.7);
-	stroke: rgba(var(--smoothly-input-foreground), 0.7);
-}
 
 :host[looks="border"]::slotted(smoothly-picker-menu smoothly-input),
 :host[looks="border"] {


### PR DESCRIPTION

As the name `readonly` suggest the input is supposed to be read in the state, so making the input less clear makes no sense.
If we had a disabled state it could make sense to grey out the values.

Also added readonly to input in input-demo-standard that was missing readonly.

## Before
![Screenshot from 2024-08-21 10-57-11](https://github.com/user-attachments/assets/6130544a-6ee4-424a-b5b4-b7194f8800a1)

## After
![Screenshot from 2024-08-21 10-57-01](https://github.com/user-attachments/assets/de5bd944-202d-4393-8f57-7c43cd6dc36f)

