### PR TITLE
Change smoothlyLoadMore to have consistent type.

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -8,13 +8,13 @@ import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
 import { Color, Data, Fill, Icon, Message, Notice, Option, Submit, Trigger } from "./model";
 import { FunctionalComponent, VNode } from "@stencil/core";
 import { Button } from "./components/button/Button";
+import { Editable } from "./components/input/Editable";
 import { CountryCode, Currency, Date, DateRange, DateTime, isoly } from "isoly";
 import { tidily, Type } from "tidily";
 import { selectively } from "selectively";
 import { Filter } from "./components/filter/Filter";
 import { Looks } from "./components/input/Looks";
 import { isly } from "isly";
-import { Editable } from "./components/input/Editable";
 import { Selectable } from "./components/input/radio/Selected";
 import { Controls } from "./components/picker/menu";
 import { Controls as Controls1 } from "./components/picker/menu/index";
@@ -22,13 +22,13 @@ import { Slot } from "./components/picker/slot-elements/index";
 export { Color, Data, Fill, Icon, Message, Notice, Option, Submit, Trigger } from "./model";
 export { FunctionalComponent, VNode } from "@stencil/core";
 export { Button } from "./components/button/Button";
+export { Editable } from "./components/input/Editable";
 export { CountryCode, Currency, Date, DateRange, DateTime, isoly } from "isoly";
 export { tidily, Type } from "tidily";
 export { selectively } from "selectively";
 export { Filter } from "./components/filter/Filter";
 export { Looks } from "./components/input/Looks";
 export { isly } from "isly";
-export { Editable } from "./components/input/Editable";
 export { Selectable } from "./components/input/radio/Selected";
 export { Controls } from "./components/picker/menu";
 export { Controls as Controls1 } from "./components/picker/menu/index";
