### PR TITLE
Replace value with getValue method

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -245,6 +245,7 @@ export namespace Components {
         "disabled": boolean;
         "edit": (editable: boolean) => Promise<void>;
         "getFormData": (name: string) => Promise<Record<string, any>>;
+        "getValue": () => Promise<any>;
         "invalid"?: boolean;
         "listen": (property: "changed", listener: (parent: Editable) => Promise<void>) => Promise<void>;
         "looks"?: Looks;
@@ -268,6 +269,7 @@ export namespace Components {
         "color"?: Color;
         "disabled": boolean;
         "edit": (editable: boolean) => Promise<void>;
+        "getValue": () => Promise<boolean>;
         "listen": (property: "changed", listener: (parent: Editable) => Promise<void>) => Promise<void>;
         "looks"?: Looks;
         "name": string;
@@ -294,6 +296,7 @@ export namespace Components {
         "clear": () => Promise<void>;
         "color"?: Color;
         "edit": (editable: boolean) => Promise<void>;
+        "getValue": () => Promise<string | { r: number | undefined; g: number | undefined; b: number | undefined; } | undefined>;
         "listen": (property: "changed", listener: (parent: Editable) => Promise<void>) => Promise<void>;
         "looks"?: Looks;
         "name": string;
@@ -311,6 +314,7 @@ export namespace Components {
         "clear": () => Promise<void>;
         "color"?: Color;
         "edit": (editable: boolean) => Promise<void>;
+        "getValue": () => Promise<string | undefined>;
         "invalid"?: boolean;
         "listen": (property: "changed", listener: (parent: Editable) => Promise<void>) => Promise<void>;
         "looks"?: Looks;
@@ -330,6 +334,7 @@ export namespace Components {
         "color"?: Color;
         "edit": (editable: boolean) => Promise<void>;
         "end": isoly.Date | undefined;
+        "getValue": () => Promise<{ start: string; end: string; } | undefined>;
         "invalid"?: boolean;
         "listen": (property: "changed", listener: (parent: Editable) => Promise<void>) => Promise<void>;
         "looks"?: Looks;
@@ -366,6 +371,7 @@ export namespace Components {
         "clear": () => Promise<void>;
         "color"?: Color;
         "edit": (editable: boolean) => Promise<void>;
+        "getValue": () => Promise<File | undefined>;
         "listen": (property: "changed", listener: (parent: Editable) => Promise<void>) => Promise<void>;
         "looks"?: Looks;
         "name": string;
@@ -380,6 +386,7 @@ export namespace Components {
         "clear": () => Promise<void>;
         "color"?: Color;
         "edit": (editable: boolean) => Promise<void>;
+        "getValue": () => Promise<isoly.Date | undefined>;
         "inCalendar": boolean;
         "listen": (property: "changed", listener: (parent: Editable) => Promise<void>) => Promise<void>;
         "looks"?: Looks;
@@ -400,6 +407,7 @@ export namespace Components {
         "clearable"?: boolean;
         "color"?: Color;
         "edit": (editable: boolean) => Promise<void>;
+        "getValue": () => Promise<any>;
         "listen": (property: "changed", listener: (parent: Editable) => Promise<void>) => Promise<void>;
         "looks"?: Looks;
         "name": string;
@@ -420,6 +428,7 @@ export namespace Components {
         "clear": () => Promise<void>;
         "color"?: Color;
         "edit": (editable: boolean) => Promise<void>;
+        "getValue": () => Promise<number | undefined>;
         "label": string;
         "listen": (property: "changed", listener: (parent: Editable) => Promise<void>) => Promise<void>;
         "looks"?: Looks;
@@ -455,6 +464,7 @@ export namespace Components {
         "defined": boolean;
         "edit": (editable: boolean) => Promise<void>;
         "getItems": () => Promise<HTMLSmoothlyItemElement[]>;
+        "getValue": () => Promise<any>;
         "inCalendar": boolean;
         "invalid"?: boolean;
         "listen": (property: "changed", listener: (parent: Editable) => Promise<void>) => Promise<void>;
@@ -564,6 +574,7 @@ export namespace Components {
         "changed": boolean;
         "clear": () => Promise<void>;
         "edit": (editable: boolean) => Promise<void>;
+        "getValue": () => Promise<any>;
         "listen": (property: "changed", listener: (parent: Editable) => Promise<void>) => Promise<void>;
         "looks"?: Looks;
         "multiple": boolean;

--- a/src/components/form/index.tsx
+++ b/src/components/form/index.tsx
@@ -118,7 +118,7 @@ export class SmoothlyForm implements ComponentWillLoad, Clearable, Submittable, 
 		if (Input.Element.is(event.target)) {
 			if (await event.target.binary?.())
 				this.contentType = "form-data"
-			this.value = Data.merge(this.value, { [event.target.name]: event.target.value })
+			this.value = Data.merge(this.value, { [event.target.name]: await event.target.getValue() })
 			this.inputs.set(event.target.name, event.target)
 		}
 	}

--- a/src/components/input/Input.ts
+++ b/src/components/input/Input.ts
@@ -11,7 +11,7 @@ export interface Input extends Input.Element {
 }
 export namespace Input {
 	export interface Element {
-		value?: Data[string]
+		getValue: GetValue
 		color?: Color
 		name: string
 		invalid?: boolean
@@ -21,7 +21,7 @@ export namespace Input {
 	}
 	export namespace Element {
 		export const type = isly.object<Element>({
-			value: isly.union<Required<Element>["value"], Data, Data[string]>(Data.type, Data.valueType).optional(),
+			getValue: isly.function<GetValue>(),
 			color: Color.type.optional(),
 			name: isly.string(),
 			invalid: isly.boolean().optional(),
@@ -31,6 +31,7 @@ export namespace Input {
 		})
 		export const is = type.is
 	}
+	export type GetValue = () => Promise<any>
 	export type Binary = () => Promise<boolean>
 	const EventEmitter = isly.object<EventEmitter>({ emit: isly.function<EventEmitter["emit"]>() })
 	export const type = Element.type.extend<Input>({

--- a/src/components/input/checkbox/index.tsx
+++ b/src/components/input/checkbox/index.tsx
@@ -36,7 +36,7 @@ export class SmoothlyInputCheckbox implements Input, Clearable, Editable, Compon
 		this.listener.changed?.(this)
 	}
 	@Method()
-	async getValue() {
+	async getValue(): Promise<boolean> {
 		return this.checked
 	}
 	@Method()

--- a/src/components/input/checkbox/index.tsx
+++ b/src/components/input/checkbox/index.tsx
@@ -36,6 +36,10 @@ export class SmoothlyInputCheckbox implements Input, Clearable, Editable, Compon
 		this.listener.changed?.(this)
 	}
 	@Method()
+	async getValue() {
+		return this.checked
+	}
+	@Method()
 	async clear(): Promise<void> {
 		!this.disabled && !this.readonly && (this.checked = false)
 	}
@@ -59,9 +63,9 @@ export class SmoothlyInputCheckbox implements Input, Clearable, Editable, Compon
 		this.changed = false
 	}
 	@Watch("checked")
-	elementCheck(): void {
+	async elementCheck() {
 		this.changed = this.initialValue !== this.checked
-		this.smoothlyInput.emit({ [this.name]: this.checked })
+		this.smoothlyInput.emit({ [this.name]: await this.getValue() })
 		this.listener.changed?.(this)
 	}
 	click() {

--- a/src/components/input/color/index.tsx
+++ b/src/components/input/color/index.tsx
@@ -47,22 +47,11 @@ export class SmoothlyInputColor implements Input, Clearable, Editable, Component
 	@Event() smoothlyInput: EventEmitter<Record<string, any>>
 	@Event() smoothlyInputLoad: EventEmitter<(parent: Editable) => void>
 	@Event() smoothlyFormDisable: EventEmitter<(disabled: boolean) => void>
-	componentWillLoad(): void | Promise<void> {
+	async componentWillLoad(): Promise<void> {
 		this.value && this.setInitialValue()
 		this.value && (this.rgb = Color.Hex.toRGB(this.value))
 		this.smoothlyInputLooks.emit((looks, color) => ((this.looks = this.looks ?? looks), (this.color = color)))
-		this.smoothlyInput.emit({
-			[this.name]:
-				this.output === "rgb"
-					? {
-							r: this.rgb.r === undefined ? undefined : Math.round(this.rgb.r),
-							g: this.rgb.g === undefined ? undefined : Math.round(this.rgb.g),
-							b: this.rgb.b === undefined ? undefined : Math.round(this.rgb.b),
-					  }
-					: this.value
-					? this.value
-					: undefined,
-		})
+		this.smoothlyInput.emit({ [this.name]: await this.getValue() })
 		this.smoothlyInputLoad.emit(() => {})
 		!this.readonly && this.smoothlyFormDisable.emit(readonly => (this.readonly = readonly))
 	}
@@ -79,6 +68,18 @@ export class SmoothlyInputColor implements Input, Clearable, Editable, Component
 	@Listen("click", { target: "window" })
 	onWindowClick(event: Event): void {
 		!event.composedPath().includes(this.element) && this.open && (this.open = !this.open)
+	}
+	@Method()
+	async getValue() {
+		return this.output === "rgb"
+			? {
+					r: this.rgb.r === undefined ? undefined : Math.round(this.rgb.r),
+					g: this.rgb.g === undefined ? undefined : Math.round(this.rgb.g),
+					b: this.rgb.b === undefined ? undefined : Math.round(this.rgb.b),
+			  }
+			: this.value
+			? this.value
+			: undefined
 	}
 	@Method()
 	async clear(): Promise<void> {
@@ -107,20 +108,9 @@ export class SmoothlyInputColor implements Input, Clearable, Editable, Component
 		this.open = false
 	}
 	@Watch("value")
-	valueChanged(): void {
+	async valueChanged(): Promise<void> {
 		this.changed = this.initialValue !== this.value
-		this.smoothlyInput.emit({
-			[this.name]:
-				this.output === "rgb"
-					? {
-							r: this.rgb.r === undefined ? undefined : Math.round(this.rgb.r),
-							g: this.rgb.g === undefined ? undefined : Math.round(this.rgb.g),
-							b: this.rgb.b === undefined ? undefined : Math.round(this.rgb.b),
-					  }
-					: this.value
-					? this.value
-					: undefined,
-		})
+		this.smoothlyInput.emit({ [this.name]: await this.getValue() })
 		this.listener.changed?.(this)
 	}
 	handleSwitchMode(event: CustomEvent): void {

--- a/src/components/input/color/index.tsx
+++ b/src/components/input/color/index.tsx
@@ -70,7 +70,7 @@ export class SmoothlyInputColor implements Input, Clearable, Editable, Component
 		!event.composedPath().includes(this.element) && this.open && (this.open = !this.open)
 	}
 	@Method()
-	async getValue() {
+	async getValue(): Promise<RGB | string | undefined> {
 		return this.output === "rgb"
 			? {
 					r: this.rgb.r === undefined ? undefined : Math.round(this.rgb.r),

--- a/src/components/input/date/index.tsx
+++ b/src/components/input/date/index.tsx
@@ -54,7 +54,7 @@ export class SmoothlyInputDate implements ComponentWillLoad, Clearable, Input, E
 		this.listener.changed?.(this)
 	}
 	@Method()
-	async getValue() {
+	async getValue(): Promise<Date | undefined> {
 		return this.value
 	}
 	@Method()

--- a/src/components/input/date/index.tsx
+++ b/src/components/input/date/index.tsx
@@ -54,6 +54,10 @@ export class SmoothlyInputDate implements ComponentWillLoad, Clearable, Input, E
 		this.listener.changed?.(this)
 	}
 	@Method()
+	async getValue() {
+		return this.value
+	}
+	@Method()
 	async listen(property: "changed", listener: (parent: Editable) => Promise<void>) {
 		this.listener[property] = listener
 		listener(this)

--- a/src/components/input/date/range/index.tsx
+++ b/src/components/input/date/range/index.tsx
@@ -82,7 +82,7 @@ export class SmoothlyInputDateRange implements Clearable, Input, Editable {
 		!event.composedPath().includes(this.element) && this.open && (this.open = !this.open)
 	}
 	@Method()
-	async getValue() {
+	async getValue(): Promise<isoly.DateRange | undefined> {
 		return this.start && this.end ? { start: this.start, end: this.end } : undefined
 	}
 	@Method()

--- a/src/components/input/date/range/index.tsx
+++ b/src/components/input/date/range/index.tsx
@@ -82,6 +82,10 @@ export class SmoothlyInputDateRange implements Clearable, Input, Editable {
 		!event.composedPath().includes(this.element) && this.open && (this.open = !this.open)
 	}
 	@Method()
+	async getValue() {
+		return this.start && this.end ? { start: this.start, end: this.end } : undefined
+	}
+	@Method()
 	async listen(property: "changed", listener: (parent: Editable) => Promise<void>) {
 		this.listener[property] = listener
 		listener(this)

--- a/src/components/input/file/index.tsx
+++ b/src/components/input/file/index.tsx
@@ -49,15 +49,18 @@ export class SmoothlyInputFile implements ComponentWillLoad, Input, Clearable, E
 		return this.transfer.files
 	}
 
-	componentWillLoad(): void {
+	async componentWillLoad(): Promise<void> {
 		this.smoothlyInputLooks.emit(
 			(looks, color) => ((this.looks = this.looks ?? looks), !this.color && (this.color = color))
 		)
-		this.smoothlyInput.emit({ [this.name]: this.value })
+		this.smoothlyInput.emit({ [this.name]: await this.getValue() })
 		this.smoothlyInputLoad.emit(() => {})
 		!this.readonly && this.smoothlyFormDisable.emit(readonly => (this.readonly = readonly))
 	}
-
+	@Method()
+	async getValue(): Promise<File | undefined> {
+		return this.value
+	}
 	@Method()
 	async clear(): Promise<void> {
 		this.value = undefined
@@ -86,9 +89,9 @@ export class SmoothlyInputFile implements ComponentWillLoad, Input, Clearable, E
 	}
 
 	@Watch("value")
-	valueChanged(): void {
+	async valueChanged(): Promise<void> {
 		this.changed = this.initialValue !== this.value
-		this.smoothlyInput.emit({ [this.name]: this.value })
+		this.smoothlyInput.emit({ [this.name]: await this.getValue() })
 	}
 
 	inputHandler(event: Event): void {

--- a/src/components/input/index.tsx
+++ b/src/components/input/index.tsx
@@ -45,6 +45,10 @@ export class SmoothlyInput implements Clearable, Input, Editable {
 	@Event() smoothlyInput: EventEmitter<Record<string, any>>
 
 	@Method()
+	async getValue() {
+		return this.value
+	}
+	@Method()
 	async listen(property: "changed", listener: (parent: Editable) => Promise<void>): Promise<void> {
 		this.listener[property] = listener
 		listener(this)
@@ -76,7 +80,7 @@ export class SmoothlyInput implements Clearable, Input, Editable {
 		return this.formatter.format(tidily.StateEditor.copy(this.formatter.unformat(tidily.StateEditor.copy(state))))
 	}
 	@Watch("value")
-	valueWatcher(value: any, before: any) {
+	async valueWatcher(value: any, before: any) {
 		this.changed = this.initialValue !== this.value
 		if (this.lastValue != value) {
 			this.lastValue = value
@@ -85,11 +89,8 @@ export class SmoothlyInput implements Clearable, Input, Editable {
 				value: this.newState({ value: this.formatter.toString(value), selection: this.state.selection }).value,
 			}
 		}
-		if (value != before) {
-			if (typeof value == "string")
-				value = value.trim()
-			this.smoothlyInput.emit({ [this.name]: value })
-		}
+		if (value != before)
+			this.smoothlyInput.emit({ [this.name]: await this.getValue() })
 		this.listener.changed?.(this)
 	}
 	@Watch("readonly")
@@ -142,7 +143,7 @@ export class SmoothlyInput implements Clearable, Input, Editable {
 	async setInitialValue(): Promise<void> {
 		this.changed = false
 		this.initialValue = this.value
-		this.smoothlyInput.emit({ [this.name]: this.value })
+		this.smoothlyInput.emit({ [this.name]: await this.getValue() })
 	}
 	@Method()
 	async getFormData(name: string): Promise<Record<string, any>> {

--- a/src/components/input/index.tsx
+++ b/src/components/input/index.tsx
@@ -45,7 +45,7 @@ export class SmoothlyInput implements Clearable, Input, Editable {
 	@Event() smoothlyInput: EventEmitter<Record<string, any>>
 
 	@Method()
-	async getValue() {
+	async getValue(): Promise<any | undefined> {
 		return this.value
 	}
 	@Method()

--- a/src/components/input/month/index.tsx
+++ b/src/components/input/month/index.tsx
@@ -63,6 +63,10 @@ export class SmoothlyInputMonth implements ComponentWillLoad, Input, Editable {
 		}
 	}
 	@Method()
+	async getValue(): Promise<isoly.Date | undefined> {
+		return this.value
+	}
+	@Method()
 	async clear(): Promise<void> {
 		this.year?.clear()
 		this.month?.clear()

--- a/src/components/input/radio/index.tsx
+++ b/src/components/input/radio/index.tsx
@@ -83,7 +83,7 @@ export class SmoothlyInputRadio implements Input, Clearable, Editable, Component
 		listener(this)
 	}
 	@Method()
-	async getValue(): Promise<any> {
+	async getValue(): Promise<any | undefined> {
 		return this.value
 	}
 	@Method()

--- a/src/components/input/radio/index.tsx
+++ b/src/components/input/radio/index.tsx
@@ -83,6 +83,10 @@ export class SmoothlyInputRadio implements Input, Clearable, Editable, Component
 		listener(this)
 	}
 	@Method()
+	async getValue(): Promise<any> {
+		return this.value
+	}
+	@Method()
 	async clear(): Promise<void> {
 		if (this.clearable) {
 			this.active?.select(false)
@@ -107,9 +111,9 @@ export class SmoothlyInputRadio implements Input, Clearable, Editable, Component
 		this.valueChanged()
 	}
 	@Watch("value")
-	valueChanged(): void {
+	async valueChanged(): Promise<void> {
 		this.valueReceivedOnLoad && (this.changed = this.initialValue?.value !== this.value)
-		this.smoothlyInput.emit({ [this.name]: this.value })
+		this.smoothlyInput.emit({ [this.name]: await this.getValue() })
 		this.listener.changed?.(this)
 	}
 	@Watch("readonly")

--- a/src/components/input/range/index.tsx
+++ b/src/components/input/range/index.tsx
@@ -68,6 +68,10 @@ export class SmoothlyInputRange implements Input, Clearable, Editable, Component
 			event.stopPropagation()
 	}
 	@Method()
+	async getValue(): Promise<number | undefined> {
+		return this.value
+	}
+	@Method()
 	async clear(): Promise<void> {
 		this.value = undefined
 	}

--- a/src/components/input/select/index.tsx
+++ b/src/components/input/select/index.tsx
@@ -88,6 +88,14 @@ export class SmoothlyInputSelect implements Input, Editable, Clearable, Componen
 		this.element?.style.setProperty("--element-height", `${this.element.clientHeight}px`)
 	}
 	@Method()
+	async getValue() {
+		return !this.multiple && this.selected[0]
+			? this.selected[0].value
+			: this.multiple && this.selected.length > 0
+			? this.selected.map(item => item.value)
+			: undefined
+	}
+	@Method()
 	async getItems(): Promise<HTMLSmoothlyItemElement[]> {
 		return this.items
 	}
@@ -126,16 +134,10 @@ export class SmoothlyInputSelect implements Input, Editable, Clearable, Componen
 		this.initialValue = [...this.selected]
 	}
 	@Watch("selected")
-	onSelectedChange() {
+	async onSelectedChange() {
 		this.initialValueHandled && (this.changed = !this.areValuesEqual(this.selected, this.initialValue))
 		this.defined = this.selected.length > 0
-		const value =
-			!this.multiple && this.selected[0]
-				? this.selected[0].value
-				: this.multiple && this.selected.length > 0
-				? this.selected.map(item => item.value)
-				: undefined
-		this.smoothlyInput.emit({ [this.name]: value })
+		this.smoothlyInput.emit({ [this.name]: await this.getValue() })
 		this.listener.changed?.(this)
 	}
 	@Watch("required")

--- a/src/components/input/select/index.tsx
+++ b/src/components/input/select/index.tsx
@@ -88,7 +88,7 @@ export class SmoothlyInputSelect implements Input, Editable, Clearable, Componen
 		this.element?.style.setProperty("--element-height", `${this.element.clientHeight}px`)
 	}
 	@Method()
-	async getValue() {
+	async getValue(): Promise<any | any[] | undefined> {
 		return !this.multiple && this.selected[0]
 			? this.selected[0].value
 			: this.multiple && this.selected.length > 0

--- a/src/components/picker/index.tsx
+++ b/src/components/picker/index.tsx
@@ -57,7 +57,7 @@ export class SmoothlyPicker implements Clearable, Editable, Input, ComponentDidL
 	}
 
 	@Method()
-	async getValue() {
+	async getValue(): Promise<any | any[] | undefined> {
 		const selected = Array.from(this.selected.values(), option => option.value)
 		return this.multiple ? selected : selected.at(0)
 	}

--- a/src/components/picker/index.tsx
+++ b/src/components/picker/index.tsx
@@ -56,12 +56,17 @@ export class SmoothlyPicker implements Clearable, Editable, Input, ComponentDidL
 		this.listener.changed?.(this)
 	}
 
-	@Watch("selected")
-	selectedChanged(): void {
+	@Method()
+	async getValue() {
 		const selected = Array.from(this.selected.values(), option => option.value)
+		return this.multiple ? selected : selected.at(0)
+	}
+
+	@Watch("selected")
+	async selectedChanged(): Promise<void> {
 		this.changed = !this.areValuesEqual(this.selected, this.initialValue)
-		this.smoothlyInput.emit({ [this.name]: this.multiple ? selected : selected.at(0) })
-		this.smoothlyChange.emit({ [this.name]: this.multiple ? selected : selected.at(0) })
+		this.smoothlyInput.emit({ [this.name]: await this.getValue() })
+		this.smoothlyChange.emit({ [this.name]: await this.getValue() })
 		this.display = Array.from(this.selected.values(), option => {
 			const span = document.createElement("span")
 			option.slotted.forEach(node => span.appendChild(node.cloneNode(true)))


### PR DESCRIPTION
Some inputs don't have `@Prop() value` (e.g. select, date-range).
But `smoothly-form` checks for `element.target.value` on inputs on `smoothlyInputLoad`.
Instead of trying to add `@Prop() value` on all inputs, that would then be expected to work as a Prop, 
I instead add a `@Method getValue` on all inputs that can return what their equivalent of a value is.