### PR TITLE
Reflect name on inputs and various other components

### DIFF
--- a/src/components/checkbox/index.tsx
+++ b/src/components/checkbox/index.tsx
@@ -14,7 +14,7 @@ export class SmoothlyCheckbox implements Clearable {
 	@Prop({ mutable: true, reflect: true }) intermediate = false
 	@Prop({ reflect: true }) unavailable = false
 	@Prop({ reflect: true }) disabled = false
-	@Prop() name: string
+	@Prop({ reflect: true }) name: string
 	@Prop() value: any
 	@Event() smoothlyInput: EventEmitter<Record<string, any>>
 	@State() t: langly.Translate

--- a/src/components/form/index.tsx
+++ b/src/components/form/index.tsx
@@ -35,7 +35,7 @@ export class SmoothlyForm implements ComponentWillLoad, Clearable, Submittable, 
 	@Prop() type?: "update" | "change" | "fetch" | "create" = this.action ? "create" : undefined
 	@Prop({ mutable: true }) readonly = false
 	@Prop({ reflect: true, attribute: "looks" }) looks?: Looks
-	@Prop() name?: string
+	@Prop({ reflect: true }) name?: string
 	@Prop() prevent = true
 	@Prop({ mutable: true }) changed = false
 	@State() processing?: Promise<boolean>

--- a/src/components/frame/index.tsx
+++ b/src/components/frame/index.tsx
@@ -8,7 +8,7 @@ import { Message, Trigger } from "../../model"
 })
 export class SmoothlyFrame {
 	@Prop() url: string
-	@Prop() name: string
+	@Prop({ reflect: true }) name: string
 	@Event() trigger: EventEmitter<Trigger>
 	@Event() message2: EventEmitter<Message<any>>
 	@Element() element?: HTMLElement

--- a/src/components/input/checkbox/index.tsx
+++ b/src/components/input/checkbox/index.tsx
@@ -14,7 +14,7 @@ export class SmoothlyInputCheckbox implements Input, Clearable, Editable, Compon
 	private initialValue?: any
 	private listener: { changed?: (parent: Editable) => Promise<void> } = {}
 	private mouseDownPosition?: { x: number; y: number }
-	@Prop() name: string
+	@Prop({ reflect: true }) name: string
 	@Prop({ mutable: true }) changed = false
 	@Prop({ reflect: true, mutable: true }) readonly = false
 	@Prop({ mutable: true }) checked = false

--- a/src/components/input/color/index.tsx
+++ b/src/components/input/color/index.tsx
@@ -38,7 +38,7 @@ export class SmoothlyInputColor implements Input, Clearable, Editable, Component
 	@Prop({ mutable: true }) changed = false
 	@Prop({ reflect: true, mutable: true }) readonly = false
 	@Prop() output: "rgb" | "hex" = "rgb"
-	@Prop() name: string
+	@Prop({ reflect: true }) name: string
 	@Prop({ reflect: true }) showLabel = true
 	@Element() element: HTMLSmoothlyInputColorElement
 	@State() open = false

--- a/src/components/input/date/range/index.tsx
+++ b/src/components/input/date/range/index.tsx
@@ -14,7 +14,7 @@ import { Color, Data } from "./../../../../model"
 })
 export class SmoothlyInputDateRange implements Clearable, Input, Editable {
 	@Element() element: HTMLElement
-	@Prop() name: string = "dateRange"
+	@Prop({ reflect: true }) name: string = "dateRange"
 	@Prop({ reflect: true, mutable: true }) color?: Color
 	@Prop({ reflect: true, mutable: true }) looks?: Looks
 	@Prop({ reflect: true, mutable: true }) readonly = false

--- a/src/components/input/month/index.tsx
+++ b/src/components/input/month/index.tsx
@@ -31,7 +31,7 @@ export class SmoothlyInputMonth implements ComponentWillLoad, Input, Editable {
 	@Prop({ reflect: true, mutable: true }) readonly: boolean
 	@Prop({ reflect: true }) color?: Color
 	@Prop({ reflect: true, mutable: true }) looks?: Looks
-	@Prop() name: string
+	@Prop({ reflect: true }) name: string
 	@Prop({ mutable: true }) value?: isoly.Date = isoly.Date.now()
 	@Prop({ reflect: true }) next = false
 	@Prop({ reflect: true }) previous = false

--- a/src/components/input/radio/index.tsx
+++ b/src/components/input/radio/index.tsx
@@ -34,7 +34,7 @@ export class SmoothlyInputRadio implements Input, Clearable, Editable, Component
 	@Prop({ reflect: true, mutable: true }) color?: Color
 	@Prop() clearable?: boolean
 	@Prop({ mutable: true, reflect: true }) readonly = false
-	@Prop() name: string
+	@Prop({ reflect: true }) name: string
 	@Prop({ reflect: true }) showLabel = true
 	@Event() smoothlyInputLooks: EventEmitter<(looks?: Looks, color?: Color) => void>
 	@Event() smoothlyInput: EventEmitter<Data>

--- a/src/components/input/range/index.tsx
+++ b/src/components/input/range/index.tsx
@@ -38,7 +38,7 @@ export class SmoothlyInputRange implements Input, Clearable, Editable, Component
 	@Prop() type: Extract<tidily.Type, "text" | "percent"> = "text"
 	@Prop() min = 0
 	@Prop() max = 100
-	@Prop() name = "range"
+	@Prop({ reflect: true }) name = "range"
 	@Prop() step?: number
 	@Prop() outputSide: "right" | "left" = "left"
 	@Prop() label: string

--- a/src/components/input/select/index.tsx
+++ b/src/components/input/select/index.tsx
@@ -36,7 +36,7 @@ export class SmoothlyInputSelect implements Input, Editable, Clearable, Componen
 	private itemHeight: number | undefined
 	@Element() element: HTMLSmoothlyInputSelectElement
 	@Prop() invalid?: boolean = false
-	@Prop() name = "selected"
+	@Prop({ reflect: true }) name = "selected"
 	@Prop({ reflect: true, mutable: true }) color?: Color
 	@Prop({ reflect: true, mutable: true }) looks?: Looks
 	@Prop({ reflect: true }) showLabel = true

--- a/src/components/table/header/index.tsx
+++ b/src/components/table/header/index.tsx
@@ -6,7 +6,7 @@ import { Component, h, Host, Prop } from "@stencil/core"
 	scoped: true,
 })
 export class TableHeader {
-	@Prop() name: string
+	@Prop({ reflect: true }) name: string
 	render() {
 		return (
 			<Host>


### PR DESCRIPTION
This way you can rely on styling based on `smoothly-input-thing[name="my.name"]` instead of having to add extra classes.
At least that is on option.