### PR TITLE
Remove DOM manipulation from smoothly-tabs component - use grid instead

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -879,6 +879,10 @@ export interface SmoothlyTableExpandableRowCustomEvent<T> extends CustomEvent<T>
     detail: T;
     target: HTMLSmoothlyTableExpandableRowElement;
 }
+export interface SmoothlyTabsCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLSmoothlyTabsElement;
+}
 export interface SmoothlyToggleSwitchCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLSmoothlyToggleSwitchElement;
@@ -2059,7 +2063,18 @@ declare global {
         prototype: HTMLSmoothlyTableTestingElement;
         new (): HTMLSmoothlyTableTestingElement;
     };
+    interface HTMLSmoothlyTabsElementEventMap {
+        "smoothlyTabOpen": string;
+    }
     interface HTMLSmoothlyTabsElement extends Components.SmoothlyTabs, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLSmoothlyTabsElementEventMap>(type: K, listener: (this: HTMLSmoothlyTabsElement, ev: SmoothlyTabsCustomEvent<HTMLSmoothlyTabsElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLSmoothlyTabsElementEventMap>(type: K, listener: (this: HTMLSmoothlyTabsElement, ev: SmoothlyTabsCustomEvent<HTMLSmoothlyTabsElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
     }
     var HTMLSmoothlyTabsElement: {
         prototype: HTMLSmoothlyTabsElement;
@@ -2952,6 +2967,7 @@ declare namespace LocalJSX {
     interface SmoothlyTableTesting {
     }
     interface SmoothlyTabs {
+        "onSmoothlyTabOpen"?: (event: SmoothlyTabsCustomEvent<string>) => void;
     }
     interface SmoothlyTabsDemo {
     }

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -1947,6 +1947,7 @@ declare global {
     };
     interface HTMLSmoothlyTabElementEventMap {
         "expansionOpen": HTMLDivElement;
+        "smoothlyTabLoad": void;
     }
     interface HTMLSmoothlyTabElement extends Components.SmoothlyTab, HTMLStencilElement {
         addEventListener<K extends keyof HTMLSmoothlyTabElementEventMap>(type: K, listener: (this: HTMLSmoothlyTabElement, ev: SmoothlyTabCustomEvent<HTMLSmoothlyTabElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -2924,6 +2925,7 @@ declare namespace LocalJSX {
     interface SmoothlyTab {
         "label"?: string;
         "onExpansionOpen"?: (event: SmoothlyTabCustomEvent<HTMLDivElement>) => void;
+        "onSmoothlyTabLoad"?: (event: SmoothlyTabCustomEvent<void>) => void;
         "open"?: boolean;
     }
     interface SmoothlyTable {

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -879,10 +879,6 @@ export interface SmoothlyTableExpandableRowCustomEvent<T> extends CustomEvent<T>
     detail: T;
     target: HTMLSmoothlyTableExpandableRowElement;
 }
-export interface SmoothlyTabsCustomEvent<T> extends CustomEvent<T> {
-    detail: T;
-    target: HTMLSmoothlyTabsElement;
-}
 export interface SmoothlyToggleSwitchCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLSmoothlyToggleSwitchElement;
@@ -1946,7 +1942,7 @@ declare global {
         new (): HTMLSmoothlySummaryElement;
     };
     interface HTMLSmoothlyTabElementEventMap {
-        "expansionOpen": HTMLDivElement;
+        "smoothlyTabOpen": string;
         "smoothlyTabLoad": void;
     }
     interface HTMLSmoothlyTabElement extends Components.SmoothlyTab, HTMLStencilElement {
@@ -2063,18 +2059,7 @@ declare global {
         prototype: HTMLSmoothlyTableTestingElement;
         new (): HTMLSmoothlyTableTestingElement;
     };
-    interface HTMLSmoothlyTabsElementEventMap {
-        "selectedTab": string;
-    }
     interface HTMLSmoothlyTabsElement extends Components.SmoothlyTabs, HTMLStencilElement {
-        addEventListener<K extends keyof HTMLSmoothlyTabsElementEventMap>(type: K, listener: (this: HTMLSmoothlyTabsElement, ev: SmoothlyTabsCustomEvent<HTMLSmoothlyTabsElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
-        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
-        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
-        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
-        removeEventListener<K extends keyof HTMLSmoothlyTabsElementEventMap>(type: K, listener: (this: HTMLSmoothlyTabsElement, ev: SmoothlyTabsCustomEvent<HTMLSmoothlyTabsElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
-        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
-        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
-        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
     }
     var HTMLSmoothlyTabsElement: {
         prototype: HTMLSmoothlyTabsElement;
@@ -2924,8 +2909,8 @@ declare namespace LocalJSX {
     }
     interface SmoothlyTab {
         "label"?: string;
-        "onExpansionOpen"?: (event: SmoothlyTabCustomEvent<HTMLDivElement>) => void;
         "onSmoothlyTabLoad"?: (event: SmoothlyTabCustomEvent<void>) => void;
+        "onSmoothlyTabOpen"?: (event: SmoothlyTabCustomEvent<string>) => void;
         "open"?: boolean;
     }
     interface SmoothlyTable {
@@ -2967,7 +2952,6 @@ declare namespace LocalJSX {
     interface SmoothlyTableTesting {
     }
     interface SmoothlyTabs {
-        "onSelectedTab"?: (event: SmoothlyTabsCustomEvent<string>) => void;
     }
     interface SmoothlyTabsDemo {
     }

--- a/src/components/tabs/demo/index.tsx
+++ b/src/components/tabs/demo/index.tsx
@@ -7,14 +7,14 @@ import { Component, h } from "@stencil/core"
 })
 export class SmoothlyTabsDemo {
 	render() {
-		return [
+		return (
 			<smoothly-tabs>
 				<smoothly-tab label="test1" open>
 					Hello world!
 				</smoothly-tab>
 				<smoothly-tab label="test2">this is a test message!</smoothly-tab>
 				<smoothly-tab label="test3">this is a test message again!</smoothly-tab>
-			</smoothly-tabs>,
-		]
+			</smoothly-tabs>
+		)
 	}
 }

--- a/src/components/tabs/demo/style.css
+++ b/src/components/tabs/demo/style.css
@@ -4,12 +4,8 @@
 :host[hidden] {
 	display: none;
 }
-button:focus {
-	outline: none;
-}
-smoothly-selector {
-	outline: none;
-}
-button {
-	display: block;
+:host > * {
+	margin: auto;
+	max-width: 1200px;
+	width: 100%;
 }

--- a/src/components/tabs/index.tsx
+++ b/src/components/tabs/index.tsx
@@ -1,4 +1,4 @@
-import { Component, Element, EventEmitter, h, Host, Listen, State, Watch } from "@stencil/core"
+import { Component, Element, Event, EventEmitter, h, Host, Listen, State, Watch } from "@stencil/core"
 
 @Component({
 	tag: "smoothly-tabs",
@@ -9,7 +9,7 @@ export class SmoothlyTabs {
 	@Element() element: HTMLSmoothlyTabsElement
 	@State() tabs: HTMLElement[] = []
 	@State() selectedElement: HTMLSmoothlyTabElement
-	@State() smoothlyTabOpen: EventEmitter<string>
+	@Event() smoothlyTabOpen: EventEmitter<string>
 
 	@Listen("smoothlyTabLoad")
 	onInputLoad(event: CustomEvent) {

--- a/src/components/tabs/index.tsx
+++ b/src/components/tabs/index.tsx
@@ -33,7 +33,6 @@ export class SmoothlyTabs {
 	render() {
 		return (
 			<Host style={{ "--tabs": `${this.tabs.length}` }}>
-				<div class="line" />
 				<slot></slot>
 			</Host>
 		)

--- a/src/components/tabs/index.tsx
+++ b/src/components/tabs/index.tsx
@@ -1,4 +1,4 @@
-import { Component, Element, Event, EventEmitter, h, Host, Listen, State, Watch } from "@stencil/core"
+import { Component, Element, EventEmitter, h, Host, Listen, State, Watch } from "@stencil/core"
 
 @Component({
 	tag: "smoothly-tabs",
@@ -9,7 +9,7 @@ export class SmoothlyTabs {
 	@Element() element: HTMLSmoothlyTabsElement
 	@State() tabs: HTMLElement[] = []
 	@State() selectedElement: HTMLSmoothlyTabElement
-	@Event() selectedTab: EventEmitter<string>
+	@State() smoothlyTabOpen: EventEmitter<string>
 
 	@Listen("smoothlyTabLoad")
 	onInputLoad(event: CustomEvent) {
@@ -18,11 +18,11 @@ export class SmoothlyTabs {
 		}
 	}
 
-	@Listen("expansionOpen")
+	@Listen("smoothlyTabOpen")
 	openChanged(event: CustomEvent) {
 		event.stopPropagation()
 		this.selectedElement = event.target as HTMLSmoothlyTabElement
-		this.selectedTab.emit(this.selectedElement.label)
+		this.smoothlyTabOpen.emit(event.detail)
 	}
 	@Watch("selectedElement")
 	onSelectedChange(value: HTMLSmoothlyTabElement, old: HTMLSmoothlyTabElement) {

--- a/src/components/tabs/index.tsx
+++ b/src/components/tabs/index.tsx
@@ -7,13 +7,21 @@ import { Component, Element, Event, EventEmitter, h, Host, Listen, State, Watch 
 })
 export class SmoothlyTabs {
 	@Element() element: HTMLSmoothlyTabsElement
+	@State() tabs: HTMLElement[] = []
 	@State() selectedElement: HTMLSmoothlyTabElement
 	@Event() selectedTab: EventEmitter<string>
+
+	@Listen("smoothlyTabLoad")
+	onInputLoad(event: CustomEvent) {
+		if (event.target instanceof HTMLElement && !this.tabs.includes(event.target)) {
+			this.tabs = [...this.tabs, event.target]
+		}
+	}
+
 	@Listen("expansionOpen")
 	openChanged(event: CustomEvent) {
 		event.stopPropagation()
 		this.selectedElement = event.target as HTMLSmoothlyTabElement
-		this.element.after(event.detail)
 		this.selectedTab.emit(this.selectedElement.label)
 	}
 	@Watch("selectedElement")
@@ -24,7 +32,8 @@ export class SmoothlyTabs {
 
 	render() {
 		return (
-			<Host>
+			<Host style={{ "--tabs": `${this.tabs.length}` }}>
+				<div class="line" />
 				<slot></slot>
 			</Host>
 		)

--- a/src/components/tabs/index.tsx
+++ b/src/components/tabs/index.tsx
@@ -20,9 +20,11 @@ export class SmoothlyTabs {
 
 	@Listen("smoothlyTabOpen")
 	openChanged(event: CustomEvent) {
-		event.stopPropagation()
-		this.selectedElement = event.target as HTMLSmoothlyTabElement
-		this.smoothlyTabOpen.emit(event.detail)
+		if (event.target != this.element) {
+			event.stopPropagation()
+			this.selectedElement = event.target as HTMLSmoothlyTabElement
+			this.smoothlyTabOpen.emit(event.detail)
+		}
 	}
 	@Watch("selectedElement")
 	onSelectedChange(value: HTMLSmoothlyTabElement, old: HTMLSmoothlyTabElement) {

--- a/src/components/tabs/style.css
+++ b/src/components/tabs/style.css
@@ -1,6 +1,11 @@
 :host {
-	display: flex;
-	flex-direction: row;
-	justify-content: space-around;
-	border-bottom: 3px solid rgb(var(--smoothly-default-shade));
+	display: grid;
+	grid-template-columns: repeat(var(--tabs), auto);
+	grid-template-rows: auto 3px auto;
+}
+
+:host > div.line {
+	background-color: rgb(var(--smoothly-default-shade));
+	grid-column: 1 / -1;
+	grid-row: 2 / 3;
 }

--- a/src/components/tabs/style.css
+++ b/src/components/tabs/style.css
@@ -1,11 +1,5 @@
 :host {
 	display: grid;
 	grid-template-columns: repeat(var(--tabs), auto);
-	grid-template-rows: auto 3px auto;
-}
-
-:host > div.line {
-	background-color: rgb(var(--smoothly-default-shade));
-	grid-column: 1 / -1;
-	grid-row: 2 / 3;
+	grid-template-rows: auto auto;
 }

--- a/src/components/tabs/tab/index.tsx
+++ b/src/components/tabs/tab/index.tsx
@@ -32,7 +32,9 @@ export class SmoothlyTab {
 	render() {
 		return (
 			<Host>
-				<label>{this.label}</label>
+				<div>
+					<label>{this.label}</label>
+				</div>
 				<div ref={e => (this.expansionElement = e)} hidden={!this.open}>
 					<slot />
 				</div>

--- a/src/components/tabs/tab/index.tsx
+++ b/src/components/tabs/tab/index.tsx
@@ -9,13 +9,13 @@ export class SmoothlyTab {
 	expansionElement?: HTMLDivElement
 	@Prop() label: string
 	@Prop({ mutable: true, reflect: true }) open: boolean
-	@Event() expansionOpen: EventEmitter<HTMLDivElement>
+	@Event() smoothlyTabOpen: EventEmitter<string>
 	@Event() smoothlyTabLoad: EventEmitter<void>
 
 	@Watch("open")
 	openHandler() {
 		if (this.expansionElement && this.open) {
-			this.expansionOpen.emit(this.expansionElement)
+			this.smoothlyTabOpen.emit(this.label)
 		}
 	}
 	@Listen("click")

--- a/src/components/tabs/tab/index.tsx
+++ b/src/components/tabs/tab/index.tsx
@@ -6,7 +6,6 @@ import { Component, Event, EventEmitter, h, Host, Listen, Prop, Watch } from "@s
 	scoped: true,
 })
 export class SmoothlyTab {
-	expansionElement?: HTMLDivElement
 	@Prop() label: string
 	@Prop({ mutable: true, reflect: true }) open: boolean
 	@Event() smoothlyTabOpen: EventEmitter<string>
@@ -14,9 +13,8 @@ export class SmoothlyTab {
 
 	@Watch("open")
 	openHandler() {
-		if (this.expansionElement && this.open) {
+		if (this.open)
 			this.smoothlyTabOpen.emit(this.label)
-		}
 	}
 	@Listen("click")
 	onClick(e: UIEvent) {
@@ -35,7 +33,7 @@ export class SmoothlyTab {
 				<div>
 					<label>{this.label}</label>
 				</div>
-				<div ref={e => (this.expansionElement = e)} hidden={!this.open}>
+				<div hidden={!this.open}>
 					<slot />
 				</div>
 			</Host>

--- a/src/components/tabs/tab/index.tsx
+++ b/src/components/tabs/tab/index.tsx
@@ -10,6 +10,8 @@ export class SmoothlyTab {
 	@Prop() label: string
 	@Prop({ mutable: true, reflect: true }) open: boolean
 	@Event() expansionOpen: EventEmitter<HTMLDivElement>
+	@Event() smoothlyTabLoad: EventEmitter<void>
+
 	@Watch("open")
 	openHandler() {
 		if (this.expansionElement && this.open) {
@@ -21,6 +23,9 @@ export class SmoothlyTab {
 		e.stopPropagation()
 		this.open = true
 	}
+	connectedCallback() {
+		this.smoothlyTabLoad.emit()
+	}
 	componentDidLoad(): void {
 		this.openHandler()
 	}
@@ -29,7 +34,7 @@ export class SmoothlyTab {
 			<Host>
 				<label>{this.label}</label>
 				<div ref={e => (this.expansionElement = e)} hidden={!this.open}>
-					<slot></slot>
+					<slot />
 				</div>
 			</Host>
 		)

--- a/src/components/tabs/tab/style.css
+++ b/src/components/tabs/tab/style.css
@@ -1,14 +1,22 @@
-:host([open]) {
-	border-bottom: 3px solid rgb(var(--smoothly-primary-color));
-	box-sizing: border-box;
-	margin-bottom: -3px;
+:host {
+	display: contents;
 }
 :host > label {
 	display: block;
 	padding: .5rem;
 	background-color: transparent;
+	grid-column: span 1;
 	width: auto;
-}
-:host > label:hover {
+  margin: auto;
 	cursor: pointer;
+}
+:host([open]) > label {
+	border-bottom: 3px solid rgb(var(--smoothly-primary-color));
+	margin-bottom: -3px;
+	position: relative;
+}
+
+:host > div {
+	grid-row: 3 / 4;
+	grid-column: 1 / -1;
 }

--- a/src/components/tabs/tab/style.css
+++ b/src/components/tabs/tab/style.css
@@ -1,22 +1,28 @@
 :host {
 	display: contents;
+	--line-width: 3px;
 }
-:host > label {
+:host > div:first-child {
+	grid-column: span 1;
+	background-color: transparent;
+	border-bottom-color: rgb(var(--smoothly-default-shade));
+	border-bottom-width: var(--line-width);
+	border-bottom-style: solid;
+}
+:host > div:first-child > label {
 	display: block;
 	padding: .5rem;
-	background-color: transparent;
-	grid-column: span 1;
-	width: auto;
+	width: fit-content;
   margin: auto;
 	cursor: pointer;
 }
-:host([open]) > label {
-	border-bottom: 3px solid rgb(var(--smoothly-primary-color));
-	margin-bottom: -3px;
+:host([open]) > div:first-child > label {
+	border-bottom: var(--line-width) solid rgb(var(--smoothly-primary-color));
+	margin-bottom: calc(-1 * var(--line-width));
 	position: relative;
 }
 
-:host > div {
-	grid-row: 3 / 4;
+:host > div:nth-child(2) {
+	grid-row: 2 / 3;
 	grid-column: 1 / -1;
 }


### PR DESCRIPTION
Should look the same as before. 

###  :warning:  Breaking changes
- The slotted content in tabs is no longer moved to outside the smoothly-tabs, so this might cause some styling to be off.
- Event name change on smoothly-tabs `selectedTab` -> `smoothlyTabOpen`

### Other changes
- Tabs demo styling cleaned up.

![image](https://github.com/user-attachments/assets/bce754de-fa01-4086-bf4f-cd236a1cf8f9)
