### PR TITLE
Dont check input-checkbox when highlighting label text

### DIFF
--- a/src/components/input/checkbox/index.tsx
+++ b/src/components/input/checkbox/index.tsx
@@ -13,6 +13,7 @@ import { Looks } from "../Looks"
 export class SmoothlyInputCheckbox implements Input, Clearable, Editable, ComponentWillLoad {
 	private initialValue?: any
 	private listener: { changed?: (parent: Editable) => Promise<void> } = {}
+	private mouseDownPosition?: { x: number; y: number }
 	@Prop() name: string
 	@Prop({ mutable: true }) changed = false
 	@Prop({ reflect: true, mutable: true }) readonly = false
@@ -65,12 +66,16 @@ export class SmoothlyInputCheckbox implements Input, Clearable, Editable, Compon
 		this.smoothlyInput.emit({ [this.name]: this.checked })
 		this.listener.changed?.(this)
 	}
-	inputHandler() {
+	click() {
 		!this.disabled && !this.readonly && (this.checked = !this.checked)
 	}
 	render() {
 		return (
-			<Host onClick={() => this.inputHandler()}>
+			<Host
+				onMouseDown={(e: MouseEvent) => (this.mouseDownPosition = { x: e.clientX, y: e.clientY })}
+				onMouseUp={(e: MouseEvent) =>
+					this.mouseDownPosition?.x == e.clientX && this.mouseDownPosition.y == e.clientY && this.click()
+				}>
 				<input type="checkbox" checked={this.checked} />
 				{this.checked && <smoothly-icon name="checkmark-outline" size="tiny" />}
 				<label>


### PR DESCRIPTION
Highlighting text in label caused a click event, which checks the checkbox.
This PR removes that.

## Bug

[Screencast from 2024-11-04 08:44:34.webm](https://github.com/user-attachments/assets/ade5d42d-ef47-4cfe-9bd0-f6920fef96ba)
