### PR TITLE
Input use partial formatting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
 				"langly": "2.0.9",
 				"normalize.css": "^8.0.1",
 				"selectively": "^2.0.11",
-				"tidily": "github:utily/tidily#partial-format-in-action",
+				"tidily": "^0.1.14",
 				"urlpattern-polyfill": "^8.0.2"
 			},
 			"devDependencies": {
@@ -6564,7 +6564,8 @@
 		},
 		"node_modules/tidily": {
 			"version": "0.1.14",
-			"resolved": "git+ssh://git@github.com/utily/tidily.git#387f494217afa6aa9ddd4bee4fad28158083fba1",
+			"resolved": "https://registry.npmjs.org/tidily/-/tidily-0.1.14.tgz",
+			"integrity": "sha512-tHelYKmfbqID+KqbalqCwtV5FUqJ64vt/aUHt2m5qTgFurGX7ePVD6yjREwBiQueBsngOTQtIfGcH9xsw821jQ==",
 			"license": "MIT",
 			"dependencies": {
 				"isoly": "^2.3.6"

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
 				"langly": "2.0.9",
 				"normalize.css": "^8.0.1",
 				"selectively": "^2.0.11",
-				"tidily": "^0.1.14",
+				"tidily": "^0.2.0",
 				"urlpattern-polyfill": "^8.0.2"
 			},
 			"devDependencies": {
@@ -6563,9 +6563,9 @@
 			"dev": true
 		},
 		"node_modules/tidily": {
-			"version": "0.1.14",
-			"resolved": "https://registry.npmjs.org/tidily/-/tidily-0.1.14.tgz",
-			"integrity": "sha512-tHelYKmfbqID+KqbalqCwtV5FUqJ64vt/aUHt2m5qTgFurGX7ePVD6yjREwBiQueBsngOTQtIfGcH9xsw821jQ==",
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/tidily/-/tidily-0.2.0.tgz",
+			"integrity": "sha512-VwtWTS9HXec13bMzZh4eNIZJ9Da5cGOCnCapv2ZFnmalDPZXYKLGER2DPZ81QCD1BWT07EMdX3DrgnQiqbWudw==",
 			"license": "MIT",
 			"dependencies": {
 				"isoly": "^2.3.6"

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
 				"langly": "2.0.9",
 				"normalize.css": "^8.0.1",
 				"selectively": "^2.0.11",
-				"tidily": "^0.1.15",
+				"tidily": "github:utily/tidily#partial-format-in-action",
 				"urlpattern-polyfill": "^8.0.2"
 			},
 			"devDependencies": {
@@ -6563,9 +6563,8 @@
 			"dev": true
 		},
 		"node_modules/tidily": {
-			"version": "0.1.15",
-			"resolved": "https://registry.npmjs.org/tidily/-/tidily-0.1.15.tgz",
-			"integrity": "sha512-KBke6DZ2/JFkR5DN5mQV8j49q1pvV4fkSi507S5wCUCpgIu54ka69hC9b7f6UtlrV3VIU5cvJ7MtPAgHapFa9A==",
+			"version": "0.1.14",
+			"resolved": "git+ssh://git@github.com/utily/tidily.git#387f494217afa6aa9ddd4bee4fad28158083fba1",
 			"license": "MIT",
 			"dependencies": {
 				"isoly": "^2.3.6"

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
 		"langly": "2.0.9",
 		"normalize.css": "^8.0.1",
 		"selectively": "^2.0.11",
-		"tidily": "^0.1.15",
+		"tidily": "github:utily/tidily#partial-format-in-action",
 		"urlpattern-polyfill": "^8.0.2"
 	},
 	"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
 		"langly": "2.0.9",
 		"normalize.css": "^8.0.1",
 		"selectively": "^2.0.11",
-		"tidily": "github:utily/tidily#partial-format-in-action",
+		"tidily": "^0.1.14",
 		"urlpattern-polyfill": "^8.0.2"
 	},
 	"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
 		"langly": "2.0.9",
 		"normalize.css": "^8.0.1",
 		"selectively": "^2.0.11",
-		"tidily": "^0.1.14",
+		"tidily": "^0.2.0",
 		"urlpattern-polyfill": "^8.0.2"
 	},
 	"devDependencies": {

--- a/src/components/input/Action.ts
+++ b/src/components/input/Action.ts
@@ -1,0 +1,144 @@
+import { Direction, Formatter, Selection, Settings, State, StateEditor } from "tidily"
+import { Adjacent } from "./Adjacent"
+
+export interface Action {
+	key: string
+	repeat?: boolean
+	ctrlKey?: boolean
+	shiftKey?: boolean
+	altKey?: boolean
+	metaKey?: boolean
+}
+
+export namespace Action {
+	export function apply(
+		formatter: Formatter,
+		state: Readonly<State>,
+		formatted: "formatted" | "partial",
+		action?: Action
+	): Readonly<State> & Readonly<Settings> {
+		let result = State.copy(formatter.unformat(StateEditor.copy(state)))
+
+		if ((state as any).autocomplete == "cc-exp" && /^\d\d \/$/g.test(state.value))
+			action?.key && (action.key = "Backspace")
+		if (action) {
+			if (action.ctrlKey || action.metaKey) {
+				if (action.key == "a")
+					select(result, 0, result.value.length, "forward")
+				else if (["ArrowLeft", "ArrowRight"].includes(action.key) && (state as any)?.type != "password")
+					result = ctrlArrow(formatter, state, action)
+				else if (["Delete", "Backspace"].includes(action.key) && (state as any)?.type != "password")
+					result = ctrlRemove(formatter, state, action)
+			} else if (["ArrowLeft", "ArrowRight", "Home", "End"].includes(action.key))
+				arrowHomeEnd(result, action)
+			else if (["Delete", "Backspace"].includes(action.key)) {
+				result.selection.start == result.selection.end &&
+					select(
+						result,
+						result.selection.start + (action.key == "Backspace" ? -1 : 0),
+						result.selection.end + (action.key == "Delete" ? 1 : 0)
+					)
+				erase(result)
+			} else if (action.key != "Unidentified") {
+				erase(result)
+				formatter.allowed(action.key, result) && replace(result, action.key)
+			}
+		}
+		return formatted == "formatted"
+			? formatter.format(StateEditor.copy(result))
+			: formatter.partialFormat(StateEditor.copy(result))
+	}
+
+	export function paste(
+		formatter: Formatter,
+		state: Readonly<State>,
+		formatted: "formatted" | "partial",
+		pasted: string
+	) {
+		const result = State.copy(formatter.unformat(StateEditor.copy(state)))
+		replace(result, pasted)
+		return formatted == "formatted"
+			? formatter.format(StateEditor.copy(result))
+			: formatter.partialFormat(StateEditor.copy(result))
+	}
+
+	function ctrlArrow(formatter: Formatter, state: Readonly<State>, action: Action): Readonly<State> {
+		let cursorPosition = Selection.getCursor(state.selection)
+		let stalkPosition = Selection.getStalker(state.selection)
+		cursorPosition = Adjacent.getWordBreakIndex(
+			state.value,
+			cursorPosition,
+			action.key == "ArrowLeft" ? "backward" : "forward"
+		)
+		stalkPosition = action.shiftKey ? stalkPosition : cursorPosition
+		return State.copy(
+			formatter.unformat(
+				StateEditor.copy({
+					...state,
+					selection: {
+						start: Math.min(stalkPosition, cursorPosition),
+						end: Math.max(stalkPosition, cursorPosition),
+						direction:
+							stalkPosition < cursorPosition ? "forward" : stalkPosition > cursorPosition ? "backward" : "none",
+					},
+				})
+			)
+		)
+	}
+	function ctrlRemove(formatter: Formatter, state: Readonly<State>, action: Action): Readonly<State> {
+		const cursorPosition = Selection.getCursor(state.selection)
+		const adjacentIndex = Adjacent.getWordBreakIndex(
+			state.value,
+			cursorPosition,
+			action.key == "Backspace" ? "backward" : "forward"
+		)
+		const result = State.copy(
+			formatter.unformat(
+				StateEditor.copy({
+					...state,
+					selection: {
+						start: Math.min(cursorPosition, adjacentIndex),
+						end: Math.max(cursorPosition, adjacentIndex),
+						direction: "none",
+					},
+				})
+			)
+		)
+		result.value = result.value.substring(0, result.selection.start) + result.value.substring(result.selection.end)
+		result.selection.end = result.selection.start
+		return result
+	}
+	function arrowHomeEnd(state: State, action: Action) {
+		let cursorPosition = Selection.getCursor(state.selection)
+		let stalkPosition = Selection.getStalker(state.selection)
+		cursorPosition =
+			action.key == "Home"
+				? 0
+				: action.key == "End"
+				? state.value.length
+				: state.selection.start == state.selection.end || action.shiftKey
+				? Math.min(Math.max(cursorPosition + (action.key == "ArrowLeft" ? -1 : 1), 0), state.value.length)
+				: action.key == "ArrowLeft"
+				? state.selection.start
+				: state.selection.end
+		stalkPosition = action.shiftKey ? stalkPosition : cursorPosition
+		state.selection.direction =
+			stalkPosition < cursorPosition ? "forward" : stalkPosition > cursorPosition ? "backward" : "none"
+		state.selection.start = Math.min(stalkPosition, cursorPosition)
+		state.selection.end = Math.max(stalkPosition, cursorPosition)
+	}
+	function select(state: State, from: number, to: number, direction?: Direction): void {
+		state.selection.start = from
+		state.selection.end = to
+		direction && (state.selection.direction = direction)
+	}
+	function erase(state: State): void {
+		replace(state, "")
+	}
+	function replace(state: State, insertString: string): void {
+		state.value =
+			state.value.substring(0, state.selection.start) + insertString + state.value.substring(state.selection.end)
+		state.selection.start = state.selection.start + insertString.length
+		state.selection.end = state.selection.start
+	}
+}

--- a/src/components/input/Adjacent.ts
+++ b/src/components/input/Adjacent.ts
@@ -1,0 +1,31 @@
+export namespace Adjacent {
+	export function getWordBreakIndex(str: string, index: number, direction: "backward" | "forward"): number {
+		const wordRegex = /([^.-@\s]+)/gi
+		return direction == "backward"
+			? getBackwardWordBreakIndex(str, index, wordRegex)
+			: getForwardWordBreakIndex(str, index, wordRegex)
+	}
+
+	function getBackwardWordBreakIndex(str: string, index: number, wordRegex: RegExp): number {
+		let result = 0
+		let execArray: RegExpExecArray | null
+		while ((execArray = wordRegex.exec(str)) != null) {
+			if (wordRegex.lastIndex - execArray[0].length < index)
+				result = wordRegex.lastIndex - execArray[0].length
+			else
+				break
+		}
+		return result
+	}
+
+	function getForwardWordBreakIndex(str: string, index: number, wordRegex: RegExp): number {
+		let result = 0
+		while (wordRegex.exec(str) != null) {
+			result = wordRegex.lastIndex
+			if (wordRegex.lastIndex > index)
+				break
+		}
+		wordRegex.lastIndex <= index && (result = str.length)
+		return result
+	}
+}

--- a/src/components/input/index.tsx
+++ b/src/components/input/index.tsx
@@ -2,6 +2,7 @@ import { Component, Element, Event, EventEmitter, h, Host, Listen, Method, Prop,
 import { isoly } from "isoly"
 import { tidily } from "tidily"
 import { Color } from "../../model"
+import { Action } from "./Action"
 import { Clearable } from "./Clearable"
 import { Editable } from "./Editable"
 import { Input } from "./Input"
@@ -302,13 +303,13 @@ export class SmoothlyInput implements Clearable, Input, Editable {
 	}
 	private processPaste(pasted: string, backend: HTMLInputElement) {
 		if (!this.readonly) {
-			const after = tidily.Action.paste(this.formatter, this.state, "partial", pasted)
+			const after = Action.paste(this.formatter, this.state, "partial", pasted)
 			this.updateBackend(after, backend)
 		}
 	}
-	private processKey(event: tidily.Action, backend: HTMLInputElement, formatted: "formatted" | "partial") {
+	private processKey(event: Action, backend: HTMLInputElement, formatted: "formatted" | "partial") {
 		if (!this.readonly) {
-			const after = tidily.Action.apply(this.formatter, this.state, formatted, event)
+			const after = Action.apply(this.formatter, this.state, formatted, event)
 			this.updateBackend(after, backend)
 		}
 	}

--- a/src/components/input/select/index.tsx
+++ b/src/components/input/select/index.tsx
@@ -199,7 +199,6 @@ export class SmoothlyInputSelect implements Input, Editable, Clearable, Componen
 			!this.showSelected && event.detail.selected && (event.detail.hidden = true)
 		}
 		this.displaySelected()
-		this.element.focus()
 	}
 	@Watch("open")
 	onClosed(): void {

--- a/src/components/input/style.css
+++ b/src/components/input/style.css
@@ -30,6 +30,9 @@
 
 :host>div>div.ghost {
 	position: absolute;
+  box-sizing: border-box;
+  align-content: center;
+	height: 100%;
 	padding: 
 		var(--input-value-padding-top) 
 		var(--input-padding-side) 

--- a/src/components/input/style.css
+++ b/src/components/input/style.css
@@ -28,6 +28,25 @@
 	padding: 0 var(--input-padding-side);
 }
 
+:host>div>div.ghost {
+	position: absolute;
+	padding: 
+		var(--input-value-padding-top) 
+		var(--input-padding-side) 
+		var(--input-value-padding-bottom) 
+		var(--input-padding-side);
+}
+:host>div>div.ghost>div.value {
+	display: inline;
+	pointer-events: none;
+	opacity: 0;
+}
+:host>div>div.ghost>div.remainder {
+	display: inline;
+	pointer-events: none;
+	opacity: 0.5;
+}
+
 :host>div>input {
 	padding: 
 		var(--input-value-padding-top) 


### PR DESCRIPTION
- Add `Action` from tidily into smoothly.
  - Currently the handling of formatting and events is done half in tidily.Action and the other half in smoothly-input. This is an attempt to at least keep the logic within the same repo.
- This PR also adds partialFormatting
  - Show the format of date-input while writing.
  - Make `smoothy-input type="price"` not suck.

[Screencast from 2024-10-28 21:08:18.webm](https://github.com/user-attachments/assets/d8d9f1fc-e7e8-400f-909e-bf0fbc292671)

[Screencast from 2024-10-28 21:11:01.webm](https://github.com/user-attachments/assets/ed01d45f-0493-49af-93a7-8ce1a651501f)
