### PR TITLE
Fix smoothly-icon not visible in safari browser

### DIFF
--- a/src/components/icon/style.css
+++ b/src/components/icon/style.css
@@ -44,3 +44,7 @@
 	width: 4em;
 	height: 4em;
 }
+:host::slotted(svg) {
+	/* this is needed for svg to work on safari */
+	width: 100%;
+}


### PR DESCRIPTION
### Issue
https://github.com/utily/smoothly/issues/866


### Solution Confirmed
This solution was confirmed to work using Gnome Web browser that uses web-kit just like Safari.
Also tested this on an Iphone before and after to see that it worked.