### PR TITLE
file input fix

### DIFF
--- a/src/components/form/demo/transparent/index.tsx
+++ b/src/components/form/demo/transparent/index.tsx
@@ -9,7 +9,7 @@ export class SmoothlyFormDemoTransparent {
 		return (
 			<Host>
 				<h2>Transparent</h2>
-				<smoothly-form looks={"transparent"}>
+				<smoothly-form looks={"transparent"} onSmoothlyFormSubmit={e => console.log(e.detail.value)}>
 					<smoothly-input-file name={"file"}>
 						<span slot={"label"}>File</span>
 						<smoothly-icon slot={"button"} name={"folder-open-outline"} size={"small"} />
@@ -30,6 +30,7 @@ export class SmoothlyFormDemoTransparent {
 							<smoothly-icon name={"bus-outline"} />
 						</smoothly-item>
 					</smoothly-input-select>
+					<smoothly-input-submit icon={"checkbox-outline"} />
 				</smoothly-form>
 			</Host>
 		)

--- a/src/model/Data.spec.ts
+++ b/src/model/Data.spec.ts
@@ -29,6 +29,7 @@ describe("Data", () => {
 		expect(output).toEqual(["zero", "one", undefined, "three"])
 	})
 	it("Data.set multiple", () => {
+		const file = new File(["PDF"], "my file")
 		const input: any = {
 			"name.last": "Smith",
 			"name.first": "John",
@@ -43,6 +44,8 @@ describe("Data", () => {
 			"pets.2.type": "turtle",
 			"pets.2.name": "Speedster",
 			"work.duration": {},
+			// file: new File(["PDF"], "my file"),
+			"receipts.0.file": file,
 		}
 		const output = Data.deepen(input)
 		expect(output).toEqual({
@@ -60,6 +63,7 @@ describe("Data", () => {
 				1: { name: "Mr Meow", type: "cat" },
 				2: { name: "Speedster", type: "turtle" },
 			},
+			receipts: { 0: { file } },
 			work: { duration: {} },
 		})
 		const outputWithArrays = Data.convertArrays(output)
@@ -79,6 +83,7 @@ describe("Data", () => {
 				{ name: "Speedster", type: "turtle" },
 			],
 			work: { duration: {} },
+			receipts: [{ file }],
 		})
 	})
 })

--- a/src/model/Data.spec.ts
+++ b/src/model/Data.spec.ts
@@ -44,7 +44,6 @@ describe("Data", () => {
 			"pets.2.type": "turtle",
 			"pets.2.name": "Speedster",
 			"work.duration": {},
-			// file: new File(["PDF"], "my file"),
 			"receipts.0.file": file,
 		}
 		const output = Data.deepen(input)

--- a/src/model/Data.ts
+++ b/src/model/Data.ts
@@ -45,7 +45,7 @@ export namespace Data {
 					arr[k] = convertArrays(v)
 					return arr
 			  }, [])
-			: isly.object().is(data)
+			: isly.object().is(data) && !(data instanceof Blob || data instanceof File)
 			? Object.fromEntries(Object.entries(data).map(([k, v]) => [k, convertArrays(v)]))
 			: data
 	}


### PR DESCRIPTION
`Data.convertArray()` treated blobs / files as a nested object that could have more data within which caused it to destroy the files and leave an empty object in its place. 

Both Blob and File check is required due to some platform difference in node (is at least my guess. Blob check is usually enough. 