### PR TITLE
smoothly-lazy failed to show content when refresh

### DIFF
--- a/src/components/load-more/index.tsx
+++ b/src/components/load-more/index.tsx
@@ -1,11 +1,11 @@
-import { Component, ComponentWillLoad, Element, Event, EventEmitter, h, Host, Prop, State, VNode } from "@stencil/core"
+import { Component, Element, Event, EventEmitter, h, Host, Prop, State, VNode } from "@stencil/core"
 import { Scrollable } from "../../model/Scrollable"
 
 @Component({
 	tag: "smoothly-load-more",
 	scoped: true,
 })
-export class LoadMore implements ComponentWillLoad {
+export class LoadMore {
 	private scrollableParent?: HTMLElement
 	@Element() element: HTMLSmoothlyLoadMoreElement
 	@Prop() triggerMode: "scroll" | "intersection" = "intersection"
@@ -20,6 +20,8 @@ export class LoadMore implements ComponentWillLoad {
 	}
 
 	connectedCallback() {
+		const observer = new IntersectionObserver((entries, observer) => this.observationHandler(observer, entries))
+		observer.observe(this.element)
 		if (this.triggerMode == "scroll") {
 			this.inView && this.smoothlyLoadMore.emit(this.name)
 			if (this.multiple || (!this.multiple && !this.inView)) {
@@ -31,11 +33,6 @@ export class LoadMore implements ComponentWillLoad {
 
 	disconnectedCallback() {
 		this.scrollableParent?.removeEventListener("scroll", this.checkInView.bind(this))
-	}
-
-	componentWillLoad(): void {
-		const observer = new IntersectionObserver((entries, observer) => this.observationHandler(observer, entries))
-		observer.observe(this.element)
 	}
 
 	observationHandler(observer: IntersectionObserver, entries: IntersectionObserverEntry[]): void {

--- a/src/components/load-more/index.tsx
+++ b/src/components/load-more/index.tsx
@@ -6,6 +6,7 @@ import { Scrollable } from "../../model/Scrollable"
 	scoped: true,
 })
 export class LoadMore {
+	private observer: IntersectionObserver
 	private scrollableParent?: HTMLElement
 	@Element() element: HTMLSmoothlyLoadMoreElement
 	@Prop() triggerMode: "scroll" | "intersection" = "intersection"
@@ -20,8 +21,8 @@ export class LoadMore {
 	}
 
 	connectedCallback() {
-		const observer = new IntersectionObserver((entries, observer) => this.observationHandler(observer, entries))
-		observer.observe(this.element)
+		this.observer = new IntersectionObserver((entries, observer) => this.observationHandler(observer, entries))
+		this.observer.observe(this.element)
 		if (this.triggerMode == "scroll") {
 			this.inView && this.smoothlyLoadMore.emit(this.name)
 			if (this.multiple || (!this.multiple && !this.inView)) {
@@ -33,6 +34,7 @@ export class LoadMore {
 
 	disconnectedCallback() {
 		this.scrollableParent?.removeEventListener("scroll", this.checkInView.bind(this))
+		this.observer.disconnect()
 	}
 
 	observationHandler(observer: IntersectionObserver, entries: IntersectionObserverEntry[]): void {


### PR DESCRIPTION
issue: event smoothlyLoadMore failed to emit when refresh the page
it works differently in firefox and google chrome
`this.inView = (entries.find(entry => entry.target == this.element)?.intersectionRatio ?? 0) > 0`
in chrome, this.inView is always false when you refresh a room that use lazy load
setting up observer in `connectedCallback` seems to solve the issue