### PR TITLE
Fix border-radius on button by just setting a border-radius css variable

### DIFF
--- a/src/components/button/style.css
+++ b/src/components/button/style.css
@@ -1,13 +1,17 @@
 @import "../color/style.css";
 
 :host {
+	--border-radius: 0.5rem;
 	display: inline-block;
 	box-sizing: border-box;
-	border-radius: 0.5rem;
+	border-radius: var(--border-radius);
 	cursor: pointer;
 	border: none;
 	outline: none;
 	position: relative;
+}
+:host([shape=rounded]) {
+	--border-radius: 2rem;
 }
 
 :host([type=link]) {
@@ -38,7 +42,7 @@
 	justify-content: center;
 	height: 100%;
 	width: 100%;
-	border-radius: 0.5rem;
+	border-radius: var(--border-radius);
 	align-items: center;
 }
 
@@ -53,11 +57,6 @@
 
 :host([size=icon])>button {
 	padding: 0.5em;
-}
-
-:host([shape=rounded])>button,
-:host([shape=rounded]) {
-	border-radius: 2rem;
 }
 
 :host([type=button])>a {
@@ -101,12 +100,7 @@
 :host([expand=full]) {
 	border-left: none;
 	border-right: none;
-	border-radius: 0;
-}
-
-:host([shape=rounded]),
-:host([shape=rounded])>button::before {
-	border-radius: 2rem;
+	--border-radius: 0;
 }
 
 :host([fill=outline])>button {
@@ -130,6 +124,7 @@
 	position: absolute;
 	border: 2px solid rgb(var(--smoothly-button-focus-border));
 	inset: -1px;
+	border-radius: var(--border-radius);
 }
 
 :host(:not([fill=clear]):not([fill=outline]))>button:hover,


### PR DESCRIPTION
By using a css variable it's easier to keep track of the radius rather then setting the radius on all elements for all combinations.

## Outline example on hover

### Before
![Screenshot from 2024-08-21 14-00-40](https://github.com/user-attachments/assets/7d0ee9a4-baf5-4cd8-ac58-69f1fc39d0cd)

### After
![Screenshot from 2024-08-21 14-00-57](https://github.com/user-attachments/assets/9da47ee4-1f48-479b-b666-531c4bbd40cd)
