### PR TITLE
looks on input prioritized before form looks

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -167,7 +167,7 @@ export namespace Components {
     }
     interface SmoothlyFilterSelect {
         "label": string;
-        "looks": Looks;
+        "looks"?: Looks;
         "menuHeight"?: `${number}items` | `${number}rem` | `${number}px` | `${number}vh` | undefined;
         "multiple": boolean;
         "property": string;
@@ -188,7 +188,7 @@ export namespace Components {
         "color"?: Color;
         "edit": (editable: boolean) => Promise<void>;
         "listen": (property: "changed", listener: (parent: Editable) => Promise<void>) => Promise<void>;
-        "looks": Looks;
+        "looks"?: Looks;
         "name"?: string;
         "prevent": boolean;
         "readonly": boolean;
@@ -243,7 +243,7 @@ export namespace Components {
         "getFormData": (name: string) => Promise<Record<string, any>>;
         "invalid"?: boolean;
         "listen": (property: "changed", listener: (parent: Editable) => Promise<void>) => Promise<void>;
-        "looks": Looks;
+        "looks"?: Looks;
         "name": string;
         "placeholder": string | undefined;
         "readonly": boolean;
@@ -265,7 +265,7 @@ export namespace Components {
         "disabled": boolean;
         "edit": (editable: boolean) => Promise<void>;
         "listen": (property: "changed", listener: (parent: Editable) => Promise<void>) => Promise<void>;
-        "looks": Looks;
+        "looks"?: Looks;
         "name": string;
         "readonly": boolean;
         "reset": () => Promise<void>;
@@ -291,7 +291,7 @@ export namespace Components {
         "color"?: Color;
         "edit": (editable: boolean) => Promise<void>;
         "listen": (property: "changed", listener: (parent: Editable) => Promise<void>) => Promise<void>;
-        "looks": Looks;
+        "looks"?: Looks;
         "name": string;
         "output": "rgb" | "hex";
         "readonly": boolean;
@@ -309,7 +309,7 @@ export namespace Components {
         "edit": (editable: boolean) => Promise<void>;
         "invalid"?: boolean;
         "listen": (property: "changed", listener: (parent: Editable) => Promise<void>) => Promise<void>;
-        "looks": Looks;
+        "looks"?: Looks;
         "max": Date;
         "min": Date;
         "name": string;
@@ -328,7 +328,7 @@ export namespace Components {
         "end": isoly.Date | undefined;
         "invalid"?: boolean;
         "listen": (property: "changed", listener: (parent: Editable) => Promise<void>) => Promise<void>;
-        "looks": Looks;
+        "looks"?: Looks;
         "max"?: isoly.Date;
         "min"?: isoly.Date;
         "name": string;
@@ -363,7 +363,7 @@ export namespace Components {
         "color"?: Color;
         "edit": (editable: boolean) => Promise<void>;
         "listen": (property: "changed", listener: (parent: Editable) => Promise<void>) => Promise<void>;
-        "looks": Looks;
+        "looks"?: Looks;
         "name": string;
         "placeholder": string | undefined;
         "readonly": boolean;
@@ -378,7 +378,7 @@ export namespace Components {
         "edit": (editable: boolean) => Promise<void>;
         "inCalendar": boolean;
         "listen": (property: "changed", listener: (parent: Editable) => Promise<void>) => Promise<void>;
-        "looks": Looks;
+        "looks"?: Looks;
         "name": string;
         "next": boolean;
         "previous": boolean;
@@ -397,7 +397,7 @@ export namespace Components {
         "color"?: Color;
         "edit": (editable: boolean) => Promise<void>;
         "listen": (property: "changed", listener: (parent: Editable) => Promise<void>) => Promise<void>;
-        "looks": Looks;
+        "looks"?: Looks;
         "name": string;
         "readonly": boolean;
         "reset": () => Promise<void>;
@@ -406,7 +406,7 @@ export namespace Components {
         "value": any;
     }
     interface SmoothlyInputRadioItem {
-        "looks": Looks;
+        "looks"?: Looks;
         "name": string;
         "selected": boolean;
         "value": any;
@@ -418,7 +418,7 @@ export namespace Components {
         "edit": (editable: boolean) => Promise<void>;
         "label": string;
         "listen": (property: "changed", listener: (parent: Editable) => Promise<void>) => Promise<void>;
-        "looks": Looks;
+        "looks"?: Looks;
         "max": number;
         "min": number;
         "name": string;
@@ -454,7 +454,7 @@ export namespace Components {
         "inCalendar": boolean;
         "invalid"?: boolean;
         "listen": (property: "changed", listener: (parent: Editable) => Promise<void>) => Promise<void>;
-        "looks": Looks;
+        "looks"?: Looks;
         "menuHeight"?: `${number}${"items" | "rem" | "px" | "vh"}`;
         "multiple": boolean;
         "mutable": boolean;
@@ -561,7 +561,7 @@ export namespace Components {
         "clear": () => Promise<void>;
         "edit": (editable: boolean) => Promise<void>;
         "listen": (property: "changed", listener: (parent: Editable) => Promise<void>) => Promise<void>;
-        "looks": Looks;
+        "looks"?: Looks;
         "multiple": boolean;
         "mutable": boolean;
         "name": string;
@@ -574,7 +574,7 @@ export namespace Components {
     interface SmoothlyPickerDemo {
     }
     interface SmoothlyPickerMenu {
-        "looks": Looks;
+        "looks"?: Looks;
         "multiple": boolean;
         "mutable": boolean;
         "open": boolean;
@@ -1156,7 +1156,7 @@ declare global {
     interface HTMLSmoothlyFilterSelectElementEventMap {
         "smoothlyFilterUpdate": Filter.Update;
         "smoothlyFilterManipulate": Filter.Manipulate;
-        "smoothlyInputLooks": (looks: Looks) => void;
+        "smoothlyInputLooks": (looks?: Looks) => void;
     }
     interface HTMLSmoothlyFilterSelectElement extends Components.SmoothlyFilterSelect, HTMLStencilElement {
         addEventListener<K extends keyof HTMLSmoothlyFilterSelectElementEventMap>(type: K, listener: (this: HTMLSmoothlyFilterSelectElement, ev: SmoothlyFilterSelectCustomEvent<HTMLSmoothlyFilterSelectElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -1303,7 +1303,7 @@ declare global {
         new (): HTMLSmoothlyIconDemoElement;
     };
     interface HTMLSmoothlyInputElementEventMap {
-        "smoothlyInputLooks": (looks: Looks, color: Color) => void;
+        "smoothlyInputLooks": (looks?: Looks, color?: Color) => void;
         "smoothlyInputLoad": (parent: HTMLElement) => void;
         "smoothlyFormDisable": (disabled: boolean) => void;
         "smoothlyBlur": void;
@@ -1325,7 +1325,7 @@ declare global {
         new (): HTMLSmoothlyInputElement;
     };
     interface HTMLSmoothlyInputCheckboxElementEventMap {
-        "smoothlyInputLooks": (looks: Looks, color: Color) => void;
+        "smoothlyInputLooks": (looks?: Looks, color?: Color) => void;
         "smoothlyInput": Data;
         "smoothlyInputLoad": (parent: HTMLElement) => void;
         "smoothlyFormDisable": (disabled: boolean) => void;
@@ -1368,7 +1368,7 @@ declare global {
         new (): HTMLSmoothlyInputClearElement;
     };
     interface HTMLSmoothlyInputColorElementEventMap {
-        "smoothlyInputLooks": (looks: Looks, color: Color) => void;
+        "smoothlyInputLooks": (looks?: Looks, color?: Color) => void;
         "smoothlyInput": Record<string, any>;
         "smoothlyInputLoad": (parent: HTMLElement) => void;
         "smoothlyFormDisable": (disabled: boolean) => void;
@@ -1397,7 +1397,7 @@ declare global {
         "smoothlyInputLoad": (parent: HTMLElement) => void;
         "smoothlyValueChange": Date;
         "smoothlyInput": Record<string, any>;
-        "smoothlyInputLooks": (looks: Looks, color: Color) => void;
+        "smoothlyInputLooks": (looks?: Looks, color?: Color) => void;
         "smoothlyFormDisable": (disabled: boolean) => void;
     }
     interface HTMLSmoothlyInputDateElement extends Components.SmoothlyInputDate, HTMLStencilElement {
@@ -1417,7 +1417,7 @@ declare global {
     interface HTMLSmoothlyInputDateRangeElementEventMap {
         "smoothlyInput": { [name: string]: isoly.DateRange | undefined };
         "smoothlyInputLoad": (parent: HTMLElement) => void;
-        "smoothlyInputLooks": (looks: Looks, color: Color) => void;
+        "smoothlyInputLooks": (looks?: Looks, color?: Color) => void;
         "smoothlyFormDisable": (disabled: boolean) => void;
     }
     interface HTMLSmoothlyInputDateRangeElement extends Components.SmoothlyInputDateRange, HTMLStencilElement {
@@ -1464,7 +1464,7 @@ declare global {
         new (): HTMLSmoothlyInputEditElement;
     };
     interface HTMLSmoothlyInputFileElementEventMap {
-        "smoothlyInputLooks": (looks: Looks, color: Color) => void;
+        "smoothlyInputLooks": (looks?: Looks, color?: Color) => void;
         "smoothlyInput": Record<string, any>;
         "smoothlyInputLoad": (parent: HTMLElement) => void;
         "smoothlyFormDisable": (disabled: boolean) => void;
@@ -1487,7 +1487,7 @@ declare global {
         "smoothlyInput": Data;
         "smoothlyInputLoad": (parent: HTMLElement) => void;
         "smoothlyFormDisable": (disabled: boolean) => void;
-        "smoothlyInputLooks": (looks: Looks, color: Color) => void;
+        "smoothlyInputLooks": (looks?: Looks, color?: Color) => void;
     }
     interface HTMLSmoothlyInputMonthElement extends Components.SmoothlyInputMonth, HTMLStencilElement {
         addEventListener<K extends keyof HTMLSmoothlyInputMonthElementEventMap>(type: K, listener: (this: HTMLSmoothlyInputMonthElement, ev: SmoothlyInputMonthCustomEvent<HTMLSmoothlyInputMonthElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -1510,7 +1510,7 @@ declare global {
         new (): HTMLSmoothlyInputPriceDemoElement;
     };
     interface HTMLSmoothlyInputRadioElementEventMap {
-        "smoothlyInputLooks": (looks: Looks, color: Color) => void;
+        "smoothlyInputLooks": (looks?: Looks, color?: Color) => void;
         "smoothlyInput": Data;
         "smoothlyInputLoad": (parent: HTMLElement) => void;
         "smoothlyFormDisable": (disabled: boolean) => void;
@@ -1548,7 +1548,7 @@ declare global {
         new (): HTMLSmoothlyInputRadioItemElement;
     };
     interface HTMLSmoothlyInputRangeElementEventMap {
-        "smoothlyInputLooks": (looks: Looks, color: Color) => void;
+        "smoothlyInputLooks": (looks?: Looks, color?: Color) => void;
         "smoothlyInput": Record<string, any>;
         "smoothlyInputLoad": (parent: HTMLElement) => void;
         "smoothlyFormDisable": (disabled: boolean) => void;
@@ -1592,7 +1592,7 @@ declare global {
     };
     interface HTMLSmoothlyInputSelectElementEventMap {
         "smoothlyInput": Data;
-        "smoothlyInputLooks": (looks: Looks, color: Color) => void;
+        "smoothlyInputLooks": (looks?: Looks, color?: Color) => void;
         "smoothlyInputLoad": (parent: HTMLElement) => void;
         "smoothlyFormDisable": (disabled: boolean) => void;
         "smoothlyItemSelect": HTMLSmoothlyItemElement;
@@ -1810,7 +1810,7 @@ declare global {
         "smoothlyPickerLoaded": Controls;
         "smoothlyInput": Record<string, any | any[]>;
         "smoothlyChange": Record<string, any | any[]>;
-        "smoothlyInputLooks": (looks: Looks) => void;
+        "smoothlyInputLooks": (looks?: Looks) => void;
         "smoothlyFormDisable": (disabled: boolean) => void;
         "smoothlyInputLoad": (parent: HTMLElement) => void;
     }
@@ -2460,7 +2460,7 @@ declare namespace LocalJSX {
         "multiple"?: boolean;
         "onSmoothlyFilterManipulate"?: (event: SmoothlyFilterSelectCustomEvent<Filter.Manipulate>) => void;
         "onSmoothlyFilterUpdate"?: (event: SmoothlyFilterSelectCustomEvent<Filter.Update>) => void;
-        "onSmoothlyInputLooks"?: (event: SmoothlyFilterSelectCustomEvent<(looks: Looks) => void>) => void;
+        "onSmoothlyInputLooks"?: (event: SmoothlyFilterSelectCustomEvent<(looks?: Looks) => void>) => void;
         "property"?: string;
         "type"?: "array" | "string";
     }
@@ -2542,7 +2542,7 @@ declare namespace LocalJSX {
         "onSmoothlyFormDisable"?: (event: SmoothlyInputCustomEvent<(disabled: boolean) => void>) => void;
         "onSmoothlyInput"?: (event: SmoothlyInputCustomEvent<Record<string, any>>) => void;
         "onSmoothlyInputLoad"?: (event: SmoothlyInputCustomEvent<(parent: HTMLElement) => void>) => void;
-        "onSmoothlyInputLooks"?: (event: SmoothlyInputCustomEvent<(looks: Looks, color: Color) => void>) => void;
+        "onSmoothlyInputLooks"?: (event: SmoothlyInputCustomEvent<(looks?: Looks, color?: Color) => void>) => void;
         "placeholder"?: string | undefined;
         "readonly"?: boolean;
         "required"?: boolean;
@@ -2561,7 +2561,7 @@ declare namespace LocalJSX {
         "onSmoothlyFormDisable"?: (event: SmoothlyInputCheckboxCustomEvent<(disabled: boolean) => void>) => void;
         "onSmoothlyInput"?: (event: SmoothlyInputCheckboxCustomEvent<Data>) => void;
         "onSmoothlyInputLoad"?: (event: SmoothlyInputCheckboxCustomEvent<(parent: HTMLElement) => void>) => void;
-        "onSmoothlyInputLooks"?: (event: SmoothlyInputCheckboxCustomEvent<(looks: Looks, color: Color) => void>) => void;
+        "onSmoothlyInputLooks"?: (event: SmoothlyInputCheckboxCustomEvent<(looks?: Looks, color?: Color) => void>) => void;
         "readonly"?: boolean;
         "value"?: boolean;
     }
@@ -2587,7 +2587,7 @@ declare namespace LocalJSX {
         "onSmoothlyFormDisable"?: (event: SmoothlyInputColorCustomEvent<(disabled: boolean) => void>) => void;
         "onSmoothlyInput"?: (event: SmoothlyInputColorCustomEvent<Record<string, any>>) => void;
         "onSmoothlyInputLoad"?: (event: SmoothlyInputColorCustomEvent<(parent: HTMLElement) => void>) => void;
-        "onSmoothlyInputLooks"?: (event: SmoothlyInputColorCustomEvent<(looks: Looks, color: Color) => void>) => void;
+        "onSmoothlyInputLooks"?: (event: SmoothlyInputColorCustomEvent<(looks?: Looks, color?: Color) => void>) => void;
         "output"?: "rgb" | "hex";
         "readonly"?: boolean;
         "showLabel"?: boolean;
@@ -2606,7 +2606,7 @@ declare namespace LocalJSX {
         "onSmoothlyFormDisable"?: (event: SmoothlyInputDateCustomEvent<(disabled: boolean) => void>) => void;
         "onSmoothlyInput"?: (event: SmoothlyInputDateCustomEvent<Record<string, any>>) => void;
         "onSmoothlyInputLoad"?: (event: SmoothlyInputDateCustomEvent<(parent: HTMLElement) => void>) => void;
-        "onSmoothlyInputLooks"?: (event: SmoothlyInputDateCustomEvent<(looks: Looks, color: Color) => void>) => void;
+        "onSmoothlyInputLooks"?: (event: SmoothlyInputDateCustomEvent<(looks?: Looks, color?: Color) => void>) => void;
         "onSmoothlyValueChange"?: (event: SmoothlyInputDateCustomEvent<Date>) => void;
         "open"?: boolean;
         "readonly"?: boolean;
@@ -2625,7 +2625,7 @@ declare namespace LocalJSX {
         "onSmoothlyFormDisable"?: (event: SmoothlyInputDateRangeCustomEvent<(disabled: boolean) => void>) => void;
         "onSmoothlyInput"?: (event: SmoothlyInputDateRangeCustomEvent<{ [name: string]: isoly.DateRange | undefined }>) => void;
         "onSmoothlyInputLoad"?: (event: SmoothlyInputDateRangeCustomEvent<(parent: HTMLElement) => void>) => void;
-        "onSmoothlyInputLooks"?: (event: SmoothlyInputDateRangeCustomEvent<(looks: Looks, color: Color) => void>) => void;
+        "onSmoothlyInputLooks"?: (event: SmoothlyInputDateRangeCustomEvent<(looks?: Looks, color?: Color) => void>) => void;
         "placeholder"?: string;
         "readonly"?: boolean;
         "showLabel"?: boolean;
@@ -2657,7 +2657,7 @@ declare namespace LocalJSX {
         "onSmoothlyFormDisable"?: (event: SmoothlyInputFileCustomEvent<(disabled: boolean) => void>) => void;
         "onSmoothlyInput"?: (event: SmoothlyInputFileCustomEvent<Record<string, any>>) => void;
         "onSmoothlyInputLoad"?: (event: SmoothlyInputFileCustomEvent<(parent: HTMLElement) => void>) => void;
-        "onSmoothlyInputLooks"?: (event: SmoothlyInputFileCustomEvent<(looks: Looks, color: Color) => void>) => void;
+        "onSmoothlyInputLooks"?: (event: SmoothlyInputFileCustomEvent<(looks?: Looks, color?: Color) => void>) => void;
         "placeholder"?: string | undefined;
         "readonly"?: boolean;
         "showLabel"?: boolean;
@@ -2672,7 +2672,7 @@ declare namespace LocalJSX {
         "onSmoothlyFormDisable"?: (event: SmoothlyInputMonthCustomEvent<(disabled: boolean) => void>) => void;
         "onSmoothlyInput"?: (event: SmoothlyInputMonthCustomEvent<Data>) => void;
         "onSmoothlyInputLoad"?: (event: SmoothlyInputMonthCustomEvent<(parent: HTMLElement) => void>) => void;
-        "onSmoothlyInputLooks"?: (event: SmoothlyInputMonthCustomEvent<(looks: Looks, color: Color) => void>) => void;
+        "onSmoothlyInputLooks"?: (event: SmoothlyInputMonthCustomEvent<(looks?: Looks, color?: Color) => void>) => void;
         "previous"?: boolean;
         "readonly"?: boolean;
         "showLabel"?: boolean;
@@ -2689,7 +2689,7 @@ declare namespace LocalJSX {
         "onSmoothlyFormDisable"?: (event: SmoothlyInputRadioCustomEvent<(disabled: boolean) => void>) => void;
         "onSmoothlyInput"?: (event: SmoothlyInputRadioCustomEvent<Data>) => void;
         "onSmoothlyInputLoad"?: (event: SmoothlyInputRadioCustomEvent<(parent: HTMLElement) => void>) => void;
-        "onSmoothlyInputLooks"?: (event: SmoothlyInputRadioCustomEvent<(looks: Looks, color: Color) => void>) => void;
+        "onSmoothlyInputLooks"?: (event: SmoothlyInputRadioCustomEvent<(looks?: Looks, color?: Color) => void>) => void;
         "readonly"?: boolean;
         "showLabel"?: boolean;
         "value"?: any;
@@ -2713,7 +2713,7 @@ declare namespace LocalJSX {
         "onSmoothlyFormDisable"?: (event: SmoothlyInputRangeCustomEvent<(disabled: boolean) => void>) => void;
         "onSmoothlyInput"?: (event: SmoothlyInputRangeCustomEvent<Record<string, any>>) => void;
         "onSmoothlyInputLoad"?: (event: SmoothlyInputRangeCustomEvent<(parent: HTMLElement) => void>) => void;
-        "onSmoothlyInputLooks"?: (event: SmoothlyInputRangeCustomEvent<(looks: Looks, color: Color) => void>) => void;
+        "onSmoothlyInputLooks"?: (event: SmoothlyInputRangeCustomEvent<(looks?: Looks, color?: Color) => void>) => void;
         "outputSide"?: "right" | "left";
         "readonly"?: boolean;
         "step"?: number;
@@ -2749,7 +2749,7 @@ declare namespace LocalJSX {
         "onSmoothlyFormDisable"?: (event: SmoothlyInputSelectCustomEvent<(disabled: boolean) => void>) => void;
         "onSmoothlyInput"?: (event: SmoothlyInputSelectCustomEvent<Data>) => void;
         "onSmoothlyInputLoad"?: (event: SmoothlyInputSelectCustomEvent<(parent: HTMLElement) => void>) => void;
-        "onSmoothlyInputLooks"?: (event: SmoothlyInputSelectCustomEvent<(looks: Looks, color: Color) => void>) => void;
+        "onSmoothlyInputLooks"?: (event: SmoothlyInputSelectCustomEvent<(looks?: Looks, color?: Color) => void>) => void;
         "onSmoothlyItemSelect"?: (event: SmoothlyInputSelectCustomEvent<HTMLSmoothlyItemElement>) => void;
         "placeholder"?: string | any;
         "readonly"?: boolean;
@@ -2861,7 +2861,7 @@ declare namespace LocalJSX {
         "onSmoothlyFormDisable"?: (event: SmoothlyPickerCustomEvent<(disabled: boolean) => void>) => void;
         "onSmoothlyInput"?: (event: SmoothlyPickerCustomEvent<Record<string, any | any[]>>) => void;
         "onSmoothlyInputLoad"?: (event: SmoothlyPickerCustomEvent<(parent: HTMLElement) => void>) => void;
-        "onSmoothlyInputLooks"?: (event: SmoothlyPickerCustomEvent<(looks: Looks) => void>) => void;
+        "onSmoothlyInputLooks"?: (event: SmoothlyPickerCustomEvent<(looks?: Looks) => void>) => void;
         "onSmoothlyPickerLoaded"?: (event: SmoothlyPickerCustomEvent<Controls>) => void;
         "open"?: boolean;
         "readonly"?: boolean;

--- a/src/components/filter/select/index.tsx
+++ b/src/components/filter/select/index.tsx
@@ -22,12 +22,12 @@ export class SmoothlyFilterSelect implements Filter {
 	@Prop() menuHeight?: `${number}items` | `${number}rem` | `${number}px` | `${number}vh` | undefined
 	@Prop() multiple = false
 	@Prop() type: "array" | "string" = "string"
-	@Prop({ mutable: true }) looks: Looks = "plain"
+	@Prop({ mutable: true }) looks?: Looks
 	@Event() smoothlyFilterUpdate: EventEmitter<Filter.Update>
 	@Event() smoothlyFilterManipulate: EventEmitter<Filter.Manipulate>
-	@Event() smoothlyInputLooks: EventEmitter<(looks: Looks) => void>
+	@Event() smoothlyInputLooks: EventEmitter<(looks?: Looks) => void>
 	componentWillLoad() {
-		this.smoothlyInputLooks.emit(looks => (this.looks = looks))
+		this.smoothlyInputLooks.emit(looks => (this.looks = this.looks ?? looks))
 	}
 	async componentDidLoad() {
 		this.smoothlyFilterUpdate.emit(this.update.bind(this))
@@ -42,7 +42,7 @@ export class SmoothlyFilterSelect implements Filter {
 		)
 	}
 	@Listen("smoothlyInputLooks")
-	smoothlyInputLooksHandler(event: CustomEvent<(looks: Looks) => void>): void {
+	smoothlyInputLooksHandler(event: CustomEvent<(looks?: Looks) => void>): void {
 		if (event.target != this.element) {
 			event.stopPropagation()
 			event.detail(this.looks)

--- a/src/components/form/index.tsx
+++ b/src/components/form/index.tsx
@@ -34,7 +34,7 @@ export class SmoothlyForm implements ComponentWillLoad, Clearable, Submittable, 
 	@Prop() validator?: isly.Type<any>
 	@Prop() type?: "update" | "change" | "fetch" | "create" = this.action ? "create" : undefined
 	@Prop({ mutable: true }) readonly = false
-	@Prop({ reflect: true, attribute: "looks" }) looks: Looks = "plain"
+	@Prop({ reflect: true, attribute: "looks" }) looks?: Looks
 	@Prop() name?: string
 	@Prop() prevent = true
 	@Prop({ mutable: true }) changed = false
@@ -94,7 +94,7 @@ export class SmoothlyForm implements ComponentWillLoad, Clearable, Submittable, 
 		this.listeners.changed?.forEach(l => l(this))
 	}
 	@Listen("smoothlyInputLooks")
-	smoothlyInputLooksHandler(event: CustomEvent<(looks: Looks, color: Color | undefined) => void>) {
+	smoothlyInputLooksHandler(event: CustomEvent<(looks?: Looks, color?: Color) => void>) {
 		event.stopPropagation()
 		event.detail(this.looks, this.color)
 	}

--- a/src/components/input/Input.ts
+++ b/src/components/input/Input.ts
@@ -14,7 +14,7 @@ export namespace Input {
 		color?: Color
 		name: string
 		invalid?: boolean
-		looks: Looks
+		looks?: Looks
 		defined?: boolean
 		binary?: Binary
 	}

--- a/src/components/input/checkbox/index.tsx
+++ b/src/components/input/checkbox/index.tsx
@@ -18,17 +18,19 @@ export class SmoothlyInputCheckbox implements Input, Clearable, Editable, Compon
 	@Prop({ reflect: true, mutable: true }) readonly = false
 	@Prop({ mutable: true }) checked = false
 	@Prop() value = this.checked
-	@Prop({ reflect: true, mutable: true }) looks: Looks = "plain"
+	@Prop({ reflect: true, mutable: true }) looks?: Looks
 	@Prop({ reflect: true, mutable: true }) color?: Color
 	@Prop({ reflect: true }) disabled: boolean
-	@Event() smoothlyInputLooks: EventEmitter<(looks: Looks, color: Color) => void>
+	@Event() smoothlyInputLooks: EventEmitter<(looks?: Looks, color?: Color) => void>
 	@Event() smoothlyInput: EventEmitter<Data>
 	@Event() smoothlyInputLoad: EventEmitter<(parent: HTMLElement) => void>
 	@Event() smoothlyFormDisable: EventEmitter<(disabled: boolean) => void>
 	componentWillLoad(): void | Promise<void> {
 		this.initialValue = this.checked
 		!this.readonly && this.smoothlyFormDisable.emit(readonly => (this.readonly = readonly))
-		this.smoothlyInputLooks.emit((looks, color) => ((this.looks = looks), (this.color = color)))
+		this.smoothlyInputLooks.emit(
+			(looks, color) => ((this.looks = this.looks ?? looks), !this.color && (this.color = color))
+		)
 		this.smoothlyInputLoad.emit(() => {
 			return
 		})

--- a/src/components/input/color/index.tsx
+++ b/src/components/input/color/index.tsx
@@ -33,7 +33,7 @@ export class SmoothlyInputColor implements Input, Clearable, Editable, Component
 	private hsl: HSL = { h: undefined, s: undefined, l: undefined }
 	private initialValue: string | undefined
 	@Prop({ mutable: true }) value: string | undefined = undefined
-	@Prop({ mutable: true, reflect: true }) looks: Looks = "plain"
+	@Prop({ mutable: true, reflect: true }) looks?: Looks
 	@Prop({ reflect: true, mutable: true }) color?: Color
 	@Prop({ mutable: true }) changed = false
 	@Prop({ reflect: true, mutable: true }) readonly = false
@@ -43,14 +43,14 @@ export class SmoothlyInputColor implements Input, Clearable, Editable, Component
 	@Element() element: HTMLSmoothlyInputColorElement
 	@State() open = false
 	@State() sliderMode: "rgb" | "hsl" = "rgb"
-	@Event() smoothlyInputLooks: EventEmitter<(looks: Looks, color: Color) => void>
+	@Event() smoothlyInputLooks: EventEmitter<(looks?: Looks, color?: Color) => void>
 	@Event() smoothlyInput: EventEmitter<Record<string, any>>
 	@Event() smoothlyInputLoad: EventEmitter<(parent: HTMLElement) => void>
 	@Event() smoothlyFormDisable: EventEmitter<(disabled: boolean) => void>
 	componentWillLoad(): void | Promise<void> {
 		this.value && this.setInitialValue()
 		this.value && (this.rgb = Color.Hex.toRGB(this.value))
-		this.smoothlyInputLooks.emit((looks, color) => ((this.looks = looks), (this.color = color)))
+		this.smoothlyInputLooks.emit((looks, color) => ((this.looks = this.looks ?? looks), (this.color = color)))
 		this.smoothlyInput.emit({
 			[this.name]:
 				this.output === "rgb"

--- a/src/components/input/date/index.tsx
+++ b/src/components/input/date/index.tsx
@@ -26,7 +26,7 @@ import { Looks } from "../Looks"
 export class SmoothlyInputDate implements ComponentWillLoad, Clearable, Input, Editable {
 	@Element() element: HTMLElement
 	@Prop({ reflect: true, mutable: true }) color?: Color
-	@Prop({ reflect: true, mutable: true }) looks: Looks = "plain"
+	@Prop({ reflect: true, mutable: true }) looks?: Looks
 	@Prop({ reflect: true }) name: string
 	@Prop({ mutable: true }) changed = false
 	@Prop({ reflect: true, mutable: true }) readonly = false
@@ -41,13 +41,15 @@ export class SmoothlyInputDate implements ComponentWillLoad, Clearable, Input, E
 	@Event() smoothlyInputLoad: EventEmitter<(parent: HTMLElement) => void>
 	@Event() smoothlyValueChange: EventEmitter<Date>
 	@Event() smoothlyInput: EventEmitter<Record<string, any>>
-	@Event() smoothlyInputLooks: EventEmitter<(looks: Looks, color: Color) => void>
+	@Event() smoothlyInputLooks: EventEmitter<(looks?: Looks, color?: Color) => void>
 	@Event() smoothlyFormDisable: EventEmitter<(disabled: boolean) => void>
 
 	componentWillLoad(): void {
 		this.setInitialValue()
 		this.smoothlyInputLoad.emit(_ => {})
-		this.smoothlyInputLooks.emit((looks, color) => ((this.looks = looks), !this.color && (this.color = color)))
+		this.smoothlyInputLooks.emit(
+			(looks, color) => ((this.looks = this.looks ?? looks), !this.color && (this.color = color))
+		)
 		!this.readonly && this.smoothlyFormDisable.emit(readonly => (this.readonly = readonly))
 	}
 	@Method()

--- a/src/components/input/date/range/index.tsx
+++ b/src/components/input/date/range/index.tsx
@@ -16,7 +16,7 @@ export class SmoothlyInputDateRange implements Clearable, Input, Editable {
 	@Element() element: HTMLElement
 	@Prop() name: string = "dateRange"
 	@Prop({ reflect: true, mutable: true }) color?: Color
-	@Prop({ reflect: true, mutable: true }) looks: Looks = "plain"
+	@Prop({ reflect: true, mutable: true }) looks?: Looks
 	@Prop({ reflect: true, mutable: true }) readonly = false
 	@Prop({ reflect: true }) showLabel = true
 	@Prop({ mutable: true }) start: isoly.Date | undefined
@@ -33,14 +33,16 @@ export class SmoothlyInputDateRange implements Clearable, Input, Editable {
 	@State() open: boolean
 	@Event() smoothlyInput: EventEmitter<{ [name: string]: isoly.DateRange | undefined }>
 	@Event() smoothlyInputLoad: EventEmitter<(parent: HTMLElement) => void>
-	@Event() smoothlyInputLooks: EventEmitter<(looks: Looks, color: Color) => void>
+	@Event() smoothlyInputLooks: EventEmitter<(looks?: Looks, color?: Color) => void>
 	@Event() smoothlyFormDisable: EventEmitter<(disabled: boolean) => void>
 
 	componentWillLoad() {
 		this.setInitialValue()
 		this.updateValue()
 		this.smoothlyInputLoad.emit(_ => {})
-		this.smoothlyInputLooks.emit((looks, color) => ((this.looks = looks), !this.color && (this.color = color)))
+		this.smoothlyInputLooks.emit(
+			(looks, color) => ((this.looks = this.looks ?? looks), !this.color && (this.color = color))
+		)
 		this.start && this.end && this.smoothlyInput.emit({ [this.name]: { start: this.start, end: this.end } })
 		!this.readonly && this.smoothlyFormDisable.emit(readonly => (this.readonly = readonly))
 	}

--- a/src/components/input/file/index.tsx
+++ b/src/components/input/file/index.tsx
@@ -27,14 +27,14 @@ export class SmoothlyInputFile implements ComponentWillLoad, Input, Clearable, E
 	@Prop({ reflect: true, mutable: true }) readonly = false
 	@Prop() accept?: string
 	@Prop({ reflect: true, mutable: true }) color?: Color
-	@Prop({ reflect: true, mutable: true }) looks: Looks = "plain"
+	@Prop({ reflect: true, mutable: true }) looks?: Looks
 	@Prop({ reflect: true }) camera: "front" | "back"
 	@Prop({ reflect: true }) name: string
 	@Prop({ reflect: true }) showLabel = true
 	@Prop({ mutable: true }) value?: File
 	@Prop({ mutable: true, reflect: true }) placeholder: string | undefined
 	@State() dragging = false
-	@Event() smoothlyInputLooks: EventEmitter<(looks: Looks, color: Color) => void>
+	@Event() smoothlyInputLooks: EventEmitter<(looks?: Looks, color?: Color) => void>
 	@Event() smoothlyInput: EventEmitter<Record<string, any>>
 	@Event() smoothlyInputLoad: EventEmitter<(parent: HTMLElement) => void>
 	@Event() smoothlyFormDisable: EventEmitter<(disabled: boolean) => void>
@@ -50,7 +50,9 @@ export class SmoothlyInputFile implements ComponentWillLoad, Input, Clearable, E
 	}
 
 	componentWillLoad(): void {
-		this.smoothlyInputLooks.emit((looks, color) => ((this.looks = looks), !this.color && (this.color = color)))
+		this.smoothlyInputLooks.emit(
+			(looks, color) => ((this.looks = this.looks ?? looks), !this.color && (this.color = color))
+		)
 		this.smoothlyInput.emit({ [this.name]: this.value })
 		this.smoothlyInputLoad.emit(() => {})
 		!this.readonly && this.smoothlyFormDisable.emit(readonly => (this.readonly = readonly))

--- a/src/components/input/index.tsx
+++ b/src/components/input/index.tsx
@@ -14,7 +14,7 @@ import { Looks } from "./Looks"
 })
 export class SmoothlyInput implements Clearable, Input, Editable {
 	@Prop({ reflect: true, mutable: true }) color?: Color
-	@Prop({ reflect: true, mutable: true }) looks: Looks = "plain"
+	@Prop({ reflect: true, mutable: true }) looks?: Looks
 	@Prop({ reflect: true }) name: string
 	@Prop({ mutable: true }) value: any
 	@Prop({ reflect: true }) type: tidily.Type = "text"
@@ -37,7 +37,7 @@ export class SmoothlyInput implements Clearable, Input, Editable {
 	private state: Readonly<tidily.State> & Readonly<tidily.Settings>
 	private uneditable = this.readonly
 	private listener: { changed?: (parent: Editable) => Promise<void> } = {}
-	@Event() smoothlyInputLooks: EventEmitter<(looks: Looks, color: Color) => void>
+	@Event() smoothlyInputLooks: EventEmitter<(looks?: Looks, color?: Color) => void>
 	@Event() smoothlyInputLoad: EventEmitter<(parent: HTMLElement) => void>
 	@Event() smoothlyFormDisable: EventEmitter<(disabled: boolean) => void>
 	@Event() smoothlyBlur: EventEmitter<void>
@@ -113,7 +113,9 @@ export class SmoothlyInput implements Clearable, Input, Editable {
 			value,
 			selection: { start, end: start, direction: "none" },
 		})
-		this.smoothlyInputLooks.emit((looks, color) => ((this.looks = looks), !this.color && (this.color = color)))
+		this.smoothlyInputLooks.emit(
+			(looks, color) => ((this.looks = this.looks ?? looks), !this.color && (this.color = color))
+		)
 		this.smoothlyInputLoad.emit(() => {
 			return
 		})

--- a/src/components/input/month/index.tsx
+++ b/src/components/input/month/index.tsx
@@ -30,7 +30,7 @@ export class SmoothlyInputMonth implements ComponentWillLoad, Input, Editable {
 	@Element() element: HTMLSmoothlyInputMonthElement
 	@Prop({ reflect: true, mutable: true }) readonly: boolean
 	@Prop({ reflect: true }) color?: Color
-	@Prop({ reflect: true, mutable: true }) looks: Looks
+	@Prop({ reflect: true, mutable: true }) looks?: Looks
 	@Prop() name: string
 	@Prop({ mutable: true }) value?: isoly.Date = isoly.Date.now()
 	@Prop({ reflect: true }) next = false
@@ -40,13 +40,13 @@ export class SmoothlyInputMonth implements ComponentWillLoad, Input, Editable {
 	@Event() smoothlyInput: EventEmitter<Data>
 	@Event() smoothlyInputLoad: EventEmitter<(parent: HTMLElement) => void>
 	@Event() smoothlyFormDisable: EventEmitter<(disabled: boolean) => void>
-	@Event() smoothlyInputLooks: EventEmitter<(looks: Looks, color: Color) => void>
+	@Event() smoothlyInputLooks: EventEmitter<(looks?: Looks, color?: Color) => void>
 	private year?: HTMLSmoothlyInputSelectElement
 	private month?: HTMLSmoothlyInputSelectElement
 	private listener: { changed?: (parent: Editable) => Promise<void> } = {}
 
 	componentWillLoad(): void {
-		this.smoothlyInputLooks.emit(looks => (this.looks = looks))
+		this.smoothlyInputLooks.emit(looks => (this.looks = this.looks ?? looks))
 		this.smoothlyInputLoad.emit(() => {})
 		!this.readonly && this.smoothlyFormDisable.emit(readonly => (this.readonly = readonly))
 		this.valueChanged()
@@ -98,7 +98,7 @@ export class SmoothlyInputMonth implements ComponentWillLoad, Input, Editable {
 		}
 	}
 	@Listen("smoothlyInputLooks")
-	smoothlyInputLooksHandler(event: CustomEvent<(looks: Looks, color: Color | undefined) => void>): void {
+	smoothlyInputLooksHandler(event: CustomEvent<(looks?: Looks, color?: Color) => void>): void {
 		if (event.target != this.element) {
 			event.stopPropagation()
 			event.detail(this.looks, this.color)

--- a/src/components/input/radio/index.tsx
+++ b/src/components/input/radio/index.tsx
@@ -30,18 +30,18 @@ export class SmoothlyInputRadio implements Input, Clearable, Editable, Component
 	initialValue?: Selectable
 	@Prop({ mutable: true }) changed = false
 	@Prop({ mutable: true }) value: any = undefined
-	@Prop({ mutable: true, reflect: true }) looks: Looks = "plain"
+	@Prop({ mutable: true, reflect: true }) looks?: Looks
 	@Prop({ reflect: true, mutable: true }) color?: Color
 	@Prop() clearable?: boolean
 	@Prop({ mutable: true, reflect: true }) readonly = false
 	@Prop() name: string
 	@Prop({ reflect: true }) showLabel = true
-	@Event() smoothlyInputLooks: EventEmitter<(looks: Looks, color: Color) => void>
+	@Event() smoothlyInputLooks: EventEmitter<(looks?: Looks, color?: Color) => void>
 	@Event() smoothlyInput: EventEmitter<Data>
 	@Event() smoothlyInputLoad: EventEmitter<(parent: HTMLElement) => void>
 	@Event() smoothlyFormDisable: EventEmitter<(disabled: boolean) => void>
 	componentWillLoad(): void | Promise<void> {
-		this.smoothlyInputLooks.emit((looks, color) => ((this.looks = looks), (this.color = color)))
+		this.smoothlyInputLooks.emit((looks, color) => ((this.looks = this.looks ?? looks), (this.color = color)))
 		!this.readonly && this.smoothlyFormDisable.emit(readonly => (this.readonly = readonly))
 		this.listener.changed?.(this)
 	}

--- a/src/components/input/radio/item/index.tsx
+++ b/src/components/input/radio/item/index.tsx
@@ -11,7 +11,7 @@ export class SmoothlyInputRadioItem {
 	@Element() element: HTMLInputElement
 	@Prop({ mutable: true }) value: any
 	@Prop({ mutable: true }) selected = false
-	@Prop({ mutable: true, reflect: true }) looks: Looks = "plain"
+	@Prop({ mutable: true, reflect: true }) looks?: Looks
 	@Prop({ mutable: true }) name: string
 	@Event() smoothlySelect: EventEmitter<Selectable>
 	@Event() smoothlyRadioButtonRegister: EventEmitter<(name: string) => void>

--- a/src/components/input/range/index.tsx
+++ b/src/components/input/range/index.tsx
@@ -31,7 +31,7 @@ export class SmoothlyInputRange implements Input, Clearable, Editable, Component
 	private initialValue: number | undefined = undefined
 	@Element() element: HTMLSmoothlyInputRangeElement
 	@Prop({ mutable: true }) value: number | undefined = undefined
-	@Prop({ reflect: true, mutable: true }) looks: Looks = "plain"
+	@Prop({ reflect: true, mutable: true }) looks?: Looks
 	@Prop({ reflect: true, mutable: true }) color?: Color
 	@Prop({ mutable: true }) changed = false
 	@Prop({ reflect: true, mutable: true }) readonly = false
@@ -43,12 +43,12 @@ export class SmoothlyInputRange implements Input, Clearable, Editable, Component
 	@Prop() outputSide: "right" | "left" = "left"
 	@Prop() label: string
 	@State() showInput = false
-	@Event() smoothlyInputLooks: EventEmitter<(looks: Looks, color: Color) => void>
+	@Event() smoothlyInputLooks: EventEmitter<(looks?: Looks, color?: Color) => void>
 	@Event() smoothlyInput: EventEmitter<Record<string, any>>
 	@Event() smoothlyInputLoad: EventEmitter<(parent: HTMLElement) => void>
 	@Event() smoothlyFormDisable: EventEmitter<(disabled: boolean) => void>
 	componentWillLoad(): void | Promise<void> {
-		this.smoothlyInputLooks.emit((looks, color) => ((this.looks = looks), (this.color = color)))
+		this.smoothlyInputLooks.emit((looks, color) => ((this.looks = this.looks ?? looks), (this.color = color)))
 		this.smoothlyInput.emit({ [this.name]: this.value })
 		this.smoothlyInputLoad.emit(() => {
 			return

--- a/src/components/input/select/index.tsx
+++ b/src/components/input/select/index.tsx
@@ -38,7 +38,7 @@ export class SmoothlyInputSelect implements Input, Editable, Clearable, Componen
 	@Prop() invalid?: boolean = false
 	@Prop() name = "selected"
 	@Prop({ reflect: true, mutable: true }) color?: Color
-	@Prop({ reflect: true, mutable: true }) looks: Looks = "plain"
+	@Prop({ reflect: true, mutable: true }) looks?: Looks
 	@Prop({ reflect: true }) showLabel = true
 	@Prop({ reflect: true, mutable: true }) showSelected?: boolean = true
 	@Prop({ reflect: true, mutable: true }) readonly = false
@@ -57,13 +57,15 @@ export class SmoothlyInputSelect implements Input, Editable, Clearable, Componen
 	@State() filter = ""
 	@State() addedItems: HTMLSmoothlyItemElement[] = []
 	@Event() smoothlyInput: EventEmitter<Data>
-	@Event() smoothlyInputLooks: EventEmitter<(looks: Looks, color: Color) => void>
+	@Event() smoothlyInputLooks: EventEmitter<(looks?: Looks, color?: Color) => void>
 	@Event() smoothlyInputLoad: EventEmitter<(parent: HTMLElement) => void>
 	@Event() smoothlyFormDisable: EventEmitter<(disabled: boolean) => void>
 	@Event() smoothlyItemSelect: EventEmitter<HTMLSmoothlyItemElement>
 
 	componentWillLoad(): void | Promise<void> {
-		this.smoothlyInputLooks.emit((looks, color) => ((this.looks = looks), !this.color && (this.color = color)))
+		this.smoothlyInputLooks.emit(
+			(looks, color) => ((this.looks = this.looks ?? looks), !this.color && (this.color = color))
+		)
 		this.smoothlyInputLoad.emit(() => {
 			return
 		})

--- a/src/components/picker/index.tsx
+++ b/src/components/picker/index.tsx
@@ -31,7 +31,7 @@ export class SmoothlyPicker implements Clearable, Editable, Input, ComponentDidL
 	private initialValue = new Map<any, Option>()
 	private listener: { changed?: (parent: Editable) => Promise<void> } = {}
 	@Element() element: HTMLSmoothlyPickerElement
-	@Prop({ reflect: true, mutable: true }) looks: Looks = "plain"
+	@Prop({ reflect: true, mutable: true }) looks?: Looks
 	@Prop({ reflect: true }) name: string
 	@Prop({ mutable: true }) changed = false
 	@Prop({ reflect: true, mutable: true }) open = false
@@ -44,13 +44,13 @@ export class SmoothlyPicker implements Clearable, Editable, Input, ComponentDidL
 	@Event() smoothlyPickerLoaded: EventEmitter<Controls>
 	@Event() smoothlyInput: EventEmitter<Record<string, any | any[]>> // multiple -> any[]
 	@Event() smoothlyChange: EventEmitter<Record<string, any | any[]>> // multiple -> any[]
-	@Event() smoothlyInputLooks: EventEmitter<(looks: Looks) => void>
+	@Event() smoothlyInputLooks: EventEmitter<(looks?: Looks) => void>
 	@Event() smoothlyFormDisable: EventEmitter<(disabled: boolean) => void>
 	@Event() smoothlyInputLoad: EventEmitter<(parent: HTMLElement) => void>
 	private controls?: Controls
 
 	componentWillLoad(): void | Promise<void> {
-		this.smoothlyInputLooks.emit(looks => (this.looks = looks))
+		this.smoothlyInputLooks.emit(looks => (this.looks = this.looks ?? looks))
 		!this.readonly && this.smoothlyFormDisable.emit(readonly => (this.readonly = readonly))
 		this.smoothlyInputLoad.emit(() => {
 			return
@@ -77,7 +77,7 @@ export class SmoothlyPicker implements Clearable, Editable, Input, ComponentDidL
 			this.smoothlyPickerLoaded.emit(this.controls)
 	}
 	@Listen("smoothlyInputLooks")
-	smoothlyInputLooksHandler(event: CustomEvent<(looks: Looks) => void>): void {
+	smoothlyInputLooksHandler(event: CustomEvent<(looks?: Looks) => void>): void {
 		if (event.target != this.element) {
 			event.stopPropagation()
 			event.detail(this.looks)

--- a/src/components/picker/menu/index.tsx
+++ b/src/components/picker/menu/index.tsx
@@ -34,7 +34,7 @@ export interface Controls {
 })
 export class SmoothlyPickerMenu {
 	@Element() element: HTMLSmoothlyPickerMenuElement
-	@Prop() looks: Looks
+	@Prop() looks?: Looks
 	@Prop({ reflect: true }) open = false
 	@Prop({ reflect: true }) multiple = false
 	@Prop({ reflect: true }) mutable = false


### PR DESCRIPTION
To achieve this the `looks` will default to `undefined` which styling wise is the same as `"plain"`, but this way it's clear when the looks prop is being actively set or not. 



### Code Example
```tsx
// smoothly-form looks should not override checkbox in this example. This PR fixes this.
<smoothly-form looks={"border"} >
  <smoothly-input-checkbox looks={"plain"} />
</smoothly-form>
```

### Usage Example
Can't set `looks="plain"` on the checkbox because border is set on form.
![image](https://github.com/user-attachments/assets/9a75d78c-9271-4722-a935-fe41a0041592)

