### PR TITLE
Fix broken css selector for input's floating label

### DIFF
--- a/src/components/input/shared.css
+++ b/src/components/input/shared.css
@@ -73,7 +73,7 @@
 :host[readonly] ::slotted([slot=label]),
 :host.has-value .label,
 :host[placeholder] .label,
-:host[readonly] .label
+:host[readonly] .label,
 :host:not([readonly]):focus-within .label.float-on-focus {
 	top: .2rem;
 	transform: scale(0.8);


### PR DESCRIPTION
Focus-within does not move the label now, because I broke it.
This is a pretty good reason to get a linter for css just like we have for ts.