### PR TITLE
border fix on form looks="grid"

### DIFF
--- a/src/assets/style/mapping.css
+++ b/src/assets/style/mapping.css
@@ -22,6 +22,7 @@ smoothly-color {
 	--smoothly-input-foreground: var(--smoothly-default-contrast);
 	--smoothly-input-background: var(--smoothly-default-tint);
 	--smoothly-input-border: var(--smoothly-default-shade);
+	--smoothly-input-border-readonly: var(--smoothly-input-border), 50% ;
 	--smoothly-input-border-radius: 0;
 
 	--smoothly-input-hover-background: var(--smoothly-primary-tint);

--- a/src/components/form/style.css
+++ b/src/components/form/style.css
@@ -32,6 +32,10 @@ smoothly-form[looks="border"] > form > fieldset,
 smoothly-form[looks="transparent"] > form > fieldset {
 	gap: 2em
 }
+smoothly-form[looks="grid"] > form > fieldset {
+	padding: 1px;
+	gap: 1px;
+}
 
 smoothly-form > form > div:not(:empty) {
 	display: flex;

--- a/src/components/input/shared.css
+++ b/src/components/input/shared.css
@@ -26,14 +26,11 @@
 	border-bottom: transparent solid 1px;
 }
 
-:host[looks="grid"]::slotted(smoothly-picker-menu smoothly-input),
 :host[looks="grid"] {
-	border: rgb(var(--smoothly-input-border)) solid .5px;
-	margin: -1px -1px 0 0;
-}
-
-:host[looks="grid"][readonly] {
-	border: transparent solid .5px;
+  flex-grow: 1;
+  flex-basis: 40%;
+  box-shadow: 0px 0px 0px 1px rgb(var(--smoothly-input-border));
+  border: none;
 }
 
 :host[looks="transparent"] {

--- a/src/components/input/shared.css
+++ b/src/components/input/shared.css
@@ -32,6 +32,9 @@
   box-shadow: 0px 0px 0px 1px rgb(var(--smoothly-input-border));
   border: none;
 }
+:host[looks="grid"][readonly] {
+	box-shadow: 0px 0px 0px 1px rgba(var(--smoothly-input-border-readonly));
+}
 
 :host[looks="transparent"] {
 	border: none;


### PR DESCRIPTION


the previous css rules where the border was 0.5px had some inconsistent behavior when mixing readonly and normal inputs. Sometimes the border showed, sometimes it didnt.

This change makes it work as intended.
