### PR TITLE
dont style focus for transparent readonly

### DIFF
--- a/src/components/input/shared.css
+++ b/src/components/input/shared.css
@@ -40,15 +40,17 @@
 	border: none;
 }
 
+:host[looks="transparent"][readonly],
 :host[looks="transparent"]:not(:focus-within) {
 	background-color: transparent;
 }
 
+:host[looks="transparent"][readonly]>input,
 :host[looks="transparent"]:not(:focus-within)>input {
 	background: transparent;
 }
 
-:host[looks="transparent"]:focus-within {
+:host[looks="transparent"]:not([readonly]):focus-within {
 	outline: 1px solid rgb(var(--smoothly-input-border));
 }
 


### PR DESCRIPTION
[Screencast from 2024-09-25 13:31:35.webm](https://github.com/user-attachments/assets/8929ddaa-7848-4b74-a762-bc8896cf7641)

The main difference is the background and border do not become visible on focus.
This way it works just like the other looks (readonly with focus do not change styling).
![image](https://github.com/user-attachments/assets/30271f64-f898-4468-8382-6cb8e93b187b)
