### PR TITLE
Remove smoothly-form race condition

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -215,6 +215,8 @@ export namespace Components {
     }
     interface SmoothlyFormDemoLogin {
     }
+    interface SmoothlyFormDemoPet {
+    }
     interface SmoothlyFormDemoPrices {
     }
     interface SmoothlyFormDemoTransparent {
@@ -1302,6 +1304,12 @@ declare global {
         prototype: HTMLSmoothlyFormDemoLoginElement;
         new (): HTMLSmoothlyFormDemoLoginElement;
     };
+    interface HTMLSmoothlyFormDemoPetElement extends Components.SmoothlyFormDemoPet, HTMLStencilElement {
+    }
+    var HTMLSmoothlyFormDemoPetElement: {
+        prototype: HTMLSmoothlyFormDemoPetElement;
+        new (): HTMLSmoothlyFormDemoPetElement;
+    };
     interface HTMLSmoothlyFormDemoPricesElement extends Components.SmoothlyFormDemoPrices, HTMLStencilElement {
     }
     var HTMLSmoothlyFormDemoPricesElement: {
@@ -2287,6 +2295,7 @@ declare global {
         "smoothly-form-demo-date": HTMLSmoothlyFormDemoDateElement;
         "smoothly-form-demo-date-range": HTMLSmoothlyFormDemoDateRangeElement;
         "smoothly-form-demo-login": HTMLSmoothlyFormDemoLoginElement;
+        "smoothly-form-demo-pet": HTMLSmoothlyFormDemoPetElement;
         "smoothly-form-demo-prices": HTMLSmoothlyFormDemoPricesElement;
         "smoothly-form-demo-transparent": HTMLSmoothlyFormDemoTransparentElement;
         "smoothly-form-demo-typed": HTMLSmoothlyFormDemoTypedElement;
@@ -2570,6 +2579,8 @@ declare namespace LocalJSX {
         "onNotice"?: (event: SmoothlyFormDemoDateRangeCustomEvent<Notice>) => void;
     }
     interface SmoothlyFormDemoLogin {
+    }
+    interface SmoothlyFormDemoPet {
     }
     interface SmoothlyFormDemoPrices {
     }
@@ -3127,6 +3138,7 @@ declare namespace LocalJSX {
         "smoothly-form-demo-date": SmoothlyFormDemoDate;
         "smoothly-form-demo-date-range": SmoothlyFormDemoDateRange;
         "smoothly-form-demo-login": SmoothlyFormDemoLogin;
+        "smoothly-form-demo-pet": SmoothlyFormDemoPet;
         "smoothly-form-demo-prices": SmoothlyFormDemoPrices;
         "smoothly-form-demo-transparent": SmoothlyFormDemoTransparent;
         "smoothly-form-demo-typed": SmoothlyFormDemoTyped;
@@ -3251,6 +3263,7 @@ declare module "@stencil/core" {
             "smoothly-form-demo-date": LocalJSX.SmoothlyFormDemoDate & JSXBase.HTMLAttributes<HTMLSmoothlyFormDemoDateElement>;
             "smoothly-form-demo-date-range": LocalJSX.SmoothlyFormDemoDateRange & JSXBase.HTMLAttributes<HTMLSmoothlyFormDemoDateRangeElement>;
             "smoothly-form-demo-login": LocalJSX.SmoothlyFormDemoLogin & JSXBase.HTMLAttributes<HTMLSmoothlyFormDemoLoginElement>;
+            "smoothly-form-demo-pet": LocalJSX.SmoothlyFormDemoPet & JSXBase.HTMLAttributes<HTMLSmoothlyFormDemoPetElement>;
             "smoothly-form-demo-prices": LocalJSX.SmoothlyFormDemoPrices & JSXBase.HTMLAttributes<HTMLSmoothlyFormDemoPricesElement>;
             "smoothly-form-demo-transparent": LocalJSX.SmoothlyFormDemoTransparent & JSXBase.HTMLAttributes<HTMLSmoothlyFormDemoTransparentElement>;
             "smoothly-form-demo-typed": LocalJSX.SmoothlyFormDemoTyped & JSXBase.HTMLAttributes<HTMLSmoothlyFormDemoTypedElement>;

--- a/src/components/form/demo/index.tsx
+++ b/src/components/form/demo/index.tsx
@@ -11,6 +11,7 @@ export class SmoothlyFormDemo {
 			<Host>
 				<div>
 					<smoothly-form-demo-all />
+					<smoothly-form-demo-pet />
 					<smoothly-form-demo-card />
 					<smoothly-form-demo-login />
 					<smoothly-form-demo-prices />

--- a/src/components/form/demo/pet/index.tsx
+++ b/src/components/form/demo/pet/index.tsx
@@ -1,0 +1,36 @@
+import { Component, h, Host, State, VNode } from "@stencil/core"
+
+@Component({
+	tag: "smoothly-form-demo-pet",
+	styleUrl: "style.css",
+	scoped: true,
+})
+export class SmoothlyFormDemoPet {
+	@State() value: any
+
+	render(): VNode | VNode[] {
+		return (
+			<Host>
+				<h2>Pet</h2>
+				<h3>Value</h3>
+				<smoothly-form
+					looks="border"
+					onSmoothlyFormSubmit={(e: CustomEvent) => alert(JSON.stringify(e.detail))}
+					onSmoothlyFormInput={e => (this.value = { ...e.detail })}>
+					<smoothly-input type="text" name="name.first">
+						Name
+					</smoothly-input>
+					<smoothly-input type="integer" name="age">
+						Age (Years)
+					</smoothly-input>
+					<smoothly-input type={"text"} name="owner.firstName">
+						Owners First Name
+					</smoothly-input>
+					<smoothly-input name={"owner.lastName"}>Owners Last Name</smoothly-input>
+					<smoothly-input-submit size="icon" slot="submit" color="success" fill="solid" />
+				</smoothly-form>
+				<smoothly-display type="json" value={this.value} />
+			</Host>
+		)
+	}
+}

--- a/src/components/form/demo/pet/style.css
+++ b/src/components/form/demo/pet/style.css
@@ -1,0 +1,7 @@
+
+:host {
+	display: grid;
+	grid-template-columns: 2fr 1fr;
+	grid-template-rows: auto auto;
+	grid-column-gap: 2rem;
+}

--- a/src/components/form/index.tsx
+++ b/src/components/form/index.tsx
@@ -118,7 +118,7 @@ export class SmoothlyForm implements ComponentWillLoad, Clearable, Submittable, 
 		if (Input.Element.is(event.target)) {
 			if (await event.target.binary?.())
 				this.contentType = "form-data"
-			const inputValue = await event.target.getValue()
+			const inputValue = await event.target.getValue() // Needs to await value separately to avoid race condition
 			this.value = Data.merge(this.value, { [event.target.name]: inputValue })
 			this.smoothlyFormInput.emit(Data.convertArrays(this.value))
 			this.inputs.set(event.target.name, event.target)

--- a/src/components/form/index.tsx
+++ b/src/components/form/index.tsx
@@ -119,6 +119,9 @@ export class SmoothlyForm implements ComponentWillLoad, Clearable, Submittable, 
 			if (await event.target.binary?.())
 				this.contentType = "form-data"
 			this.value = Data.merge(this.value, { [event.target.name]: await event.target.getValue() })
+			const inputValue = await event.target.getValue()
+			this.value = Data.merge(this.value, { [event.target.name]: inputValue })
+			this.smoothlyFormInput.emit(Data.convertArrays(this.value))
 			this.inputs.set(event.target.name, event.target)
 		}
 	}

--- a/src/components/form/index.tsx
+++ b/src/components/form/index.tsx
@@ -118,7 +118,6 @@ export class SmoothlyForm implements ComponentWillLoad, Clearable, Submittable, 
 		if (Input.Element.is(event.target)) {
 			if (await event.target.binary?.())
 				this.contentType = "form-data"
-			this.value = Data.merge(this.value, { [event.target.name]: await event.target.getValue() })
 			const inputValue = await event.target.getValue()
 			this.value = Data.merge(this.value, { [event.target.name]: inputValue })
 			this.smoothlyFormInput.emit(Data.convertArrays(this.value))


### PR DESCRIPTION

Found race condition when listening to `smoothlyInputLoad`.
Awaiting the inputValue separately seems to solve this.
![image](https://github.com/user-attachments/assets/65050da3-6675-4882-a9a6-3c19414f43cc)



Also
- `smoothlyFormInput.emit` on smoothlyInputLoad
- Add `form-demo-pet` to show form value update live - hope to add more to this component when/if I get removeInput working.

[Screencast from 2024-11-13 17:01:28.webm](https://github.com/user-attachments/assets/2c42163e-365c-4f66-9e99-4477b0d45315)

