### PR TITLE
section covers the entire element

### DIFF
--- a/src/components/input/date/range/style.scss
+++ b/src/components/input/date/range/style.scss
@@ -47,6 +47,7 @@
 
 :host>section {
 	display: flex;
+	width: 100%;
 	background-color: var(--smoothly-input-background);
 	border-radius: 0.25rem;
 	cursor: pointer;


### PR DESCRIPTION
Having a singular date-range element in a form that was the width of the screen caused the section element inside of the date-range to not cover the entire visual area of the input causing clicks on the right side of the input element (outside of the section) to not register clicks to open the calendar. 

This PR fixes this and clicking anywhere inside the visual area of the input causes the calendar to open.