### PR TITLE
Date forms

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -209,6 +209,8 @@ export namespace Components {
     }
     interface SmoothlyFormDemoDate {
     }
+    interface SmoothlyFormDemoDateRange {
+    }
     interface SmoothlyFormDemoLogin {
     }
     interface SmoothlyFormDemoPrices {
@@ -757,6 +759,10 @@ export interface SmoothlyFormDemoDateCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLSmoothlyFormDemoDateElement;
 }
+export interface SmoothlyFormDemoDateRangeCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLSmoothlyFormDemoDateRangeElement;
+}
 export interface SmoothlyFrameCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLSmoothlyFrameElement;
@@ -1259,6 +1265,23 @@ declare global {
     var HTMLSmoothlyFormDemoDateElement: {
         prototype: HTMLSmoothlyFormDemoDateElement;
         new (): HTMLSmoothlyFormDemoDateElement;
+    };
+    interface HTMLSmoothlyFormDemoDateRangeElementEventMap {
+        "notice": Notice;
+    }
+    interface HTMLSmoothlyFormDemoDateRangeElement extends Components.SmoothlyFormDemoDateRange, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLSmoothlyFormDemoDateRangeElementEventMap>(type: K, listener: (this: HTMLSmoothlyFormDemoDateRangeElement, ev: SmoothlyFormDemoDateRangeCustomEvent<HTMLSmoothlyFormDemoDateRangeElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLSmoothlyFormDemoDateRangeElementEventMap>(type: K, listener: (this: HTMLSmoothlyFormDemoDateRangeElement, ev: SmoothlyFormDemoDateRangeCustomEvent<HTMLSmoothlyFormDemoDateRangeElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
+    }
+    var HTMLSmoothlyFormDemoDateRangeElement: {
+        prototype: HTMLSmoothlyFormDemoDateRangeElement;
+        new (): HTMLSmoothlyFormDemoDateRangeElement;
     };
     interface HTMLSmoothlyFormDemoLoginElement extends Components.SmoothlyFormDemoLogin, HTMLStencilElement {
     }
@@ -2249,6 +2272,7 @@ declare global {
         "smoothly-form-demo-card": HTMLSmoothlyFormDemoCardElement;
         "smoothly-form-demo-controlled": HTMLSmoothlyFormDemoControlledElement;
         "smoothly-form-demo-date": HTMLSmoothlyFormDemoDateElement;
+        "smoothly-form-demo-date-range": HTMLSmoothlyFormDemoDateRangeElement;
         "smoothly-form-demo-login": HTMLSmoothlyFormDemoLoginElement;
         "smoothly-form-demo-prices": HTMLSmoothlyFormDemoPricesElement;
         "smoothly-form-demo-transparent": HTMLSmoothlyFormDemoTransparentElement;
@@ -2528,6 +2552,9 @@ declare namespace LocalJSX {
     }
     interface SmoothlyFormDemoDate {
         "onNotice"?: (event: SmoothlyFormDemoDateCustomEvent<Notice>) => void;
+    }
+    interface SmoothlyFormDemoDateRange {
+        "onNotice"?: (event: SmoothlyFormDemoDateRangeCustomEvent<Notice>) => void;
     }
     interface SmoothlyFormDemoLogin {
     }
@@ -3085,6 +3112,7 @@ declare namespace LocalJSX {
         "smoothly-form-demo-card": SmoothlyFormDemoCard;
         "smoothly-form-demo-controlled": SmoothlyFormDemoControlled;
         "smoothly-form-demo-date": SmoothlyFormDemoDate;
+        "smoothly-form-demo-date-range": SmoothlyFormDemoDateRange;
         "smoothly-form-demo-login": SmoothlyFormDemoLogin;
         "smoothly-form-demo-prices": SmoothlyFormDemoPrices;
         "smoothly-form-demo-transparent": SmoothlyFormDemoTransparent;
@@ -3208,6 +3236,7 @@ declare module "@stencil/core" {
             "smoothly-form-demo-card": LocalJSX.SmoothlyFormDemoCard & JSXBase.HTMLAttributes<HTMLSmoothlyFormDemoCardElement>;
             "smoothly-form-demo-controlled": LocalJSX.SmoothlyFormDemoControlled & JSXBase.HTMLAttributes<HTMLSmoothlyFormDemoControlledElement>;
             "smoothly-form-demo-date": LocalJSX.SmoothlyFormDemoDate & JSXBase.HTMLAttributes<HTMLSmoothlyFormDemoDateElement>;
+            "smoothly-form-demo-date-range": LocalJSX.SmoothlyFormDemoDateRange & JSXBase.HTMLAttributes<HTMLSmoothlyFormDemoDateRangeElement>;
             "smoothly-form-demo-login": LocalJSX.SmoothlyFormDemoLogin & JSXBase.HTMLAttributes<HTMLSmoothlyFormDemoLoginElement>;
             "smoothly-form-demo-prices": LocalJSX.SmoothlyFormDemoPrices & JSXBase.HTMLAttributes<HTMLSmoothlyFormDemoPricesElement>;
             "smoothly-form-demo-transparent": LocalJSX.SmoothlyFormDemoTransparent & JSXBase.HTMLAttributes<HTMLSmoothlyFormDemoTransparentElement>;

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -207,6 +207,8 @@ export namespace Components {
     }
     interface SmoothlyFormDemoControlled {
     }
+    interface SmoothlyFormDemoDate {
+    }
     interface SmoothlyFormDemoLogin {
     }
     interface SmoothlyFormDemoPrices {
@@ -751,6 +753,10 @@ export interface SmoothlyFormCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLSmoothlyFormElement;
 }
+export interface SmoothlyFormDemoDateCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLSmoothlyFormDemoDateElement;
+}
 export interface SmoothlyFrameCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLSmoothlyFrameElement;
@@ -1236,6 +1242,23 @@ declare global {
     var HTMLSmoothlyFormDemoControlledElement: {
         prototype: HTMLSmoothlyFormDemoControlledElement;
         new (): HTMLSmoothlyFormDemoControlledElement;
+    };
+    interface HTMLSmoothlyFormDemoDateElementEventMap {
+        "notice": Notice;
+    }
+    interface HTMLSmoothlyFormDemoDateElement extends Components.SmoothlyFormDemoDate, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLSmoothlyFormDemoDateElementEventMap>(type: K, listener: (this: HTMLSmoothlyFormDemoDateElement, ev: SmoothlyFormDemoDateCustomEvent<HTMLSmoothlyFormDemoDateElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLSmoothlyFormDemoDateElementEventMap>(type: K, listener: (this: HTMLSmoothlyFormDemoDateElement, ev: SmoothlyFormDemoDateCustomEvent<HTMLSmoothlyFormDemoDateElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
+    }
+    var HTMLSmoothlyFormDemoDateElement: {
+        prototype: HTMLSmoothlyFormDemoDateElement;
+        new (): HTMLSmoothlyFormDemoDateElement;
     };
     interface HTMLSmoothlyFormDemoLoginElement extends Components.SmoothlyFormDemoLogin, HTMLStencilElement {
     }
@@ -2225,6 +2248,7 @@ declare global {
         "smoothly-form-demo-all": HTMLSmoothlyFormDemoAllElement;
         "smoothly-form-demo-card": HTMLSmoothlyFormDemoCardElement;
         "smoothly-form-demo-controlled": HTMLSmoothlyFormDemoControlledElement;
+        "smoothly-form-demo-date": HTMLSmoothlyFormDemoDateElement;
         "smoothly-form-demo-login": HTMLSmoothlyFormDemoLoginElement;
         "smoothly-form-demo-prices": HTMLSmoothlyFormDemoPricesElement;
         "smoothly-form-demo-transparent": HTMLSmoothlyFormDemoTransparentElement;
@@ -2501,6 +2525,9 @@ declare namespace LocalJSX {
     interface SmoothlyFormDemoCard {
     }
     interface SmoothlyFormDemoControlled {
+    }
+    interface SmoothlyFormDemoDate {
+        "onNotice"?: (event: SmoothlyFormDemoDateCustomEvent<Notice>) => void;
     }
     interface SmoothlyFormDemoLogin {
     }
@@ -3057,6 +3084,7 @@ declare namespace LocalJSX {
         "smoothly-form-demo-all": SmoothlyFormDemoAll;
         "smoothly-form-demo-card": SmoothlyFormDemoCard;
         "smoothly-form-demo-controlled": SmoothlyFormDemoControlled;
+        "smoothly-form-demo-date": SmoothlyFormDemoDate;
         "smoothly-form-demo-login": SmoothlyFormDemoLogin;
         "smoothly-form-demo-prices": SmoothlyFormDemoPrices;
         "smoothly-form-demo-transparent": SmoothlyFormDemoTransparent;
@@ -3179,6 +3207,7 @@ declare module "@stencil/core" {
             "smoothly-form-demo-all": LocalJSX.SmoothlyFormDemoAll & JSXBase.HTMLAttributes<HTMLSmoothlyFormDemoAllElement>;
             "smoothly-form-demo-card": LocalJSX.SmoothlyFormDemoCard & JSXBase.HTMLAttributes<HTMLSmoothlyFormDemoCardElement>;
             "smoothly-form-demo-controlled": LocalJSX.SmoothlyFormDemoControlled & JSXBase.HTMLAttributes<HTMLSmoothlyFormDemoControlledElement>;
+            "smoothly-form-demo-date": LocalJSX.SmoothlyFormDemoDate & JSXBase.HTMLAttributes<HTMLSmoothlyFormDemoDateElement>;
             "smoothly-form-demo-login": LocalJSX.SmoothlyFormDemoLogin & JSXBase.HTMLAttributes<HTMLSmoothlyFormDemoLoginElement>;
             "smoothly-form-demo-prices": LocalJSX.SmoothlyFormDemoPrices & JSXBase.HTMLAttributes<HTMLSmoothlyFormDemoPricesElement>;
             "smoothly-form-demo-transparent": LocalJSX.SmoothlyFormDemoTransparent & JSXBase.HTMLAttributes<HTMLSmoothlyFormDemoTransparentElement>;

--- a/src/components/form/demo/date-range/index.tsx
+++ b/src/components/form/demo/date-range/index.tsx
@@ -4,14 +4,14 @@ import { isly } from "isly"
 import { Notice, Submit } from "../../../../model"
 
 @Component({
-	tag: "smoothly-form-demo-date",
+	tag: "smoothly-form-demo-date-range",
 	styleUrl: "style.css",
 	scoped: true,
 })
-export class SmoothlyFormDemoDate {
+export class SmoothlyFormDemoDateRange {
 	@Event() notice: EventEmitter<Notice>
-	private validator = isly.object<{ date: isoly.Date }>({
-		date: isly.fromIs("isoly.Date", isoly.Date.is),
+	private validator = isly.object<{ range: isoly.DateRange }>({
+		range: isly.fromIs("isoly.DateRange", isoly.DateRange.is),
 	})
 	async submitHandler(event: CustomEvent<Submit>): Promise<void> {
 		event.stopPropagation()
@@ -32,7 +32,7 @@ export class SmoothlyFormDemoDate {
 					type={"create"}
 					validator={this.validator}
 					onSmoothlyFormSubmit={e => this.submitHandler(e)}>
-					<smoothly-input-date name={"date"}>{"Date"}</smoothly-input-date>
+					<smoothly-input-date-range name={"range"}>{"Range"}</smoothly-input-date-range>
 					<smoothly-input-submit slot={"submit"}>
 						<smoothly-icon name={"checkmark-outline"} />
 					</smoothly-input-submit>

--- a/src/components/form/demo/date-range/index.tsx
+++ b/src/components/form/demo/date-range/index.tsx
@@ -27,6 +27,7 @@ export class SmoothlyFormDemoDateRange {
 	render(): VNode | VNode[] {
 		return (
 			<Host>
+				<h2>Date-range input</h2>
 				<smoothly-form
 					looks={"border"}
 					type={"create"}

--- a/src/components/form/demo/date-range/style.css
+++ b/src/components/form/demo/date-range/style.css
@@ -1,0 +1,3 @@
+:host {
+	display: block;
+}

--- a/src/components/form/demo/date/index.tsx
+++ b/src/components/form/demo/date/index.tsx
@@ -1,0 +1,45 @@
+import { Component, Event, EventEmitter, h, Host, VNode } from "@stencil/core"
+import { isoly } from "isoly"
+import { isly } from "isly"
+import { Notice, Submit } from "../../../../model"
+
+@Component({
+	tag: "smoothly-form-demo-date",
+	styleUrl: "style.css",
+	scoped: true,
+})
+export class SmoothlyFormDemoDate {
+	@Event() notice: EventEmitter<Notice>
+	private validator = isly.object<{ date: isoly.Date; range: isoly.DateRange }>({
+		date: isly.fromIs("isoly.Date", isoly.Date.is),
+		range: isly.fromIs("isoly.DateRange", isoly.DateRange.is),
+	})
+	async submitHandler(event: CustomEvent<Submit>): Promise<void> {
+		event.stopPropagation()
+		if (!this.validator.is(event.detail.value)) {
+			console.error(`Type is incomplete.`)
+			this.notice.emit(Notice.failed(`Type is incomplete.`))
+		} else {
+			this.notice.emit(Notice.succeeded(`Type is complete!`))
+			event.detail.result(true)
+		}
+		event.detail.result(false)
+	}
+	render(): VNode | VNode[] {
+		return (
+			<Host>
+				<smoothly-form
+					looks={"border"}
+					type={"create"}
+					onSmoothlyFormInput={e => console.log("form input", e.detail)}
+					onSmoothlyFormSubmit={e => this.submitHandler(e)}>
+					<smoothly-input-date name={"date"}>{"Date"}</smoothly-input-date>
+					<smoothly-input-date-range name={"range"}>{"Range"}</smoothly-input-date-range>
+					<smoothly-input-submit slot={"submit"}>
+						<smoothly-icon name={"checkmark-outline"} />
+					</smoothly-input-submit>
+				</smoothly-form>
+			</Host>
+		)
+	}
+}

--- a/src/components/form/demo/date/index.tsx
+++ b/src/components/form/demo/date/index.tsx
@@ -27,6 +27,7 @@ export class SmoothlyFormDemoDate {
 	render(): VNode | VNode[] {
 		return (
 			<Host>
+				<h2>Date input</h2>
 				<smoothly-form
 					looks={"border"}
 					type={"create"}

--- a/src/components/form/demo/date/style.css
+++ b/src/components/form/demo/date/style.css
@@ -1,0 +1,3 @@
+:host {
+	display: block;
+}

--- a/src/components/form/demo/index.tsx
+++ b/src/components/form/demo/index.tsx
@@ -10,13 +10,14 @@ export class SmoothlyFormDemo {
 		return (
 			<Host>
 				<div>
-					<smoothly-form-demo-all />
+					<smoothly-form-demo-date />
+					{/* <smoothly-form-demo-all />
 					<smoothly-form-demo-card />
 					<smoothly-form-demo-login />
 					<smoothly-form-demo-prices />
 					<smoothly-form-demo-typed />
 					<smoothly-form-demo-transparent />
-					<smoothly-form-demo-controlled />
+					<smoothly-form-demo-controlled /> */}
 				</div>
 			</Host>
 		)

--- a/src/components/form/demo/index.tsx
+++ b/src/components/form/demo/index.tsx
@@ -10,14 +10,15 @@ export class SmoothlyFormDemo {
 		return (
 			<Host>
 				<div>
-					<smoothly-form-demo-date />
-					{/* <smoothly-form-demo-all />
+					<smoothly-form-demo-all />
 					<smoothly-form-demo-card />
 					<smoothly-form-demo-login />
 					<smoothly-form-demo-prices />
 					<smoothly-form-demo-typed />
 					<smoothly-form-demo-transparent />
-					<smoothly-form-demo-controlled /> */}
+					<smoothly-form-demo-date />
+					<smoothly-form-demo-date-range />
+					<smoothly-form-demo-controlled />
 				</div>
 			</Host>
 		)

--- a/src/components/input/date/index.tsx
+++ b/src/components/input/date/index.tsx
@@ -46,7 +46,6 @@ export class SmoothlyInputDate implements ComponentWillLoad, Clearable, Input, E
 
 	componentWillLoad(): void {
 		this.setInitialValue()
-
 		this.smoothlyInputLooks.emit(
 			(looks, color) => ((this.looks = this.looks ?? looks), !this.color && (this.color = color))
 		)

--- a/src/components/input/date/index.tsx
+++ b/src/components/input/date/index.tsx
@@ -46,11 +46,13 @@ export class SmoothlyInputDate implements ComponentWillLoad, Clearable, Input, E
 
 	componentWillLoad(): void {
 		this.setInitialValue()
-		this.smoothlyInputLoad.emit(_ => {})
+
 		this.smoothlyInputLooks.emit(
 			(looks, color) => ((this.looks = this.looks ?? looks), !this.color && (this.color = color))
 		)
+		this.smoothlyInputLoad.emit(_ => {})
 		!this.readonly && this.smoothlyFormDisable.emit(readonly => (this.readonly = readonly))
+		this.listener.changed?.(this)
 	}
 	@Method()
 	async listen(property: "changed", listener: (parent: Editable) => Promise<void>) {

--- a/src/components/input/date/range/index.tsx
+++ b/src/components/input/date/range/index.tsx
@@ -39,12 +39,13 @@ export class SmoothlyInputDateRange implements Clearable, Input, Editable {
 	componentWillLoad() {
 		this.setInitialValue()
 		this.updateValue()
-		this.smoothlyInputLoad.emit(_ => {})
 		this.smoothlyInputLooks.emit(
 			(looks, color) => ((this.looks = this.looks ?? looks), !this.color && (this.color = color))
 		)
+		this.smoothlyInputLoad.emit(_ => {})
 		this.start && this.end && this.smoothlyInput.emit({ [this.name]: { start: this.start, end: this.end } })
 		!this.readonly && this.smoothlyFormDisable.emit(readonly => (this.readonly = readonly))
+		this.listener.changed?.(this)
 	}
 	// TODO: disable search fields in month selectors so that the input becomes typeable and then fix input handler
 	inputHandler(data: Data) {


### PR DESCRIPTION
## Issue
forms with a mixture of only `<smoothly-input-date>` and `<smoothly-input-date-range>` never register to the submit button that the form is submittable.
[Demo](https://96be9de5.smoothly.pages.dev/form) with issue. Forms are under the transparent form.

## Fix
sending `smoothlyInputLooks` event before sending `smoothlyInputLoad` seams to fix the issue.
