### PR TITLE
Add toInteger prop on display and input

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
 				"langly": "2.0.9",
 				"normalize.css": "^8.0.1",
 				"selectively": "^2.0.11",
-				"tidily": "^0.1.9",
+				"tidily": "^0.1.14",
 				"urlpattern-polyfill": "^8.0.2"
 			},
 			"devDependencies": {
@@ -6563,9 +6563,9 @@
 			"dev": true
 		},
 		"node_modules/tidily": {
-			"version": "0.1.9",
-			"resolved": "https://registry.npmjs.org/tidily/-/tidily-0.1.9.tgz",
-			"integrity": "sha512-/Q7NNeBIolwMRYIb79tqa8/t1wcDY1ceianoaReDvDvWnidsH3gTgSDw01n8/VXevkEaAX0xXnFr1KkHU2rNEA==",
+			"version": "0.1.14",
+			"resolved": "https://registry.npmjs.org/tidily/-/tidily-0.1.14.tgz",
+			"integrity": "sha512-tHelYKmfbqID+KqbalqCwtV5FUqJ64vt/aUHt2m5qTgFurGX7ePVD6yjREwBiQueBsngOTQtIfGcH9xsw821jQ==",
 			"license": "MIT",
 			"dependencies": {
 				"isoly": "^2.3.6"

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
 		"langly": "2.0.9",
 		"normalize.css": "^8.0.1",
 		"selectively": "^2.0.11",
-		"tidily": "^0.1.9",
+		"tidily": "^0.1.14",
 		"urlpattern-polyfill": "^8.0.2"
 	},
 	"devDependencies": {

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -127,6 +127,7 @@ export namespace Components {
         "currency"?: Currency;
         "format"?: DateTime.Format;
         "label"?: string;
+        "toInteger"?: boolean;
         "type": Type | "json";
         "value"?: any;
     }
@@ -252,6 +253,7 @@ export namespace Components {
         "setKeepFocusOnReRender": (keepFocus: boolean) => Promise<void>;
         "setSelectionRange": (start: number, end: number, direction?: tidily.Direction) => Promise<void>;
         "showLabel": boolean;
+        "toInteger"?: boolean;
         "type": tidily.Type;
         "value": any;
     }
@@ -2409,6 +2411,7 @@ declare namespace LocalJSX {
         "currency"?: Currency;
         "format"?: DateTime.Format;
         "label"?: string;
+        "toInteger"?: boolean;
         "type"?: Type | "json";
         "value"?: any;
     }
@@ -2544,6 +2547,7 @@ declare namespace LocalJSX {
         "readonly"?: boolean;
         "required"?: boolean;
         "showLabel"?: boolean;
+        "toInteger"?: boolean;
         "type"?: tidily.Type;
         "value"?: any;
     }

--- a/src/components/display-amount/index.tsx
+++ b/src/components/display-amount/index.tsx
@@ -1,7 +1,7 @@
 import { Component, Prop } from "@stencil/core"
 import { isoly } from "isoly"
 
-// DEPRECATED use <smoothly-display type="amount"> instead
+// DEPRECATED use <smoothly-display type="price"> instead
 @Component({
 	tag: "smoothly-display-amount",
 	styleUrl: "style.css",

--- a/src/components/display/demo/index.tsx
+++ b/src/components/display/demo/index.tsx
@@ -56,59 +56,59 @@ export class SmoothlyDisplayDemo {
 						</dd>
 						<dt>text</dt>
 						<dd>
-							<smoothly-display type="text" value="text"></smoothly-display>
+							<smoothly-display type="text" value="text" />
 						</dd>
 						<dt>postal code</dt>
 						<dd>
-							<smoothly-display type="postal-code" value="752 31"></smoothly-display>
+							<smoothly-display type="postal-code" value="752 31" />
 						</dd>
 						<dt>password</dt>
 						<dd>
-							<smoothly-display type="password" value="password"></smoothly-display>
+							<smoothly-display type="password" value="password" />
 						</dd>
 						<dt>email</dt>
 						<dd>
-							<smoothly-display type="email" value="test@example.com"></smoothly-display>
+							<smoothly-display type="email" value="test@example.com" />
 						</dd>
 						<dt>price</dt>
 						<dd>
-							<smoothly-display type="price" value="13.37" currency="SEK"></smoothly-display>
+							<smoothly-display type="price" value="13.37" currency="SEK" />
 						</dd>
-						<dt>display amount without decimals</dt>
+						<dt>price without decimals</dt>
 						<dd>
-							<smoothly-display-amount amount={200} currency="SEK" toInteger={true}></smoothly-display-amount>
+							<smoothly-display type={"price"} value={200} currency="SEK" toInteger />
 						</dd>
-						<dt>display amount with decimals if they are set, otherwise no decimal</dt>
+						<dt>price with decimals if they are set, otherwise no decimal</dt>
 						<dd>
-							<smoothly-display-amount amount={200.2} currency="SEK" toInteger={true}></smoothly-display-amount>
+							<smoothly-display type={"price"} value={200.2} currency="SEK" toInteger />
 						</dd>
-						<dt>display amount with decimals</dt>
+						<dt>price with decimals</dt>
 						<dd>
-							<smoothly-display-amount amount={200.2} currency="SEK"></smoothly-display-amount>
+							<smoothly-display type={"price"} value={200.2} currency="SEK" />
 						</dd>
 						<dt>percent</dt>
 						<dd>
-							<smoothly-display type="percent" value="42"></smoothly-display>
+							<smoothly-display type="percent" value="42" />
 						</dd>
 						<dt>phone</dt>
 						<dd>
-							<smoothly-display type="phone" value="0101881108"></smoothly-display>
+							<smoothly-display type="phone" value="0101881108" />
 						</dd>
 						<dt>card number</dt>
 						<dd>
-							<smoothly-display type="card-number" value="4111111111111111"></smoothly-display>
+							<smoothly-display type="card-number" value="4111111111111111" />
 						</dd>
 						<dt>card expires</dt>
 						<dd>
-							<smoothly-display type="card-expires" value="7/22"></smoothly-display>
+							<smoothly-display type="card-expires" value="7/22" />
 						</dd>
 						<dt>card csc</dt>
 						<dd>
-							<smoothly-display type="card-csc" value="987"></smoothly-display>
+							<smoothly-display type="card-csc" value="987" />
 						</dd>
 						<dt>date</dt>
 						<dd>
-							<smoothly-display type="date" value="2022-07-07"></smoothly-display>
+							<smoothly-display type="date" value="2022-07-07" />
 						</dd>
 						<dt>date time</dt>
 						<dd>
@@ -122,7 +122,8 @@ export class SmoothlyDisplayDemo {
 									minute: "numeric",
 									second: "numeric",
 								}}
-								value="2022-07-07T02:02:02Z"></smoothly-display>
+								value="2022-07-07T02:02:02Z"
+							/>
 						</dd>
 						<dd>
 							<smoothly-display
@@ -135,7 +136,8 @@ export class SmoothlyDisplayDemo {
 									minute: "2-digit",
 									second: "2-digit",
 								}}
-								value="2022-07-07T02:02:02Z"></smoothly-display>
+								value="2022-07-07T02:02:02Z"
+							/>
 						</dd>
 						<dd>
 							<smoothly-display
@@ -148,7 +150,8 @@ export class SmoothlyDisplayDemo {
 									minute: "numeric",
 									second: "numeric",
 								}}
-								value="2022-07-07T12:22:24Z"></smoothly-display>
+								value="2022-07-07T12:22:24Z"
+							/>
 						</dd>
 						<dd>
 							<smoothly-display
@@ -161,19 +164,22 @@ export class SmoothlyDisplayDemo {
 									minute: "numeric",
 									second: "numeric",
 								}}
-								value="2022-07-07T12:22:24Z"></smoothly-display>
+								value="2022-07-07T12:22:24Z"
+							/>
 						</dd>
 						<dd>
 							<smoothly-display
 								type="date-time"
 								format={{ year: "numeric", month: "short", day: "numeric" }}
-								value="2022-07-07T00:00+02:00"></smoothly-display>
+								value="2022-07-07T00:00+02:00"
+							/>
 						</dd>
 						<dd>
 							<smoothly-display
 								type="date-time"
 								format={{ year: "2-digit", month: "numeric", day: "numeric" }}
-								value="2022-07-07T00:00+02:00"></smoothly-display>
+								value="2022-07-07T00:00+02:00"
+							/>
 						</dd>
 						<dd>
 							<smoothly-display
@@ -187,7 +193,8 @@ export class SmoothlyDisplayDemo {
 									second: "2-digit",
 									timeZone: "Europe/Stockholm",
 								}}