@@ -969,7 +969,7 @@ declare global {
         new (): HTMLSmoothlyButtonElement;
     };
     interface HTMLSmoothlyButtonConfirmElementEventMap {
-        "smoothlyInputLoad": (parent: HTMLElement) => void;
+        "smoothlyInputLoad": (parent: Editable) => void;
         "smoothlyConfirm": Data;
     }
     interface HTMLSmoothlyButtonConfirmElement extends Components.SmoothlyButtonConfirm, HTMLStencilElement {
@@ -1350,7 +1350,7 @@ declare global {
     };
     interface HTMLSmoothlyInputElementEventMap {
         "smoothlyInputLooks": (looks?: Looks, color?: Color) => void;
-        "smoothlyInputLoad": (parent: HTMLElement) => void;
+        "smoothlyInputLoad": (parent: Editable) => void;
         "smoothlyFormDisable": (disabled: boolean) => void;
         "smoothlyBlur": void;
         "smoothlyChange": Record<string, any>;
@@ -1373,7 +1373,7 @@ declare global {
     interface HTMLSmoothlyInputCheckboxElementEventMap {
         "smoothlyInputLooks": (looks?: Looks, color?: Color) => void;
         "smoothlyInput": Data;
-        "smoothlyInputLoad": (parent: HTMLElement) => void;
+        "smoothlyInputLoad": (parent: Editable) => void;
         "smoothlyFormDisable": (disabled: boolean) => void;
     }
     interface HTMLSmoothlyInputCheckboxElement extends Components.SmoothlyInputCheckbox, HTMLStencilElement {
@@ -1397,7 +1397,7 @@ declare global {
         new (): HTMLSmoothlyInputCheckboxDemoElement;
     };
     interface HTMLSmoothlyInputClearElementEventMap {
-        "smoothlyInputLoad": (parent: HTMLElement) => void;
+        "smoothlyInputLoad": (parent: Editable) => void;
     }
     interface HTMLSmoothlyInputClearElement extends Components.SmoothlyInputClear, HTMLStencilElement {
         addEventListener<K extends keyof HTMLSmoothlyInputClearElementEventMap>(type: K, listener: (this: HTMLSmoothlyInputClearElement, ev: SmoothlyInputClearCustomEvent<HTMLSmoothlyInputClearElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -1416,7 +1416,7 @@ declare global {
     interface HTMLSmoothlyInputColorElementEventMap {
         "smoothlyInputLooks": (looks?: Looks, color?: Color) => void;
         "smoothlyInput": Record<string, any>;
-        "smoothlyInputLoad": (parent: HTMLElement) => void;
+        "smoothlyInputLoad": (parent: Editable) => void;
         "smoothlyFormDisable": (disabled: boolean) => void;
     }
     interface HTMLSmoothlyInputColorElement extends Components.SmoothlyInputColor, HTMLStencilElement {
@@ -1440,7 +1440,7 @@ declare global {
         new (): HTMLSmoothlyInputColorDemoElement;
     };
     interface HTMLSmoothlyInputDateElementEventMap {
-        "smoothlyInputLoad": (parent: HTMLElement) => void;
+        "smoothlyInputLoad": (parent: Editable) => void;
         "smoothlyValueChange": Date;
         "smoothlyInput": Record<string, any>;
         "smoothlyInputLooks": (looks?: Looks, color?: Color) => void;
@@ -1462,7 +1462,7 @@ declare global {
     };
     interface HTMLSmoothlyInputDateRangeElementEventMap {
         "smoothlyInput": { [name: string]: isoly.DateRange | undefined };
-        "smoothlyInputLoad": (parent: HTMLElement) => void;
+        "smoothlyInputLoad": (parent: Editable) => void;
         "smoothlyInputLooks": (looks?: Looks, color?: Color) => void;
         "smoothlyFormDisable": (disabled: boolean) => void;
     }
@@ -1493,7 +1493,7 @@ declare global {
         new (): HTMLSmoothlyInputDemoStandardElement;
     };
     interface HTMLSmoothlyInputEditElementEventMap {
-        "smoothlyInputLoad": (parent: HTMLElement) => void;
+        "smoothlyInputLoad": (parent: Editable) => void;
     }
     interface HTMLSmoothlyInputEditElement extends Components.SmoothlyInputEdit, HTMLStencilElement {
         addEventListener<K extends keyof HTMLSmoothlyInputEditElementEventMap>(type: K, listener: (this: HTMLSmoothlyInputEditElement, ev: SmoothlyInputEditCustomEvent<HTMLSmoothlyInputEditElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -1512,7 +1512,7 @@ declare global {
     interface HTMLSmoothlyInputFileElementEventMap {
         "smoothlyInputLooks": (looks?: Looks, color?: Color) => void;
         "smoothlyInput": Record<string, any>;
-        "smoothlyInputLoad": (parent: HTMLElement) => void;
+        "smoothlyInputLoad": (parent: Editable) => void;
         "smoothlyFormDisable": (disabled: boolean) => void;
     }
     interface HTMLSmoothlyInputFileElement extends Components.SmoothlyInputFile, HTMLStencilElement {
@@ -1531,7 +1531,7 @@ declare global {
     };
     interface HTMLSmoothlyInputMonthElementEventMap {
         "smoothlyInput": Data;
-        "smoothlyInputLoad": (parent: HTMLElement) => void;
+        "smoothlyInputLoad": (parent: Editable) => void;
         "smoothlyFormDisable": (disabled: boolean) => void;
         "smoothlyInputLooks": (looks?: Looks, color?: Color) => void;
     }
@@ -1558,7 +1558,7 @@ declare global {
     interface HTMLSmoothlyInputRadioElementEventMap {
         "smoothlyInputLooks": (looks?: Looks, color?: Color) => void;
         "smoothlyInput": Data;
-        "smoothlyInputLoad": (parent: HTMLElement) => void;
+        "smoothlyInputLoad": (parent: Editable) => void;
         "smoothlyFormDisable": (disabled: boolean) => void;
     }
     interface HTMLSmoothlyInputRadioElement extends Components.SmoothlyInputRadio, HTMLStencilElement {
@@ -1596,7 +1596,7 @@ declare global {
     interface HTMLSmoothlyInputRangeElementEventMap {
         "smoothlyInputLooks": (looks?: Looks, color?: Color) => void;
         "smoothlyInput": Record<string, any>;
-        "smoothlyInputLoad": (parent: HTMLElement) => void;
+        "smoothlyInputLoad": (parent: Editable) => void;
         "smoothlyFormDisable": (disabled: boolean) => void;
     }
     interface HTMLSmoothlyInputRangeElement extends Components.SmoothlyInputRange, HTMLStencilElement {
@@ -1620,7 +1620,7 @@ declare global {
         new (): HTMLSmoothlyInputRangeDemoElement;
     };
     interface HTMLSmoothlyInputResetElementEventMap {
-        "smoothlyInputLoad": (parent: HTMLElement) => void;
+        "smoothlyInputLoad": (parent: Editable) => void;
     }
     interface HTMLSmoothlyInputResetElement extends Components.SmoothlyInputReset, HTMLStencilElement {
         addEventListener<K extends keyof HTMLSmoothlyInputResetElementEventMap>(type: K, listener: (this: HTMLSmoothlyInputResetElement, ev: SmoothlyInputResetCustomEvent<HTMLSmoothlyInputResetElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -1639,7 +1639,7 @@ declare global {
     interface HTMLSmoothlyInputSelectElementEventMap {
         "smoothlyInput": Data;
         "smoothlyInputLooks": (looks?: Looks, color?: Color) => void;
-        "smoothlyInputLoad": (parent: HTMLElement) => void;
+        "smoothlyInputLoad": (parent: Editable) => void;
         "smoothlyFormDisable": (disabled: boolean) => void;
         "smoothlyItemSelect": HTMLSmoothlyItemElement;
     }
@@ -1658,7 +1658,7 @@ declare global {
         new (): HTMLSmoothlyInputSelectElement;
     };
     interface HTMLSmoothlyInputSubmitElementEventMap {
-        "smoothlyInputLoad": (parent: HTMLElement) => void;
+        "smoothlyInputLoad": (parent: Editable) => void;
     }
     interface HTMLSmoothlyInputSubmitElement extends Components.SmoothlyInputSubmit, HTMLStencilElement {
         addEventListener<K extends keyof HTMLSmoothlyInputSubmitElementEventMap>(type: K, listener: (this: HTMLSmoothlyInputSubmitElement, ev: SmoothlyInputSubmitCustomEvent<HTMLSmoothlyInputSubmitElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -1676,7 +1676,7 @@ declare global {
     };
     interface HTMLSmoothlyItemElementEventMap {
         "smoothlyItemSelect": HTMLSmoothlyItemElement;
-        "smoothlyInputLoad": (parent: HTMLElement) => void;
+        "smoothlyInputLoad": (parent: Editable) => void;
     }
     interface HTMLSmoothlyItemElement extends Components.SmoothlyItem, HTMLStencilElement {
         addEventListener<K extends keyof HTMLSmoothlyItemElementEventMap>(type: K, listener: (this: HTMLSmoothlyItemElement, ev: SmoothlyItemCustomEvent<HTMLSmoothlyItemElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -1858,7 +1858,7 @@ declare global {
         "smoothlyChange": Record<string, any | any[]>;
         "smoothlyInputLooks": (looks?: Looks) => void;
         "smoothlyFormDisable": (disabled: boolean) => void;
-        "smoothlyInputLoad": (parent: HTMLElement) => void;
+        "smoothlyInputLoad": (parent: Editable) => void;
     }
     interface HTMLSmoothlyPickerElement extends Components.SmoothlyPicker, HTMLStencilElement {
         addEventListener<K extends keyof HTMLSmoothlyPickerElementEventMap>(type: K, listener: (this: HTMLSmoothlyPickerElement, ev: SmoothlyPickerCustomEvent<HTMLSmoothlyPickerElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -1958,7 +1958,7 @@ declare global {
         new (): HTMLSmoothlySpinnerElement;
     };
     interface HTMLSmoothlySubmitElementEventMap {
-        "smoothlyInputLoad": (parent: HTMLElement) => void;
+        "smoothlyInputLoad": (parent: Editable) => void;
     }
     interface HTMLSmoothlySubmitElement extends Components.SmoothlySubmit, HTMLStencilElement {
         addEventListener<K extends keyof HTMLSmoothlySubmitElementEventMap>(type: K, listener: (this: HTMLSmoothlySubmitElement, ev: SmoothlySubmitCustomEvent<HTMLSmoothlySubmitElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -2409,7 +2409,7 @@ declare namespace LocalJSX {
         "fill"?: Fill;
         "name"?: string;
         "onSmoothlyConfirm"?: (event: SmoothlyButtonConfirmCustomEvent<Data>) => void;
-        "onSmoothlyInputLoad"?: (event: SmoothlyButtonConfirmCustomEvent<(parent: HTMLElement) => void>) => void;
+        "onSmoothlyInputLoad"?: (event: SmoothlyButtonConfirmCustomEvent<(parent: Editable) => void>) => void;
         "shape"?: "rounded";
         "size"?: "small" | "large" | "icon" | "flexible";
     }
@@ -2596,7 +2596,7 @@ declare namespace LocalJSX {
         "onSmoothlyChange"?: (event: SmoothlyInputCustomEvent<Record<string, any>>) => void;
         "onSmoothlyFormDisable"?: (event: SmoothlyInputCustomEvent<(disabled: boolean) => void>) => void;
         "onSmoothlyInput"?: (event: SmoothlyInputCustomEvent<Record<string, any>>) => void;
-        "onSmoothlyInputLoad"?: (event: SmoothlyInputCustomEvent<(parent: HTMLElement) => void>) => void;
+        "onSmoothlyInputLoad"?: (event: SmoothlyInputCustomEvent<(parent: Editable) => void>) => void;
         "onSmoothlyInputLooks"?: (event: SmoothlyInputCustomEvent<(looks?: Looks, color?: Color) => void>) => void;
         "placeholder"?: string | undefined;
         "readonly"?: boolean;
@@ -2615,7 +2615,7 @@ declare namespace LocalJSX {
         "name"?: string;
         "onSmoothlyFormDisable"?: (event: SmoothlyInputCheckboxCustomEvent<(disabled: boolean) => void>) => void;
         "onSmoothlyInput"?: (event: SmoothlyInputCheckboxCustomEvent<Data>) => void;
-        "onSmoothlyInputLoad"?: (event: SmoothlyInputCheckboxCustomEvent<(parent: HTMLElement) => void>) => void;
+        "onSmoothlyInputLoad"?: (event: SmoothlyInputCheckboxCustomEvent<(parent: Editable) => void>) => void;
         "onSmoothlyInputLooks"?: (event: SmoothlyInputCheckboxCustomEvent<(looks?: Looks, color?: Color) => void>) => void;
         "readonly"?: boolean;
         "value"?: boolean;
@@ -2628,7 +2628,7 @@ declare namespace LocalJSX {
         "display"?: boolean;
         "expand"?: "block" | "full";
         "fill"?: Fill;
-        "onSmoothlyInputLoad"?: (event: SmoothlyInputClearCustomEvent<(parent: HTMLElement) => void>) => void;
+        "onSmoothlyInputLoad"?: (event: SmoothlyInputClearCustomEvent<(parent: Editable) => void>) => void;
         "shape"?: "rounded";
         "size"?: "small" | "large" | "icon" | "flexible";
         "tooltip"?: string;
@@ -2641,7 +2641,7 @@ declare namespace LocalJSX {
         "name"?: string;
         "onSmoothlyFormDisable"?: (event: SmoothlyInputColorCustomEvent<(disabled: boolean) => void>) => void;
         "onSmoothlyInput"?: (event: SmoothlyInputColorCustomEvent<Record<string, any>>) => void;
-        "onSmoothlyInputLoad"?: (event: SmoothlyInputColorCustomEvent<(parent: HTMLElement) => void>) => void;
+        "onSmoothlyInputLoad"?: (event: SmoothlyInputColorCustomEvent<(parent: Editable) => void>) => void;
         "onSmoothlyInputLooks"?: (event: SmoothlyInputColorCustomEvent<(looks?: Looks, color?: Color) => void>) => void;
         "output"?: "rgb" | "hex";
         "readonly"?: boolean;
@@ -2660,7 +2660,7 @@ declare namespace LocalJSX {
         "name"?: string;
         "onSmoothlyFormDisable"?: (event: SmoothlyInputDateCustomEvent<(disabled: boolean) => void>) => void;
         "onSmoothlyInput"?: (event: SmoothlyInputDateCustomEvent<Record<string, any>>) => void;
-        "onSmoothlyInputLoad"?: (event: SmoothlyInputDateCustomEvent<(parent: HTMLElement) => void>) => void;
+        "onSmoothlyInputLoad"?: (event: SmoothlyInputDateCustomEvent<(parent: Editable) => void>) => void;
         "onSmoothlyInputLooks"?: (event: SmoothlyInputDateCustomEvent<(looks?: Looks, color?: Color) => void>) => void;
         "onSmoothlyValueChange"?: (event: SmoothlyInputDateCustomEvent<Date>) => void;
         "open"?: boolean;
@@ -2679,7 +2679,7 @@ declare namespace LocalJSX {
         "name"?: string;
         "onSmoothlyFormDisable"?: (event: SmoothlyInputDateRangeCustomEvent<(disabled: boolean) => void>) => void;
         "onSmoothlyInput"?: (event: SmoothlyInputDateRangeCustomEvent<{ [name: string]: isoly.DateRange | undefined }>) => void;
-        "onSmoothlyInputLoad"?: (event: SmoothlyInputDateRangeCustomEvent<(parent: HTMLElement) => void>) => void;
+        "onSmoothlyInputLoad"?: (event: SmoothlyInputDateRangeCustomEvent<(parent: Editable) => void>) => void;
         "onSmoothlyInputLooks"?: (event: SmoothlyInputDateRangeCustomEvent<(looks?: Looks, color?: Color) => void>) => void;
         "placeholder"?: string;
         "readonly"?: boolean;
@@ -2696,7 +2696,7 @@ declare namespace LocalJSX {
         "display"?: boolean;
         "expand"?: "block" | "full";
         "fill"?: Fill;
-        "onSmoothlyInputLoad"?: (event: SmoothlyInputEditCustomEvent<(parent: HTMLElement) => void>) => void;
+        "onSmoothlyInputLoad"?: (event: SmoothlyInputEditCustomEvent<(parent: Editable) => void>) => void;
         "shape"?: "rounded";
         "size"?: "flexible" | "small" | "large" | "icon";
         "toolTip"?: string;
@@ -2711,7 +2711,7 @@ declare namespace LocalJSX {
         "name"?: string;
         "onSmoothlyFormDisable"?: (event: SmoothlyInputFileCustomEvent<(disabled: boolean) => void>) => void;
         "onSmoothlyInput"?: (event: SmoothlyInputFileCustomEvent<Record<string, any>>) => void;
-        "onSmoothlyInputLoad"?: (event: SmoothlyInputFileCustomEvent<(parent: HTMLElement) => void>) => void;
+        "onSmoothlyInputLoad"?: (event: SmoothlyInputFileCustomEvent<(parent: Editable) => void>) => void;
         "onSmoothlyInputLooks"?: (event: SmoothlyInputFileCustomEvent<(looks?: Looks, color?: Color) => void>) => void;
         "placeholder"?: string | undefined;
         "readonly"?: boolean;
@@ -2726,7 +2726,7 @@ declare namespace LocalJSX {
         "next"?: boolean;
         "onSmoothlyFormDisable"?: (event: SmoothlyInputMonthCustomEvent<(disabled: boolean) => void>) => void;
         "onSmoothlyInput"?: (event: SmoothlyInputMonthCustomEvent<Data>) => void;
-        "onSmoothlyInputLoad"?: (event: SmoothlyInputMonthCustomEvent<(parent: HTMLElement) => void>) => void;
+        "onSmoothlyInputLoad"?: (event: SmoothlyInputMonthCustomEvent<(parent: Editable) => void>) => void;
         "onSmoothlyInputLooks"?: (event: SmoothlyInputMonthCustomEvent<(looks?: Looks, color?: Color) => void>) => void;
         "previous"?: boolean;
         "readonly"?: boolean;
@@ -2743,7 +2743,7 @@ declare namespace LocalJSX {
         "name"?: string;
         "onSmoothlyFormDisable"?: (event: SmoothlyInputRadioCustomEvent<(disabled: boolean) => void>) => void;
         "onSmoothlyInput"?: (event: SmoothlyInputRadioCustomEvent<Data>) => void;
-        "onSmoothlyInputLoad"?: (event: SmoothlyInputRadioCustomEvent<(parent: HTMLElement) => void>) => void;
+        "onSmoothlyInputLoad"?: (event: SmoothlyInputRadioCustomEvent<(parent: Editable) => void>) => void;
         "onSmoothlyInputLooks"?: (event: SmoothlyInputRadioCustomEvent<(looks?: Looks, color?: Color) => void>) => void;
         "readonly"?: boolean;
         "showLabel"?: boolean;
@@ -2767,7 +2767,7 @@ declare namespace LocalJSX {
         "name"?: string;
         "onSmoothlyFormDisable"?: (event: SmoothlyInputRangeCustomEvent<(disabled: boolean) => void>) => void;
         "onSmoothlyInput"?: (event: SmoothlyInputRangeCustomEvent<Record<string, any>>) => void;
-        "onSmoothlyInputLoad"?: (event: SmoothlyInputRangeCustomEvent<(parent: HTMLElement) => void>) => void;
+        "onSmoothlyInputLoad"?: (event: SmoothlyInputRangeCustomEvent<(parent: Editable) => void>) => void;
         "onSmoothlyInputLooks"?: (event: SmoothlyInputRangeCustomEvent<(looks?: Looks, color?: Color) => void>) => void;
         "outputSide"?: "right" | "left";
         "readonly"?: boolean;
@@ -2783,7 +2783,7 @@ declare namespace LocalJSX {
         "display"?: boolean;
         "expand"?: "block" | "full";
         "fill"?: Fill;
-        "onSmoothlyInputLoad"?: (event: SmoothlyInputResetCustomEvent<(parent: HTMLElement) => void>) => void;
+        "onSmoothlyInputLoad"?: (event: SmoothlyInputResetCustomEvent<(parent: Editable) => void>) => void;
         "shape"?: "rounded";
         "size"?: "flexible" | "small" | "large" | "icon";
         "tooltip"?: string;
@@ -2803,7 +2803,7 @@ declare namespace LocalJSX {
         "name"?: string;
         "onSmoothlyFormDisable"?: (event: SmoothlyInputSelectCustomEvent<(disabled: boolean) => void>) => void;
         "onSmoothlyInput"?: (event: SmoothlyInputSelectCustomEvent<Data>) => void;
-        "onSmoothlyInputLoad"?: (event: SmoothlyInputSelectCustomEvent<(parent: HTMLElement) => void>) => void;
+        "onSmoothlyInputLoad"?: (event: SmoothlyInputSelectCustomEvent<(parent: Editable) => void>) => void;
         "onSmoothlyInputLooks"?: (event: SmoothlyInputSelectCustomEvent<(looks?: Looks, color?: Color) => void>) => void;
         "onSmoothlyItemSelect"?: (event: SmoothlyInputSelectCustomEvent<HTMLSmoothlyItemElement>) => void;
         "placeholder"?: string | any;
@@ -2821,7 +2821,7 @@ declare namespace LocalJSX {
         "expand"?: "block" | "full";
         "fill"?: Fill;
         "icon"?: Icon | false;
-        "onSmoothlyInputLoad"?: (event: SmoothlyInputSubmitCustomEvent<(parent: HTMLElement) => void>) => void;
+        "onSmoothlyInputLoad"?: (event: SmoothlyInputSubmitCustomEvent<(parent: Editable) => void>) => void;
         "shape"?: "rounded";
         "size"?: "flexible" | "small" | "large" | "icon";
         "toolTip"?: string;
@@ -2829,7 +2829,7 @@ declare namespace LocalJSX {
     interface SmoothlyItem {
         "deselectable"?: boolean;
         "marked"?: boolean;
-        "onSmoothlyInputLoad"?: (event: SmoothlyItemCustomEvent<(parent: HTMLElement) => void>) => void;
+        "onSmoothlyInputLoad"?: (event: SmoothlyItemCustomEvent<(parent: Editable) => void>) => void;
         "onSmoothlyItemSelect"?: (event: SmoothlyItemCustomEvent<HTMLSmoothlyItemElement>) => void;
         "selectable"?: boolean;
         "selected"?: boolean;
@@ -2915,7 +2915,7 @@ declare namespace LocalJSX {
         "onSmoothlyChange"?: (event: SmoothlyPickerCustomEvent<Record<string, any | any[]>>) => void;
         "onSmoothlyFormDisable"?: (event: SmoothlyPickerCustomEvent<(disabled: boolean) => void>) => void;
         "onSmoothlyInput"?: (event: SmoothlyPickerCustomEvent<Record<string, any | any[]>>) => void;
-        "onSmoothlyInputLoad"?: (event: SmoothlyPickerCustomEvent<(parent: HTMLElement) => void>) => void;
+        "onSmoothlyInputLoad"?: (event: SmoothlyPickerCustomEvent<(parent: Editable) => void>) => void;
         "onSmoothlyInputLooks"?: (event: SmoothlyPickerCustomEvent<(looks?: Looks) => void>) => void;
         "onSmoothlyPickerLoaded"?: (event: SmoothlyPickerCustomEvent<Controls>) => void;
         "open"?: boolean;
@@ -2963,7 +2963,7 @@ declare namespace LocalJSX {
         "disabled"?: boolean;
         "expand"?: "block" | "full";
         "fill"?: Fill;
-        "onSmoothlyInputLoad"?: (event: SmoothlySubmitCustomEvent<(parent: HTMLElement) => void>) => void;
+        "onSmoothlyInputLoad"?: (event: SmoothlySubmitCustomEvent<(parent: Editable) => void>) => void;
         "prevent"?: boolean;
         "shape"?: "rounded";
         "size"?: "flexible" | "small" | "large" | "icon";

--- a/src/components/confirm/index.tsx
+++ b/src/components/confirm/index.tsx
@@ -1,5 +1,6 @@
 import { Component, Event, EventEmitter, h, Host, Prop, State, VNode } from "@stencil/core"
 import { Color, Data, Fill } from "../../model"
+import { Editable } from "../input/Editable"
 
 @Component({
 	tag: "smoothly-button-confirm",
@@ -17,7 +18,7 @@ export class SmoothlyButtonConfirm {
 	@Prop() shape?: "rounded"
 	@Prop() size: "small" | "large" | "icon" | "flexible"
 	@State() clickTimeStamp: number | undefined
-	@Event() smoothlyInputLoad: EventEmitter<(parent: HTMLElement) => void>
+	@Event() smoothlyInputLoad: EventEmitter<(parent: Editable) => void>
 	@Event() smoothlyConfirm: EventEmitter<Data>
 
 	clickHandler(event: MouseEvent): void {

--- a/src/components/filter/select/index.tsx
+++ b/src/components/filter/select/index.tsx
@@ -1,6 +1,7 @@
 import { Component, Element, Event, EventEmitter, h, Listen, Prop } from "@stencil/core"
 import { selectively } from "selectively"
 import { isly } from "isly"
+import { Editable } from "../../input/Editable"
 import { Looks } from "../../input/Looks"
 import { Filter } from "../Filter"
 
@@ -33,7 +34,7 @@ export class SmoothlyFilterSelect implements Filter {
 		this.smoothlyFilterUpdate.emit(this.update.bind(this))
 	}
 	@Listen("smoothlyInputLoad")
-	async smoothlyInputLoadHandler(event: CustomEvent<(parent: any) => void>): Promise<void> {
+	async smoothlyInputLoadHandler(_: CustomEvent<(parent: Editable) => void>): Promise<void> {
 		;(await this.selectElement?.getItems())?.forEach(item =>
 			this.items.set(item.value, {
 				state: this.property.split(".").reduceRight((r, e) => ({ [e]: r }), item.value),

--- a/src/components/input/Input.ts
+++ b/src/components/input/Input.ts
@@ -1,10 +1,11 @@
 import { EventEmitter } from "@stencil/core"
 import { isly } from "isly"
 import { Color, Data } from "../../model"
+import { Editable } from "./Editable"
 import { Looks } from "./Looks"
 
 export interface Input extends Input.Element {
-	smoothlyInputLoad: EventEmitter<(parent: HTMLElement) => void>
+	smoothlyInputLoad: EventEmitter<(parent: Editable) => void>
 	smoothlyInput: EventEmitter<Data>
 	smoothlyInputForm?: EventEmitter<Record<string, Data>>
 }

--- a/src/components/input/checkbox/index.tsx
+++ b/src/components/input/checkbox/index.tsx
@@ -24,7 +24,7 @@ export class SmoothlyInputCheckbox implements Input, Clearable, Editable, Compon
 	@Prop({ reflect: true }) disabled: boolean
 	@Event() smoothlyInputLooks: EventEmitter<(looks?: Looks, color?: Color) => void>
 	@Event() smoothlyInput: EventEmitter<Data>
-	@Event() smoothlyInputLoad: EventEmitter<(parent: HTMLElement) => void>
+	@Event() smoothlyInputLoad: EventEmitter<(parent: Editable) => void>
 	@Event() smoothlyFormDisable: EventEmitter<(disabled: boolean) => void>
 	componentWillLoad(): void | Promise<void> {
 		this.initialValue = this.checked
@@ -32,9 +32,7 @@ export class SmoothlyInputCheckbox implements Input, Clearable, Editable, Compon
 		this.smoothlyInputLooks.emit(
 			(looks, color) => ((this.looks = this.looks ?? looks), !this.color && (this.color = color))
 		)
-		this.smoothlyInputLoad.emit(() => {
-			return
-		})
+		this.smoothlyInputLoad.emit(() => {})
 		this.listener.changed?.(this)
 	}
 	@Method()

--- a/src/components/input/clear/index.tsx
+++ b/src/components/input/clear/index.tsx
@@ -21,7 +21,7 @@ export class SmoothlyInputClear {
 	@Prop({ reflect: true }) type: "form" | "input" = "input"
 	@Prop() tooltip = "Clear"
 	private parent?: Clearable | (Clearable & Editable)
-	@Event() smoothlyInputLoad: EventEmitter<(parent: HTMLElement) => void>
+	@Event() smoothlyInputLoad: EventEmitter<(parent: Editable) => void>
 
 	async componentWillLoad() {
 		this.smoothlyInputLoad.emit(parent => {

--- a/src/components/input/color/index.tsx
+++ b/src/components/input/color/index.tsx
@@ -45,7 +45,7 @@ export class SmoothlyInputColor implements Input, Clearable, Editable, Component
 	@State() sliderMode: "rgb" | "hsl" = "rgb"
 	@Event() smoothlyInputLooks: EventEmitter<(looks?: Looks, color?: Color) => void>
 	@Event() smoothlyInput: EventEmitter<Record<string, any>>
-	@Event() smoothlyInputLoad: EventEmitter<(parent: HTMLElement) => void>
+	@Event() smoothlyInputLoad: EventEmitter<(parent: Editable) => void>
 	@Event() smoothlyFormDisable: EventEmitter<(disabled: boolean) => void>
 	componentWillLoad(): void | Promise<void> {
 		this.value && this.setInitialValue()

--- a/src/components/input/date/index.tsx
+++ b/src/components/input/date/index.tsx
@@ -38,7 +38,7 @@ export class SmoothlyInputDate implements ComponentWillLoad, Clearable, Input, E
 	@Prop({ mutable: true }) max: Date
 	@Prop({ mutable: true }) min: Date
 	@Prop({ reflect: true }) showLabel = true
-	@Event() smoothlyInputLoad: EventEmitter<(parent: HTMLElement) => void>
+	@Event() smoothlyInputLoad: EventEmitter<(parent: Editable) => void>
 	@Event() smoothlyValueChange: EventEmitter<Date>
 	@Event() smoothlyInput: EventEmitter<Record<string, any>>
 	@Event() smoothlyInputLooks: EventEmitter<(looks?: Looks, color?: Color) => void>

--- a/src/components/input/date/range/index.tsx
+++ b/src/components/input/date/range/index.tsx
@@ -32,7 +32,7 @@ export class SmoothlyInputDateRange implements Clearable, Input, Editable {
 	@State() value?: isoly.DateRange
 	@State() open: boolean
 	@Event() smoothlyInput: EventEmitter<{ [name: string]: isoly.DateRange | undefined }>
-	@Event() smoothlyInputLoad: EventEmitter<(parent: HTMLElement) => void>
+	@Event() smoothlyInputLoad: EventEmitter<(parent: Editable) => void>
 	@Event() smoothlyInputLooks: EventEmitter<(looks?: Looks, color?: Color) => void>
 	@Event() smoothlyFormDisable: EventEmitter<(disabled: boolean) => void>
 

--- a/src/components/input/edit/index.tsx
+++ b/src/components/input/edit/index.tsx
@@ -18,7 +18,7 @@ export class SmoothlyInputEdit implements ComponentWillLoad {
 	@Prop({ reflect: true }) type: "form" | "input" = "input"
 	@Prop({ reflect: true }) size: "flexible" | "small" | "large" | "icon"
 	@Prop() toolTip = "Edit"
-	@Event() smoothlyInputLoad: EventEmitter<(parent: HTMLElement) => void>
+	@Event() smoothlyInputLoad: EventEmitter<(parent: Editable) => void>
 	componentWillLoad(): void {
 		this.smoothlyInputLoad.emit(parent => {
 			if (Editable.type.is(parent)) {

--- a/src/components/input/file/index.tsx
+++ b/src/components/input/file/index.tsx
@@ -36,7 +36,7 @@ export class SmoothlyInputFile implements ComponentWillLoad, Input, Clearable, E
 	@State() dragging = false
 	@Event() smoothlyInputLooks: EventEmitter<(looks?: Looks, color?: Color) => void>
 	@Event() smoothlyInput: EventEmitter<Record<string, any>>
-	@Event() smoothlyInputLoad: EventEmitter<(parent: HTMLElement) => void>
+	@Event() smoothlyInputLoad: EventEmitter<(parent: Editable) => void>
 	@Event() smoothlyFormDisable: EventEmitter<(disabled: boolean) => void>
 	private listener: { changed?: (parent: Editable) => Promise<void> }
 	private transfer: DataTransfer = new DataTransfer()

--- a/src/components/input/index.tsx
+++ b/src/components/input/index.tsx
@@ -38,7 +38,7 @@ export class SmoothlyInput implements Clearable, Input, Editable {
 	private uneditable = this.readonly
 	private listener: { changed?: (parent: Editable) => Promise<void> } = {}
 	@Event() smoothlyInputLooks: EventEmitter<(looks?: Looks, color?: Color) => void>
-	@Event() smoothlyInputLoad: EventEmitter<(parent: HTMLElement) => void>
+	@Event() smoothlyInputLoad: EventEmitter<(parent: Editable) => void>
 	@Event() smoothlyFormDisable: EventEmitter<(disabled: boolean) => void>
 	@Event() smoothlyBlur: EventEmitter<void>
 	@Event() smoothlyChange: EventEmitter<Record<string, any>>
@@ -116,9 +116,7 @@ export class SmoothlyInput implements Clearable, Input, Editable {
 		this.smoothlyInputLooks.emit(
 			(looks, color) => ((this.looks = this.looks ?? looks), !this.color && (this.color = color))
 		)
-		this.smoothlyInputLoad.emit(() => {
-			return
-		})
+		this.smoothlyInputLoad.emit(() => {})
 		!this.readonly && this.smoothlyFormDisable.emit(readonly => (this.readonly = readonly))
 		this.listener.changed?.(this)
 	}

--- a/src/components/input/month/index.tsx
+++ b/src/components/input/month/index.tsx
@@ -38,7 +38,7 @@ export class SmoothlyInputMonth implements ComponentWillLoad, Input, Editable {
 	@Prop({ reflect: true }) inCalendar = false
 	@Prop({ reflect: true }) showLabel = true
 	@Event() smoothlyInput: EventEmitter<Data>
-	@Event() smoothlyInputLoad: EventEmitter<(parent: HTMLElement) => void>
+	@Event() smoothlyInputLoad: EventEmitter<(parent: Editable) => void>
 	@Event() smoothlyFormDisable: EventEmitter<(disabled: boolean) => void>
 	@Event() smoothlyInputLooks: EventEmitter<(looks?: Looks, color?: Color) => void>
 	private year?: HTMLSmoothlyInputSelectElement
@@ -105,7 +105,7 @@ export class SmoothlyInputMonth implements ComponentWillLoad, Input, Editable {
 		}
 	}
 	@Listen("smoothlyInputLoad")
-	async smoothlyInputLoadHandler(event: CustomEvent<(parent: unknown) => void>): Promise<void> {
+	async smoothlyInputLoadHandler(event: CustomEvent<(parent: Editable) => void>): Promise<void> {
 		if (event.target != this.element)
 			event.stopPropagation()
 	}

--- a/src/components/input/radio/index.tsx
+++ b/src/components/input/radio/index.tsx
@@ -38,7 +38,7 @@ export class SmoothlyInputRadio implements Input, Clearable, Editable, Component
 	@Prop({ reflect: true }) showLabel = true
 	@Event() smoothlyInputLooks: EventEmitter<(looks?: Looks, color?: Color) => void>
 	@Event() smoothlyInput: EventEmitter<Data>
-	@Event() smoothlyInputLoad: EventEmitter<(parent: HTMLElement) => void>
+	@Event() smoothlyInputLoad: EventEmitter<(parent: Editable) => void>
 	@Event() smoothlyFormDisable: EventEmitter<(disabled: boolean) => void>
 	componentWillLoad(): void | Promise<void> {
 		this.smoothlyInputLooks.emit((looks, color) => ((this.looks = this.looks ?? looks), (this.color = color)))
@@ -47,9 +47,7 @@ export class SmoothlyInputRadio implements Input, Clearable, Editable, Component
 	}
 	componentDidLoad(): void | Promise<void> {
 		!this.valueReceivedOnLoad && this.smoothlyInput.emit({ [this.name]: this.value })
-		this.smoothlyInputLoad.emit(() => {
-			return
-		})
+		this.smoothlyInputLoad.emit(() => {})
 		this.initialValue = this.active
 	}
 	@Listen("smoothlyRadioButtonRegister")

--- a/src/components/input/range/index.tsx
+++ b/src/components/input/range/index.tsx
@@ -45,20 +45,18 @@ export class SmoothlyInputRange implements Input, Clearable, Editable, Component
 	@State() showInput = false
 	@Event() smoothlyInputLooks: EventEmitter<(looks?: Looks, color?: Color) => void>
 	@Event() smoothlyInput: EventEmitter<Record<string, any>>
-	@Event() smoothlyInputLoad: EventEmitter<(parent: HTMLElement) => void>
+	@Event() smoothlyInputLoad: EventEmitter<(parent: Editable) => void>
 	@Event() smoothlyFormDisable: EventEmitter<(disabled: boolean) => void>
 	componentWillLoad(): void | Promise<void> {
 		this.smoothlyInputLooks.emit((looks, color) => ((this.looks = this.looks ?? looks), (this.color = color)))
 		this.smoothlyInput.emit({ [this.name]: this.value })
-		this.smoothlyInputLoad.emit(() => {
-			return
-		})
+		this.smoothlyInputLoad.emit(() => {})
 		!this.readonly && this.smoothlyFormDisable.emit(readonly => (this.readonly = readonly))
 		this.value && (this.initialValue = this.value)
 		this.valueChanged()
 	}
 	@Listen("smoothlyInputLoad")
-	smoothlyInputLoadHandler(event: CustomEvent<(parent: unknown) => void>) {
+	smoothlyInputLoadHandler(event: CustomEvent<(parent: Editable) => void>) {
 		if (event.target != this.element) {
 			event.stopPropagation()
 			event.detail(this)

--- a/src/components/input/reset/index.tsx
+++ b/src/components/input/reset/index.tsx
@@ -21,7 +21,7 @@ export class SmoothlyInputReset {
 	@Prop({ reflect: true }) type: "form" | "input" = "input"
 	@Prop() tooltip = "Reset"
 	private parent?: Editable.Element
-	@Event() smoothlyInputLoad: EventEmitter<(parent: HTMLElement) => void>
+	@Event() smoothlyInputLoad: EventEmitter<(parent: Editable) => void>
 
 	async componentWillLoad() {
 		this.smoothlyInputLoad.emit(parent => {

--- a/src/components/input/select/index.tsx
+++ b/src/components/input/select/index.tsx
@@ -58,7 +58,7 @@ export class SmoothlyInputSelect implements Input, Editable, Clearable, Componen
 	@State() addedItems: HTMLSmoothlyItemElement[] = []
 	@Event() smoothlyInput: EventEmitter<Data>
 	@Event() smoothlyInputLooks: EventEmitter<(looks?: Looks, color?: Color) => void>
-	@Event() smoothlyInputLoad: EventEmitter<(parent: HTMLElement) => void>
+	@Event() smoothlyInputLoad: EventEmitter<(parent: Editable) => void>
 	@Event() smoothlyFormDisable: EventEmitter<(disabled: boolean) => void>
 	@Event() smoothlyItemSelect: EventEmitter<HTMLSmoothlyItemElement>
 
@@ -66,9 +66,7 @@ export class SmoothlyInputSelect implements Input, Editable, Clearable, Componen
 		this.smoothlyInputLooks.emit(
 			(looks, color) => ((this.looks = this.looks ?? looks), !this.color && (this.color = color))
 		)
-		this.smoothlyInputLoad.emit(() => {
-			return
-		})
+		this.smoothlyInputLoad.emit(() => {})
 		!this.readonly && this.smoothlyFormDisable.emit(readonly => (this.readonly = readonly))
 		this.listener.changed?.(this)
 	}

--- a/src/components/input/submit/index.tsx
+++ b/src/components/input/submit/index.tsx
@@ -21,7 +21,7 @@ export class SmoothlyInputSubmit implements ComponentWillLoad {
 	@Prop({ reflect: true }) shape?: "rounded"
 	@Prop({ reflect: true }) size: "flexible" | "small" | "large" | "icon" = "icon"
 	@Prop() toolTip = this.delete ? "Remove" : "Submit"
-	@Event() smoothlyInputLoad: EventEmitter<(parent: HTMLElement) => void>
+	@Event() smoothlyInputLoad: EventEmitter<(parent: Editable) => void>
 	componentWillLoad(): void {
 		this.smoothlyInputLoad.emit(parent => {
 			if (Submittable.is(parent) && Editable.type.is(parent)) {

--- a/src/components/item/index.tsx
+++ b/src/components/item/index.tsx
@@ -13,6 +13,7 @@ import {
 	VNode,
 	Watch,
 } from "@stencil/core"
+import { Editable } from "../input/Editable"
 import { Item } from "./Item"
 
 @Component({
@@ -28,7 +29,7 @@ export class SmoothlyItem implements Item, ComponentWillLoad, ComponentDidLoad {
 	@Prop({ reflect: true }) selectable = true
 	@Prop() deselectable = true
 	@Event() smoothlyItemSelect: EventEmitter<HTMLSmoothlyItemElement>
-	@Event() smoothlyInputLoad: EventEmitter<(parent: HTMLElement) => void>
+	@Event() smoothlyInputLoad: EventEmitter<(parent: Editable) => void>
 
 	@Listen("click")
 	clickHandler(): void {
@@ -40,9 +41,7 @@ export class SmoothlyItem implements Item, ComponentWillLoad, ComponentDidLoad {
 		this.smoothlyItemSelect.emit(this.element)
 	}
 	componentWillLoad(): void {
-		this.smoothlyInputLoad.emit(() => {
-			return
-		})
+		this.smoothlyInputLoad.emit(() => {})
 	}
 	componentDidLoad(): void {
 		if (this.selected && this.selectable)

--- a/src/components/picker/index.tsx
+++ b/src/components/picker/index.tsx
@@ -46,15 +46,13 @@ export class SmoothlyPicker implements Clearable, Editable, Input, ComponentDidL
 	@Event() smoothlyChange: EventEmitter<Record<string, any | any[]>> // multiple -> any[]
 	@Event() smoothlyInputLooks: EventEmitter<(looks?: Looks) => void>
 	@Event() smoothlyFormDisable: EventEmitter<(disabled: boolean) => void>
-	@Event() smoothlyInputLoad: EventEmitter<(parent: HTMLElement) => void>
+	@Event() smoothlyInputLoad: EventEmitter<(parent: Editable) => void>
 	private controls?: Controls
 
 	componentWillLoad(): void | Promise<void> {
 		this.smoothlyInputLooks.emit(looks => (this.looks = this.looks ?? looks))
 		!this.readonly && this.smoothlyFormDisable.emit(readonly => (this.readonly = readonly))
-		this.smoothlyInputLoad.emit(() => {
-			return
-		})
+		this.smoothlyInputLoad.emit(() => {})
 		this.listener.changed?.(this)
 	}
 

--- a/src/components/submit/index.tsx
+++ b/src/components/submit/index.tsx
@@ -1,6 +1,7 @@
 import { Component, Event, EventEmitter, h, Listen, Prop } from "@stencil/core"
 import { Color, Fill } from "../../model"
 import { Button } from "../button/Button"
+import { Editable } from "../input/Editable"
 import { Submittable } from "../input/Submittable"
 
 @Component({
@@ -18,7 +19,7 @@ export class SmoothlySubmit {
 	@Prop({ reflect: true }) shape?: "rounded"
 	@Prop() prevent = true
 	private parent?: Submittable
-	@Event() smoothlyInputLoad: EventEmitter<(parent: HTMLElement) => void>
+	@Event() smoothlyInputLoad: EventEmitter<(parent: Editable) => void>
 
 	async componentWillLoad() {
 		this.smoothlyInputLoad.emit(parent => {


### PR DESCRIPTION
Input's specified that `HTMLElement`, as the parent, but the actual code uses the class the generates the web-component.
I noticed that setting `Editable` instead worked, well, and I think it's better then setting `any`.