### PR TITLE
Floating labels for readonly inputs

### DIFF
--- a/src/components/input/shared.css
+++ b/src/components/input/shared.css
@@ -70,8 +70,10 @@
 :host.floating-label ::slotted([slot=label]),
 :host.has-value ::slotted([slot=label]),
 :host[placeholder] ::slotted([slot=label]),
+:host[readonly] ::slotted([slot=label]),
 :host.has-value .label,
 :host[placeholder] .label,
+:host[readonly] .label
 :host:not([readonly]):focus-within .label.float-on-focus {
 	top: .2rem;
 	transform: scale(0.8);


### PR DESCRIPTION
We used to have floating labels on `readonly` but I think I removed it, because I failed to see the point of them.

Now, I see why we used them. When using inputs as readonly to show values we want all the inputs to look consistent even when they are empty.


## Before
![image](https://github.com/user-attachments/assets/1aa7bc0a-ebc4-4fbf-bc52-84b8394e1814)

## After (with floating labels on readonly)
![image](https://github.com/user-attachments/assets/871691ef-759e-4f3a-98c7-60a434473e88)