-								value="2022-07-07T12:15Z"></smoothly-display>
+								value="2022-07-07T12:15Z"
+							/>
 						</dd>
 						<dt>Display JSON</dt>
 						<dd>
@@ -201,16 +208,17 @@ export class SmoothlyDisplayDemo {
 				</fieldset>
 				<h2>With labels</h2>
 				<dd>
-					<smoothly-display label="Today" type="date" value={isoly.Date.now()}></smoothly-display>
-					<smoothly-display label="Total amount" type="price" currency="SEK" value={6789}></smoothly-display>
-					<smoothly-display label="Total amount" type="price" currency="GBP" value={678.9}></smoothly-display>
+					<smoothly-display label="Today" type="date" value={isoly.Date.now()} />
+					<smoothly-display label="Total amount" type="price" currency="SEK" value={6789} />
+					<smoothly-display label="Total amount" type="price" currency="GBP" value={678.9} />
 					<smoothly-display
 						label="Logs"
 						type="json"
 						value={[
 							{ type: "trace", message: "Hello" },
 							{ type: "error", message: "Oh no!" },
-						]}></smoothly-display>
+						]}
+					/>
 				</dd>
 				<fieldset>
 					<h2>Test of different kinds of notifier</h2>

--- a/src/components/display/index.tsx
+++ b/src/components/display/index.tsx
@@ -12,6 +12,7 @@ export class SmoothlyDisplay {
 	@Prop() label?: string
 	@Prop() value?: any
 	@Prop() collapseDepth?: number
+	@Prop() toInteger?: boolean
 	@Prop() currency?: Currency
 	@Prop() country?: CountryCode.Alpha2
 	@Prop() format?: DateTime.Format
@@ -35,7 +36,7 @@ export class SmoothlyDisplay {
 				result = format(this.value, type, this.country)
 				break
 			case "price":
-				result = format(this.value, type, this.currency)
+				result = format(this.value, type, { currency: this.currency, toInteger: this.toInteger })
 				break
 			case "date":
 				result = get(this.type as Type, getLocale())?.toString(this.value)

--- a/src/components/form/demo/prices/index.tsx
+++ b/src/components/form/demo/prices/index.tsx
@@ -13,8 +13,8 @@ export class SmoothlyFormDemoPrices {
 					<smoothly-input type="price" name="no">
 						No currency
 					</smoothly-input>
-					<smoothly-input type="price" name="crowns" currency="SEK">
-						SEK
+					<smoothly-input type="price" name="crowns" currency="SEK" toInteger>
+						SEK (toInteger)
 					</smoothly-input>
 					<smoothly-input type="price" name="usDollar" currency="USD">
 						USD

--- a/src/components/input/index.tsx
+++ b/src/components/input/index.tsx
@@ -24,6 +24,7 @@ export class SmoothlyInput implements Clearable, Input, Editable {
 	@Prop({ reflect: true }) placeholder: string | undefined
 	@Prop() disabled = false
 	@Prop({ mutable: true, reflect: true }) readonly = false
+	@Prop() toInteger?: boolean
 	@Prop({ reflect: true }) currency?: isoly.Currency
 	@Prop() invalid?: boolean = false
 	@Prop({ mutable: true }) changed = false
@@ -61,7 +62,7 @@ export class SmoothlyInput implements Clearable, Input, Editable {
 		let result: (tidily.Formatter & tidily.Converter<any>) | undefined
 		switch (this.type) {
 			case "price":
-				result = tidily.get("price", this.currency)
+				result = tidily.get("price", { currency: this.currency, toInteger: this.toInteger })
 				break
 			default:
 				result = tidily.get(this.type, getLocale())


### PR DESCRIPTION
Add Prop `toInteger` on `<smoothly-display type="price" />` and `<smoothly-input type="price" />`
This will make sure to not add decimals on the price unless warranted.
e.g. 
`45` -> `45 EUR`, 
instead of 
`45` -> `45.00 EUR`


This means `<smoothly-display type="price" />` now has the same functionality as `smoothly-display-amount` which is deprecated.

### Display
![image](https://github.com/user-attachments/assets/238d9db0-a54a-4c11-9307-ac0e49983263)

### Input type=price
![image](https://github.com/user-attachments/assets/4a3bf8cd-a950-472d-9670-816da28d926a)


