### PR TITLE
Calendar input month visual fixes

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -380,6 +380,7 @@ export namespace Components {
         "readonly": boolean;
         "reset": () => Promise<void>;
         "setInitialValue": () => Promise<void>;
+        "showLabel": boolean;
         "value"?: isoly.Date;
     }
     interface SmoothlyInputRadio {
@@ -457,6 +458,7 @@ export namespace Components {
         "reset": () => Promise<void>;
         "searchDisabled": boolean;
         "setInitialValue": () => Promise<void>;
+        "showLabel": boolean;
         "showSelected"?: boolean;
     }
     interface SmoothlyInputSubmit {
@@ -2631,6 +2633,7 @@ declare namespace LocalJSX {
         "onSmoothlyInputLooks"?: (event: SmoothlyInputMonthCustomEvent<(looks: Looks, color: Color) => void>) => void;
         "previous"?: boolean;
         "readonly"?: boolean;
+        "showLabel"?: boolean;
         "value"?: isoly.Date;
     }
     interface SmoothlyInputRadio {
@@ -2708,6 +2711,7 @@ declare namespace LocalJSX {
         "readonly"?: boolean;
         "required"?: boolean;
         "searchDisabled"?: boolean;
+        "showLabel"?: boolean;
         "showSelected"?: boolean;
     }
     interface SmoothlyInputSubmit {

--- a/src/components/calendar/index.tsx
+++ b/src/components/calendar/index.tsx
@@ -71,6 +71,7 @@ export class Calendar {
 				inCalendar
 				next
 				previous
+				showLabel={false}
 				onSmoothlyInput={e => {
 					e.stopPropagation()
 					"month" in e.detail && typeof e.detail.month == "string" && (this.month = e.detail.month)

--- a/src/components/input/month/index.tsx
+++ b/src/components/input/month/index.tsx
@@ -36,6 +36,7 @@ export class SmoothlyInputMonth implements ComponentWillLoad, Input, Editable {
 	@Prop({ reflect: true }) next = false
 	@Prop({ reflect: true }) previous = false
 	@Prop({ reflect: true }) inCalendar = false
+	@Prop({ reflect: true }) showLabel = true
 	@Event() smoothlyInput: EventEmitter<Data>
 	@Event() smoothlyInputLoad: EventEmitter<(parent: HTMLElement) => void>
 	@Event() smoothlyFormDisable: EventEmitter<(disabled: boolean) => void>
@@ -128,6 +129,7 @@ export class SmoothlyInputMonth implements ComponentWillLoad, Input, Editable {
 					menuHeight="5.5items"
 					required
 					inCalendar={this.inCalendar}
+					showLabel={this.showLabel}
 					onSmoothlyInput={e => this.inputHandler(e)}
 					searchDisabled>
 					<div slot={"label"}>
@@ -149,6 +151,7 @@ export class SmoothlyInputMonth implements ComponentWillLoad, Input, Editable {
 					menuHeight="5.5items"
 					required
 					inCalendar={this.inCalendar}
+					showLabel={this.showLabel}
 					onSmoothlyInput={e => this.inputHandler(e)}
 					searchDisabled>
 					<div slot={"label"}>

--- a/src/components/input/select/index.tsx
+++ b/src/components/input/select/index.tsx
@@ -39,6 +39,7 @@ export class SmoothlyInputSelect implements Input, Editable, Clearable, Componen
 	@Prop() name = "selected"
 	@Prop({ reflect: true, mutable: true }) color?: Color
 	@Prop({ reflect: true, mutable: true }) looks: Looks = "plain"
+	@Prop({ reflect: true }) showLabel = true
 	@Prop({ reflect: true, mutable: true }) showSelected?: boolean = true
 	@Prop({ reflect: true, mutable: true }) readonly = false
 	@Prop({ reflect: true }) inCalendar = false

--- a/src/components/input/select/style.css
+++ b/src/components/input/select/style.css
@@ -108,6 +108,7 @@ smoothly-icon[name=caret-forward-outline] {
 	left: 0;
 	right: 0;
 	border-radius: 0 0 var(--smoothly-input-border-radius) var(--smoothly-input-border-radius);
+	min-width: fit-content;
 }
 
 :host[looks=border]>div.options {

--- a/src/components/input/select/style.css
+++ b/src/components/input/select/style.css
@@ -33,7 +33,8 @@
 	text-overflow: ellipsis;
 }
 
-:host:not(:has([slot=label]))>div.select-display  {
+:host:not(:has([slot=label]))>div.select-display,
+:host:not([show-label])>div.select-display  {
 	padding: .6em 0;
 	align-items: center;
 }
@@ -88,7 +89,7 @@ smoothly-icon[name=caret-forward-outline] {
 	left: .5rem;
 }
 
-:host.has-value:has([slot=label])>div.select-display,
+:host.has-value:has([slot=label]:not(:empty))>div.select-display,
 :host:not(.has-value)[placeholder]>div.select-display {
 	overflow: hidden;
 	width: 100%;


### PR DESCRIPTION
## Center year and month in calendar
Added option for showLabel in calendar and month to be able to center year and month in calendar
<table>
<tr>
    <td>Before</td>
    <td>After</td>
  </tr>
  <tr>
    <td><img src=https://github.com/user-attachments/assets/bef586bd-6d04-4beb-96df-94fd1296b98b /></td>
    <td><img src=https://github.com/user-attachments/assets/1277c36e-6050-47ac-878c-01cb8de7ad44 /></td>
  </tr>
</table>


## Fit content in smoothly-input-select (before vs. after)
<table>
<tr>
    <td><img src=https://github.com/user-attachments/assets/424ccf86-e57f-4823-aa8c-a0e8f06a8e3c /></td>
    <td><img src=https://github.com/user-attachments/assets/65492878-3a1c-480e-b354-2e6305828d8e /></td>
</tr>
</table>

Chromium based browsers were even worse since the scrollbar covered the items.
<table>
<tr>
    <td><img src=https://github.com/user-attachments/assets/942db12d-61fb-4cee-bc7a-b1b06a070b9f /></td>
    <td><img src=https://github.com/user-attachments/assets/cce1456b-6aab-47af-8a06-83468faee8cf /></td>
</tr>
</table>

This does how ever mean that the options div can be larger then the input field.
<table>
<tr>
    <td><img src=https://github.com/user-attachments/assets/e0138554-f825-4303-9fd0-16097c876218 /></td>
    <td><img src=https://github.com/user-attachments/assets/1081b315-eabd-4727-8d2e-106773ebc471 /></td>
</tr>
</table>