### PR TITLE
Add collapseDepth to display-json component

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -122,7 +122,7 @@ export namespace Components {
     interface SmoothlyDialogDemo {
     }
     interface SmoothlyDisplay {
-        "collapsed"?: boolean;
+        "collapseDepth"?: number;
         "country"?: CountryCode.Alpha2;
         "currency"?: Currency;
         "format"?: DateTime.Format;
@@ -137,12 +137,14 @@ export namespace Components {
     }
     interface SmoothlyDisplayDemo {
     }
+    interface SmoothlyDisplayDemoJson {
+    }
     interface SmoothlyDisplayJson {
-        "collapsed"?: boolean;
+        "collapseDepth"?: number;
         "value": any;
     }
     interface SmoothlyDisplayJsonObject {
-        "collapsed"?: boolean;
+        "collapseDepth"?: number;
         "value": Record<string, any> | any[];
     }
     interface SmoothlyDisplayJsonPrimitive {
@@ -1060,6 +1062,12 @@ declare global {
     var HTMLSmoothlyDisplayDemoElement: {
         prototype: HTMLSmoothlyDisplayDemoElement;
         new (): HTMLSmoothlyDisplayDemoElement;
+    };
+    interface HTMLSmoothlyDisplayDemoJsonElement extends Components.SmoothlyDisplayDemoJson, HTMLStencilElement {
+    }
+    var HTMLSmoothlyDisplayDemoJsonElement: {
+        prototype: HTMLSmoothlyDisplayDemoJsonElement;
+        new (): HTMLSmoothlyDisplayDemoJsonElement;
     };
     interface HTMLSmoothlyDisplayJsonElement extends Components.SmoothlyDisplayJson, HTMLStencilElement {
     }
@@ -2176,6 +2184,7 @@ declare global {
         "smoothly-display": HTMLSmoothlyDisplayElement;
         "smoothly-display-amount": HTMLSmoothlyDisplayAmountElement;
         "smoothly-display-demo": HTMLSmoothlyDisplayDemoElement;
+        "smoothly-display-demo-json": HTMLSmoothlyDisplayDemoJsonElement;
         "smoothly-display-json": HTMLSmoothlyDisplayJsonElement;
         "smoothly-display-json-object": HTMLSmoothlyDisplayJsonObjectElement;
         "smoothly-display-json-primitive": HTMLSmoothlyDisplayJsonPrimitiveElement;
@@ -2371,7 +2380,7 @@ declare namespace LocalJSX {
     interface SmoothlyDialogDemo {
     }
     interface SmoothlyDisplay {
-        "collapsed"?: boolean;
+        "collapseDepth"?: number;
         "country"?: CountryCode.Alpha2;
         "currency"?: Currency;
         "format"?: DateTime.Format;
@@ -2387,12 +2396,14 @@ declare namespace LocalJSX {
     interface SmoothlyDisplayDemo {
         "onNotice"?: (event: SmoothlyDisplayDemoCustomEvent<Notice>) => void;
     }
+    interface SmoothlyDisplayDemoJson {
+    }
     interface SmoothlyDisplayJson {
-        "collapsed"?: boolean;
+        "collapseDepth"?: number;
         "value"?: any;
     }
     interface SmoothlyDisplayJsonObject {
-        "collapsed"?: boolean;
+        "collapseDepth"?: number;
         "value"?: Record<string, any> | any[];
     }
     interface SmoothlyDisplayJsonPrimitive {
@@ -2998,6 +3009,7 @@ declare namespace LocalJSX {
         "smoothly-display": SmoothlyDisplay;
         "smoothly-display-amount": SmoothlyDisplayAmount;
         "smoothly-display-demo": SmoothlyDisplayDemo;
+        "smoothly-display-demo-json": SmoothlyDisplayDemoJson;
         "smoothly-display-json": SmoothlyDisplayJson;
         "smoothly-display-json-object": SmoothlyDisplayJsonObject;
         "smoothly-display-json-primitive": SmoothlyDisplayJsonPrimitive;
@@ -3118,6 +3130,7 @@ declare module "@stencil/core" {
             "smoothly-display": LocalJSX.SmoothlyDisplay & JSXBase.HTMLAttributes<HTMLSmoothlyDisplayElement>;
             "smoothly-display-amount": LocalJSX.SmoothlyDisplayAmount & JSXBase.HTMLAttributes<HTMLSmoothlyDisplayAmountElement>;
             "smoothly-display-demo": LocalJSX.SmoothlyDisplayDemo & JSXBase.HTMLAttributes<HTMLSmoothlyDisplayDemoElement>;
+            "smoothly-display-demo-json": LocalJSX.SmoothlyDisplayDemoJson & JSXBase.HTMLAttributes<HTMLSmoothlyDisplayDemoJsonElement>;
             "smoothly-display-json": LocalJSX.SmoothlyDisplayJson & JSXBase.HTMLAttributes<HTMLSmoothlyDisplayJsonElement>;
             "smoothly-display-json-object": LocalJSX.SmoothlyDisplayJsonObject & JSXBase.HTMLAttributes<HTMLSmoothlyDisplayJsonObjectElement>;
             "smoothly-display-json-primitive": LocalJSX.SmoothlyDisplayJsonPrimitive & JSXBase.HTMLAttributes<HTMLSmoothlyDisplayJsonPrimitiveElement>;

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -122,6 +122,7 @@ export namespace Components {
     interface SmoothlyDialogDemo {
     }
     interface SmoothlyDisplay {
+        "collapsed"?: boolean;
         "country"?: CountryCode.Alpha2;
         "currency"?: Currency;
         "format"?: DateTime.Format;
@@ -137,10 +138,11 @@ export namespace Components {
     interface SmoothlyDisplayDemo {
     }
     interface SmoothlyDisplayJson {
+        "collapsed"?: boolean;
         "value": any;
     }
     interface SmoothlyDisplayJsonObject {
-        "open": boolean;
+        "collapsed"?: boolean;
         "value": Record<string, any> | any[];
     }
     interface SmoothlyDisplayJsonPrimitive {
@@ -2369,6 +2371,7 @@ declare namespace LocalJSX {
     interface SmoothlyDialogDemo {
     }
     interface SmoothlyDisplay {
+        "collapsed"?: boolean;
         "country"?: CountryCode.Alpha2;
         "currency"?: Currency;
         "format"?: DateTime.Format;
@@ -2385,10 +2388,11 @@ declare namespace LocalJSX {
         "onNotice"?: (event: SmoothlyDisplayDemoCustomEvent<Notice>) => void;
     }
     interface SmoothlyDisplayJson {
+        "collapsed"?: boolean;
         "value"?: any;
     }
     interface SmoothlyDisplayJsonObject {
-        "open"?: boolean;
+        "collapsed"?: boolean;
         "value"?: Record<string, any> | any[];
     }
     interface SmoothlyDisplayJsonPrimitive {

--- a/src/components/display/demo/index.tsx
+++ b/src/components/display/demo/index.tsx
@@ -189,27 +189,9 @@ export class SmoothlyDisplayDemo {
 								}}
 								value="2022-07-07T12:15Z"></smoothly-display>
 						</dd>
-						<dt>Display JSON (collapsed)</dt>
+						<dt>Display JSON</dt>
 						<dd>
-							<smoothly-display
-								type="json"
-								value={{
-									name: "stringy",
-									nested: {
-										age: 109,
-										array: ["one", "two", "three", { name: "four" }],
-										emptyObject: {},
-										emptyArray: [],
-										truthy: true,
-										falsy: false,
-										null: null,
-										notDefined: undefined,
-										longString:
-											"pepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakor",
-									},
-								}}
-								collapsed
-							/>
+							<smoothly-display-demo-json />
 						</dd>
 						<dt>Display amount</dt>
 						<dd>

--- a/src/components/display/demo/index.tsx
+++ b/src/components/display/demo/index.tsx
@@ -189,7 +189,7 @@ export class SmoothlyDisplayDemo {
 								}}
 								value="2022-07-07T12:15Z"></smoothly-display>
 						</dd>
-						<dt>Display JSON</dt>
+						<dt>Display JSON (collapsed)</dt>
 						<dd>
 							<smoothly-display
 								type="json"
@@ -207,7 +207,9 @@ export class SmoothlyDisplayDemo {
 										longString:
 											"pepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakor",
 									},
-								}}></smoothly-display>
+								}}
+								collapsed
+							/>
 						</dd>
 						<dt>Display amount</dt>
 						<dd>

--- a/src/components/display/demo/json/index.tsx
+++ b/src/components/display/demo/json/index.tsx
@@ -1,0 +1,35 @@
+import { Component, h, Host } from "@stencil/core"
+
+@Component({
+	tag: "smoothly-display-demo-json",
+})
+export class SmoothlyDisplayDemoJson {
+	render() {
+		return (
+			<Host>
+				{[0, 1, 3, undefined].map(colapseDepth => [
+					<div>collapseDepth={colapseDepth ?? "undefined"}</div>,
+					<div>
+						<smoothly-display type="json" value={json} collapseDepth={colapseDepth} />
+					</div>,
+				])}
+			</Host>
+		)
+	}
+}
+
+const json = {
+	name: "stringy",
+	nested: {
+		age: 109,
+		array: ["one", "two", "three", { name: "four" }],
+		emptyObject: {},
+		emptyArray: [],
+		truthy: true,
+		falsy: false,
+		null: null,
+		notDefined: undefined,
+		longString:
+			"pepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakorpepparkakor",
+	},
+}

--- a/src/components/display/index.tsx
+++ b/src/components/display/index.tsx
@@ -11,7 +11,7 @@ export class SmoothlyDisplay {
 	@Prop() type: Type | "json"
 	@Prop() label?: string
 	@Prop() value?: any
-	@Prop() collapsed?: boolean
+	@Prop() collapseDepth?: number
 	@Prop() currency?: Currency
 	@Prop() country?: CountryCode.Alpha2
 	@Prop() format?: DateTime.Format
@@ -20,7 +20,7 @@ export class SmoothlyDisplay {
 		const type = this.type
 		switch (type) {
 			case "json":
-				result = <smoothly-display-json value={this.value} collapsed={this.collapsed}></smoothly-display-json>
+				result = <smoothly-display-json value={this.value} collapseDepth={this.collapseDepth}></smoothly-display-json>
 				break
 			default:
 				result = format(this.value, type)

--- a/src/components/display/index.tsx
+++ b/src/components/display/index.tsx
@@ -11,6 +11,7 @@ export class SmoothlyDisplay {
 	@Prop() type: Type | "json"
 	@Prop() label?: string
 	@Prop() value?: any
+	@Prop() collapsed?: boolean
 	@Prop() currency?: Currency
 	@Prop() country?: CountryCode.Alpha2
 	@Prop() format?: DateTime.Format
@@ -19,7 +20,7 @@ export class SmoothlyDisplay {
 		const type = this.type
 		switch (type) {
 			case "json":
-				result = <smoothly-display-json value={this.value}></smoothly-display-json>
+				result = <smoothly-display-json value={this.value} collapsed={this.collapsed}></smoothly-display-json>
 				break
 			default:
 				result = format(this.value, type)

--- a/src/components/display/json/JsonValue.tsx
+++ b/src/components/display/json/JsonValue.tsx
@@ -1,10 +1,10 @@
 import { FunctionalComponent, h } from "@stencil/core"
 import { isly } from "isly"
 
-export const JsonValue: FunctionalComponent<{ value: any; collapsed?: boolean }> = ({ value, collapsed }) => {
+export const JsonValue: FunctionalComponent<{ value: any; collapseDepth?: number }> = ({ value, collapseDepth }) => {
 	return isly.object().is(value) || Array.isArray(value) ? (
-		<smoothly-display-json-object value={value} collapsed={collapsed}></smoothly-display-json-object>
+		<smoothly-display-json-object value={value} collapseDepth={collapseDepth} />
 	) : (
-		<smoothly-display-json-primitive value={value}></smoothly-display-json-primitive>
+		<smoothly-display-json-primitive value={value} />
 	)
 }

--- a/src/components/display/json/JsonValue.tsx
+++ b/src/components/display/json/JsonValue.tsx
@@ -1,9 +1,9 @@
 import { FunctionalComponent, h } from "@stencil/core"
 import { isly } from "isly"
 
-export const JsonValue: FunctionalComponent<{ value: any }> = ({ value }) => {
+export const JsonValue: FunctionalComponent<{ value: any; collapsed?: boolean }> = ({ value, collapsed }) => {
 	return isly.object().is(value) || Array.isArray(value) ? (
-		<smoothly-display-json-object value={value}></smoothly-display-json-object>
+		<smoothly-display-json-object value={value} collapsed={collapsed}></smoothly-display-json-object>
 	) : (
 		<smoothly-display-json-primitive value={value}></smoothly-display-json-primitive>
 	)

--- a/src/components/display/json/index.tsx
+++ b/src/components/display/json/index.tsx
@@ -8,9 +8,9 @@ import { JsonValue } from "./JsonValue"
 })
 export class SmoothlyDisplayJson {
 	@Prop() value: any
-	@Prop() collapsed?: boolean
+	@Prop() collapseDepth?: number
 
 	render(): VNode {
-		return <JsonValue value={this.value} collapsed={this.collapsed}></JsonValue>
+		return <JsonValue value={this.value} collapseDepth={this.collapseDepth}></JsonValue>
 	}
 }

--- a/src/components/display/json/index.tsx
+++ b/src/components/display/json/index.tsx
@@ -8,8 +8,9 @@ import { JsonValue } from "./JsonValue"
 })
 export class SmoothlyDisplayJson {
 	@Prop() value: any
+	@Prop() collapsed?: boolean
 
 	render(): VNode {
-		return <JsonValue value={this.value}></JsonValue>
+		return <JsonValue value={this.value} collapsed={this.collapsed}></JsonValue>
 	}
 }

--- a/src/components/display/json/object/index.tsx
+++ b/src/components/display/json/object/index.tsx
@@ -8,13 +8,15 @@ import { JsonValue } from "../JsonValue"
 })
 export class SmoothlyDisplayJsonObject implements ComponentWillLoad {
 	@Prop() value: Record<string, any> | any[]
-	@Prop({ reflect: true, mutable: true }) open = true
+	@Prop() collapsed?: boolean
+	@State() open: boolean
 	@State() empty: boolean
 	private openBracket: string = ""
 	private closeBracket: string = ""
 	private length: number
 
 	componentWillLoad() {
+		this.open = !this.collapsed
 		if (Array.isArray(this.value)) {
 			this.openBracket = "["
 			this.closeBracket = "]"
@@ -29,7 +31,7 @@ export class SmoothlyDisplayJsonObject implements ComponentWillLoad {
 
 	render(): VNode {
 		return (
-			<Host class={{ empty: this.empty }}>
+			<Host class={{ empty: this.empty, open: this.open }}>
 				<span class="open-bracket" onClick={() => (this.open = !this.open)}>
 					{this.openBracket}
 				</span>
@@ -37,14 +39,14 @@ export class SmoothlyDisplayJsonObject implements ComponentWillLoad {
 					{Array.isArray(this.value)
 						? this.value.map((v, index) => (
 								<div class="indent">
-									<JsonValue value={v}></JsonValue>
+									<JsonValue value={v} collapsed={this.collapsed}></JsonValue>
 									{index < this.length - 1 ? "," : ""}
 								</div>
 						  ))
 						: Object.entries(this.value).map(([k, v], index) => (
 								<div class="indent">
 									{<smoothly-display-json-record-key value={k}></smoothly-display-json-record-key>}:{" "}
-									{<JsonValue value={v}></JsonValue>}
+									{<JsonValue value={v} collapsed={this.collapsed}></JsonValue>}
 									{index < this.length - 1 ? "," : ""}
 								</div>
 						  ))}

--- a/src/components/display/json/object/index.tsx
+++ b/src/components/display/json/object/index.tsx
@@ -8,7 +8,7 @@ import { JsonValue } from "../JsonValue"
 })
 export class SmoothlyDisplayJsonObject implements ComponentWillLoad {
 	@Prop() value: Record<string, any> | any[]
-	@Prop() collapsed?: boolean
+	@Prop() collapseDepth?: number
 	@State() open: boolean
 	@State() empty: boolean
 	private openBracket: string = ""
@@ -16,7 +16,7 @@ export class SmoothlyDisplayJsonObject implements ComponentWillLoad {
 	private length: number
 
 	componentWillLoad() {
-		this.open = !this.collapsed
+		this.open = typeof this.collapseDepth == "undefined" ? true : this.collapseDepth > 0
 		if (Array.isArray(this.value)) {
 			this.openBracket = "["
 			this.closeBracket = "]"
@@ -30,6 +30,7 @@ export class SmoothlyDisplayJsonObject implements ComponentWillLoad {
 	}
 
 	render(): VNode {
+		const nextCollapseDepth = typeof this.collapseDepth == "undefined" ? undefined : Math.max(this.collapseDepth - 1, 0)
 		return (
 			<Host class={{ empty: this.empty, open: this.open }}>
 				<span class="open-bracket" onClick={() => (this.open = !this.open)}>
@@ -39,14 +40,14 @@ export class SmoothlyDisplayJsonObject implements ComponentWillLoad {
 					{Array.isArray(this.value)
 						? this.value.map((v, index) => (
 								<div class="indent">
-									<JsonValue value={v} collapsed={this.collapsed}></JsonValue>
+									<JsonValue value={v} collapseDepth={nextCollapseDepth}></JsonValue>
 									{index < this.length - 1 ? "," : ""}
 								</div>
 						  ))
 						: Object.entries(this.value).map(([k, v], index) => (
 								<div class="indent">
 									{<smoothly-display-json-record-key value={k}></smoothly-display-json-record-key>}:{" "}
-									{<JsonValue value={v} collapsed={this.collapsed}></JsonValue>}
+									{<JsonValue value={v} collapseDepth={nextCollapseDepth}></JsonValue>}
 									{index < this.length - 1 ? "," : ""}
 								</div>
 						  ))}

--- a/src/components/display/json/object/index.tsx
+++ b/src/components/display/json/object/index.tsx
@@ -16,7 +16,7 @@ export class SmoothlyDisplayJsonObject implements ComponentWillLoad {
 	private length: number
 
 	componentWillLoad() {
-		this.open = typeof this.collapseDepth == "undefined" ? true : this.collapseDepth > 0
+		this.open = typeof this.collapseDepth == "number" ? this.collapseDepth > 0 : true
 		if (Array.isArray(this.value)) {
 			this.openBracket = "["
 			this.closeBracket = "]"
@@ -30,7 +30,7 @@ export class SmoothlyDisplayJsonObject implements ComponentWillLoad {
 	}
 
 	render(): VNode {
-		const nextCollapseDepth = typeof this.collapseDepth == "undefined" ? undefined : Math.max(this.collapseDepth - 1, 0)
+		const nextCollapseDepth = typeof this.collapseDepth == "number" ? Math.max(this.collapseDepth - 1, 0) : undefined
 		return (
 			<Host class={{ empty: this.empty, open: this.open }}>
 				<span class="open-bracket" onClick={() => (this.open = !this.open)}>

--- a/src/components/display/json/object/style.css
+++ b/src/components/display/json/object/style.css
@@ -10,7 +10,7 @@
 	padding-left: 1rem;
 	border-left: 1px solid rgb(var(--smoothly-light-shade));
 }
-:host(:not([open])) .content {
+:host(:not(.open)) .content {
 	display: none;
 }
 .open-bracket::after {
@@ -22,9 +22,9 @@
 	font-size: 0.8em;
 }
 
-:host(:not([open]):not(.empty))>.open-bracket::after {
+:host(:not(.open):not(.empty))>.open-bracket::after {
 	content: " ▶-◀ ";
 }
-:host([open]:not(.empty))>.open-bracket::after {
+:host(.open:not(.empty))>.open-bracket::after {
 	content: " ▼ ";
 }


### PR DESCRIPTION
This is also added to the regular `smoothly-display` component so it can be used there.



![image](https://github.com/user-attachments/assets/53e56b47-aa58-499d-a6af-e4aaee195376)
