### PR TITLE
Select align value text

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -394,6 +394,7 @@ export namespace Components {
         "readonly": boolean;
         "reset": () => Promise<void>;
         "setInitialValue": () => Promise<void>;
+        "showLabel": boolean;
         "value": any;
     }
     interface SmoothlyInputRadioItem {
@@ -2643,6 +2644,7 @@ declare namespace LocalJSX {
         "onSmoothlyInputLoad"?: (event: SmoothlyInputRadioCustomEvent<(parent: HTMLElement) => void>) => void;
         "onSmoothlyInputLooks"?: (event: SmoothlyInputRadioCustomEvent<(looks: Looks, color: Color) => void>) => void;
         "readonly"?: boolean;
+        "showLabel"?: boolean;
         "value"?: any;
     }
     interface SmoothlyInputRadioItem {

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -292,6 +292,7 @@ export namespace Components {
         "readonly": boolean;
         "reset": () => Promise<void>;
         "setInitialValue": () => Promise<void>;
+        "showLabel": boolean;
         "value": string | undefined;
     }
     interface SmoothlyInputColorDemo {
@@ -2544,6 +2545,7 @@ declare namespace LocalJSX {
         "onSmoothlyInputLooks"?: (event: SmoothlyInputColorCustomEvent<(looks: Looks, color: Color) => void>) => void;
         "output"?: "rgb" | "hex";
         "readonly"?: boolean;
+        "showLabel"?: boolean;
         "value"?: string | undefined;
     }
     interface SmoothlyInputColorDemo {

--- a/src/components/button/style.css
+++ b/src/components/button/style.css
@@ -35,6 +35,10 @@
 	gap: 0.5rem;
 	box-sizing: border-box;
 }
+:host>a:empty,
+:host>button:empty {
+	border-width: 0;
+}
 
 :host>button {
 	font-weight: bold;

--- a/src/components/input/color/index.tsx
+++ b/src/components/input/color/index.tsx
@@ -39,6 +39,7 @@ export class SmoothlyInputColor implements Input, Clearable, Editable, Component
 	@Prop({ reflect: true, mutable: true }) readonly = false
 	@Prop() output: "rgb" | "hex" = "rgb"
 	@Prop() name: string
+	@Prop({ reflect: true }) showLabel = true
 	@Element() element: HTMLSmoothlyInputColorElement
 	@State() open = false
 	@State() sliderMode: "rgb" | "hsl" = "rgb"
@@ -195,6 +196,7 @@ export class SmoothlyInputColor implements Input, Clearable, Editable, Component
 					looks={undefined}
 					color={this.color}
 					type={"hex-color"}
+					showLabel={this.showLabel}
 					readonly={this.readonly}
 					onSmoothlyInput={event => (event?.stopPropagation(), this.hexInputHandler(event.detail[this.name]))}>
 					<slot />

--- a/src/components/input/demo/standard/index.tsx
+++ b/src/components/input/demo/standard/index.tsx
@@ -21,7 +21,14 @@ export class SmoothlyInputDemoStandard {
 	@State() duration: isoly.TimeSpan = { hours: 8 }
 	@State() options: Options = { showLabel: true }
 
+	connectedCallback() {
+		this.updateInputHeightText()
+	}
 	componentDidRender() {
+		this.updateInputHeightText()
+	}
+
+	updateInputHeightText() {
 		const rootFontSize = Number(getComputedStyle(document.documentElement).fontSize.replace("px", ""))
 		this.element.querySelectorAll(".height").forEach((el: HTMLDivElement) => {
 			const height = el.clientHeight
@@ -116,7 +123,11 @@ export class SmoothlyInputDemoStandard {
 					</smoothly-input-radio>
 					<div class="height"></div>
 
-					<smoothly-input-file looks={this.options.looks} readonly={this.options.readonly} color={this.options.color}>
+					<smoothly-input-file
+						looks={this.options.looks}
+						readonly={this.options.readonly}
+						color={this.options.color}
+						showLabel={this.options.showLabel}>
 						{this.options.showLabel && <span slot={"label"}>File</span>}
 						<smoothly-input-clear slot="end" />
 					</smoothly-input-file>

--- a/src/components/input/demo/standard/index.tsx
+++ b/src/components/input/demo/standard/index.tsx
@@ -112,7 +112,11 @@ export class SmoothlyInputDemoStandard {
 					</smoothly-input-checkbox>
 					<div class="height"></div>
 
-					<smoothly-input-radio looks={this.options.looks} readonly={this.options.readonly} color={this.options.color}>
+					<smoothly-input-radio
+						looks={this.options.looks}
+						readonly={this.options.readonly}
+						color={this.options.color}
+						showLabel={this.options.showLabel}>
 						{this.options.showLabel && <label slot="label">Radio</label>}
 						<smoothly-input-radio-item value={"first"}>Label 1</smoothly-input-radio-item>
 						<smoothly-input-radio-item selected value={"second"}>

--- a/src/components/input/demo/standard/index.tsx
+++ b/src/components/input/demo/standard/index.tsx
@@ -142,7 +142,11 @@ export class SmoothlyInputDemoStandard {
 					</smoothly-input-range>
 					<div class="height"></div>
 
-					<smoothly-input-color looks={this.options.looks} readonly={this.options.readonly} color={this.options.color}>
+					<smoothly-input-color
+						looks={this.options.looks}
+						readonly={this.options.readonly}
+						color={this.options.color}
+						showLabel={this.options.showLabel}>
 						{this.options.showLabel && <span>Color</span>}
 						<smoothly-input-clear slot="end" />
 					</smoothly-input-color>

--- a/src/components/input/demo/standard/index.tsx
+++ b/src/components/input/demo/standard/index.tsx
@@ -148,7 +148,11 @@ export class SmoothlyInputDemoStandard {
 					</smoothly-input-color>
 					<div class="height"></div>
 
-					<smoothly-input-date looks={this.options.looks} readonly={this.options.readonly} color={this.options.color}>
+					<smoothly-input-date
+						looks={this.options.looks}
+						readonly={this.options.readonly}
+						color={this.options.color}
+						showLabel={this.options.showLabel}>
 						{this.options.showLabel && <span>Date</span>}
 						<smoothly-input-clear slot="end" />
 					</smoothly-input-date>

--- a/src/components/input/file/index.tsx
+++ b/src/components/input/file/index.tsx
@@ -122,7 +122,7 @@ export class SmoothlyInputFile implements ComponentWillLoad, Input, Clearable, E
 	render(): VNode | VNode[] {
 		return (
 			<Host
-				class={{ dragging: this.dragging }}
+				class={{ dragging: this.dragging, "has-value": !!this.value }}
 				tabindex={0}
 				onClick={(e: MouseEvent) => this.clickHandler(e)}
 				onDragOver={(e: DragEvent) => this.dragOverHandler(e)}

--- a/src/components/input/file/style.css
+++ b/src/components/input/file/style.css
@@ -35,8 +35,12 @@
 	display: flex;
 	align-items: center;
 	padding-bottom: 0.2rem;
-	column-gap: 1ch;
 }
+
+:host:not([show-label])>smoothly-button:not(:empty) {
+	margin-right: 1ch;
+}
+
 :host([show-label]) > div.input {
 	display: flex;
 	padding: 1.25rem 0 .25rem 0;
@@ -58,7 +62,8 @@
 	transition: transform 100ms ease;
 }
 
-:host.has-value>label {
+:host.has-value>label,
+:host[placeholder]>label {
 	top: 0.2em;
   transform: scale(0.8);
 }

--- a/src/components/input/file/style.css
+++ b/src/components/input/file/style.css
@@ -31,11 +31,17 @@
 	padding: 0;
 }
 
-:host>div.input {
+:host:not([show-label])>div.input {
 	display: flex;
 	align-items: center;
 	padding-bottom: 0.2rem;
 	column-gap: 1ch;
+}
+:host([show-label]) > div.input {
+	display: flex;
+	padding: 1.25rem 0 .25rem 0;
+	height: 100%;
+	box-sizing: border-box;
 }
 
 :host>div>smoothly-button {
@@ -44,21 +50,17 @@
 }
 
 :host>label {
-	padding-top: 0.4rem;
-	display: flex;
-	width: 100%;
-	align-items: baseline;
-	justify-content: flex-start;
-	color: rgb(var(--smoothly-input-foreground));
-	cursor: inherit;
-
+	position: absolute;
+	left: .5rem;
+	top: .6rem;
+	opacity: 0.8;
+	transform-origin: top left;
+	transition: transform 100ms ease;
 }
 
-:host>label::slotted(*) {
-	display: block;
-	width: 100%;
-	font-size: 0.8rem;
-	opacity: 0.8;
+:host.has-value>label {
+	top: 0.2em;
+  transform: scale(0.8);
 }
 
 :host:not([show-label]) label {

--- a/src/components/input/radio/index.tsx
+++ b/src/components/input/radio/index.tsx
@@ -35,6 +35,7 @@ export class SmoothlyInputRadio implements Input, Clearable, Editable, Component
 	@Prop() clearable?: boolean
 	@Prop({ mutable: true, reflect: true }) readonly = false
 	@Prop() name: string
+	@Prop({ reflect: true }) showLabel = true
 	@Event() smoothlyInputLooks: EventEmitter<(looks: Looks, color: Color) => void>
 	@Event() smoothlyInput: EventEmitter<Data>
 	@Event() smoothlyInputLoad: EventEmitter<(parent: HTMLElement) => void>

--- a/src/components/input/radio/style.css
+++ b/src/components/input/radio/style.css
@@ -8,7 +8,7 @@
 	box-sizing: border-box;
 	min-height: 3rem;
 }
-:host>div {
+:host[show-label]>div {
 	position: relative;
 	padding: 1.25rem 0 .25rem 0;
 }

--- a/src/components/input/range/index.tsx
+++ b/src/components/input/range/index.tsx
@@ -123,13 +123,11 @@ export class SmoothlyInputRange implements Input, Clearable, Editable, Component
 						ref={e => (this.input = e)}
 						looks={undefined}
 						color={this.color}
-						showLabel={this.outputSide === "left"}
+						showLabel={this.outputSide === "left" && !!this.label}
 						type={this.type}
 						onSmoothlyInputLoad={e => (e.stopPropagation(), this.inputHandler(e))}
 						onSmoothlyBlur={e => this.inputHandler(e)}
-						onSmoothlyInput={e => {
-							e.stopPropagation()
-						}}
+						onSmoothlyInput={e => e.stopPropagation()}
 						value={this.type == "percent" ? this.value : this.value?.toString()}
 						placeholder={this.outputSide === "right" ? "-" : undefined}
 						readonly={this.readonly}>

--- a/src/components/input/select/style.css
+++ b/src/components/input/select/style.css
@@ -24,14 +24,13 @@
 
 :host>div.select-display {
 	box-sizing: border-box;
-	min-height: 2.7em;
 	display: flex;
 	cursor: pointer;
-	padding: 1.2em 0em 0.2em 0em;
+	padding: 1.25rem 0 .25rem 0;
 	overflow: hidden;
 	width: 100%;
 	white-space: nowrap;
-	gap: 1em;
+	gap: 1rem;
 	text-overflow: ellipsis;
 }
 
@@ -88,8 +87,8 @@ smoothly-icon[name=caret-forward-outline] {
 
 :host::slotted([slot=label]) {
 	position: absolute;
-	left: 0.5em;
-	top: .6em;
+	left: .5rem;
+	top: .6rem;
 	opacity: 0.8;
 	transform-origin: top left;
 	transition: transform 100ms ease;


### PR DESCRIPTION
- [x] https://github.com/utily/smoothly/pull/852

Fix positioning of values and labels in inputs.
- Align file value with other values
- Use same padding for `smoothly-input-select` as regular `smoothly-input`
- Make showLabel (or hide) label positioning the same in inputs.
