### PR TITLE
Input refactored

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -239,7 +239,7 @@ export namespace Components {
         "disabled": boolean;
         "edit": (editable: boolean) => Promise<void>;
         "errorMessage"?: string;
-        "getValue": () => Promise<any | undefined>;
+        "getValue": () => Promise<any>;
         "invalid"?: boolean;
         "listen": (property: "changed", listener: (parent: Editable) => Promise<void>) => Promise<void>;
         "looks"?: Looks;

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -239,7 +239,7 @@ export namespace Components {
         "disabled": boolean;
         "edit": (editable: boolean) => Promise<void>;
         "errorMessage"?: string;
-        "getValue": () => Promise<any>;
+        "getValue": () => Promise<any | undefined>;
         "invalid"?: boolean;
         "listen": (property: "changed", listener: (parent: Editable) => Promise<void>) => Promise<void>;
         "looks"?: Looks;

--- a/src/components/input/Deep.spec.ts
+++ b/src/components/input/Deep.spec.ts
@@ -1,0 +1,18 @@
+import { Deep } from "./Deep"
+
+describe("Deep", () => {
+	it.each([
+		[1, 1, true],
+		[1, 2, false],
+		[{ a: 1 }, { a: 1 }, true],
+		[{ a: 1 }, { a: 2 }, false],
+		[{ a: 1 }, { b: 1 }, false],
+		[{ a: 1 }, { b: 2 }, false],
+		[{ a: 1, b: 2 }, { a: 1, b: 2 }, true],
+		[{ a: 1, b: 2 }, { a: 1, b: 3 }, false],
+		[{ a: 1, b: 2 }, { a: 1, c: 2 }, false],
+	])("equal(%p, %p)", (a: any, b: any, isEqual: boolean) => {
+		expect(Deep.equal(a, b)).toEqual(isEqual)
+		expect(Deep.notEqual(a, b)).toEqual(!isEqual)
+	})
+})

--- a/src/components/input/Deep.ts
+++ b/src/components/input/Deep.ts
@@ -1,0 +1,15 @@
+export namespace Deep {
+	export function equal(a: any, b: any): boolean {
+		if (a === b)
+			return true
+		if (typeof a == "object" && typeof b == "object") {
+			const keys = Object.keys(a)
+			if (keys.length == Object.keys(b).length && keys.every(key => equal(a[key], b[key])))
+				return true
+		}
+		return false
+	}
+	export function notEqual(a: any, b: any): boolean {
+		return !equal(a, b)
+	}
+}

--- a/src/components/input/InputStateHandler.ts
+++ b/src/components/input/InputStateHandler.ts
@@ -5,19 +5,11 @@ import { Adjacent } from "./Adjacent"
 type Formatter = tidily.Formatter & tidily.Converter<any>
 type Handler<E extends Event> = (event: E, unformatted: tidily.State, formatted: tidily.State) => tidily.State
 
-/**
-Alternative names:
-- EventToStateHandler
-- EventHandler
-- InputStateManager
-- InputHandler
-- InputStateController
- */
-export class Action {
+export class InputStateHandler {
 	constructor(private formatter: Formatter, private type: tidily.Type) {}
-	static create(type: "price", priceOptions: { currency?: isoly.Currency; toInteger?: boolean }): Action
-	static create(type: tidily.Type, locale?: isoly.Locale): Action
-	static create(type: tidily.Type, extra?: any): Action {
+	static create(type: "price", priceOptions: { currency?: isoly.Currency; toInteger?: boolean }): InputStateHandler
+	static create(type: tidily.Type, locale?: isoly.Locale): InputStateHandler
+	static create(type: tidily.Type, extra?: any): InputStateHandler {
 		let result: (tidily.Formatter & tidily.Converter<any>) | undefined
 		switch (type) {
 			case "price":
@@ -28,7 +20,7 @@ export class Action {
 				break
 		}
 		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-		return new Action(result || tidily.get("text")!, type)
+		return new InputStateHandler(result || tidily.get("text")!, type)
 	}
 
 	public onKeyDown(

--- a/src/components/input/index.tsx
+++ b/src/components/input/index.tsx
@@ -47,7 +47,7 @@ export class SmoothlyInput implements Clearable, Input, Editable {
 	@Event() smoothlyInput: EventEmitter<Record<string, any>>
 
 	@Method()
-	async getValue(): Promise<any> {
+	async getValue(): Promise<any | undefined> {
 		return this.stateHandler.getValue(this.state)
 	}
 	@Method()

--- a/src/components/input/index.tsx
+++ b/src/components/input/index.tsx
@@ -4,6 +4,7 @@ import { tidily } from "tidily"
 import { Color } from "../../model"
 import { getLocale } from "../../model/getLocale"
 import { Clearable } from "./Clearable"
+import { Deep } from "./Deep"
 import { Editable } from "./Editable"
 import { Input } from "./Input"
 import { InputStateHandler } from "./InputStateHandler"
@@ -111,7 +112,7 @@ export class SmoothlyInput implements Clearable, Input, Editable {
 	@Watch("value")
 	valueChange(value: any) {
 		const lastValue = this.stateHandler.getValue(this.state)
-		if (lastValue != value && this.inputElement) {
+		if (Deep.notEqual(lastValue, value) && this.inputElement) {
 			this.state = this.stateHandler.setValue(this.inputElement, this.state, value)
 			this.smoothlyInput.emit({ [this.name]: this.stateHandler.getValue(this.state) })
 		}
@@ -132,7 +133,7 @@ export class SmoothlyInput implements Clearable, Input, Editable {
 	}
 	componentDidLoad() {
 		if (this.inputElement)
-			this.state = this.stateHandler.setValue(this.inputElement, this.state, this.value)
+			this.inputElement.value = this.state.value
 	}
 	async disconnectedCallback() {
 		if (!this.element.isConnected)
@@ -178,7 +179,7 @@ export class SmoothlyInput implements Clearable, Input, Editable {
 							this.state = this.stateHandler.onBlur(event, this.state)
 							this.smoothlyBlur.emit()
 							this.smoothlyInput.emit({ [this.name]: this.stateHandler.getValue(this.state) })
-							if (lastValue != this.stateHandler.getValue(this.state))
+							if (Deep.notEqual(lastValue, this.stateHandler.getValue(this.state)))
 								this.smoothlyChange.emit({ [this.name]: this.stateHandler.getValue(this.state) })
 						}}
 					/>

--- a/src/components/input/index.tsx
+++ b/src/components/input/index.tsx
@@ -32,12 +32,11 @@ export class SmoothlyInput implements Clearable, Input, Editable {
 	@Prop({ reflect: true }) invalid?: boolean = false
 	@Prop({ mutable: true }) changed = false
 	@Prop() errorMessage?: string
-	@State() formatter: tidily.Formatter & tidily.Converter<any>
+	@State() action: Action
 	@State() initialValue?: any
 	@State() state: Readonly<tidily.State> & Readonly<tidily.Settings>
 	parent: Editable | undefined
-	private inputElement: HTMLInputElement
-	private lastValue: any
+	private inputElement: HTMLInputElement | undefined
 	private uneditable = this.readonly
 	private listener: { changed?: (parent: Editable) => Promise<void> } = {}
 	@Event() smoothlyInputLooks: EventEmitter<(looks?: Looks, color?: Color) => void>
@@ -48,8 +47,8 @@ export class SmoothlyInput implements Clearable, Input, Editable {
 	@Event() smoothlyInput: EventEmitter<Record<string, any>>
 
 	@Method()
-	async getValue(): Promise<any | undefined> {
-		return this.value
+	async getValue(): Promise<any> {
+		return this.action.getValue(this.state)
 	}
 	@Method()
 	async listen(property: "changed", listener: (parent: Editable) => Promise<void>): Promise<void> {
@@ -83,7 +82,7 @@ export class SmoothlyInput implements Clearable, Input, Editable {
 		this.smoothlyInput.emit({ [this.name]: await this.getValue() })
 	}
 	@Listen("smoothlyInputLoad")
-	async SmoothlyInputLoadHandler(event: CustomEvent<(parent: SmoothlyInput) => void>): Promise<void> {
+	async smoothlyInputLoadHandler(event: CustomEvent<(parent: SmoothlyInput) => void>): Promise<void> {
 		if (!(event.target && "name" in event.target && event.target.name == this.name)) {
 			event.stopPropagation()
 			event.detail(this)
@@ -92,62 +91,35 @@ export class SmoothlyInput implements Clearable, Input, Editable {
 	@Watch("currency")
 	@Watch("type")
 	typeChange(): void {
-		let result: (tidily.Formatter & tidily.Converter<any>) | undefined
 		switch (this.type) {
 			case "price":
-				result = tidily.get("price", { currency: this.currency, toInteger: this.toInteger })
+				this.action = Action.create("price", { currency: this.currency, toInteger: this.toInteger })
 				break
 			default:
-				result = tidily.get(this.type, getLocale())
+				this.action = Action.create(this.type, getLocale())
 				break
 		}
-
-		// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-		this.formatter = result || tidily.get("text")!
-		if (this.state)
-			this.state = this.formattedState(this.state)
+		this.state = this.action.initialState(this.value)
+	}
+	@Watch("state")
+	stateChange() {
+		this.smoothlyInput.emit({ [this.name]: this.action.getValue(this.state) })
 	}
 	@Watch("value")
-	async valueChange(value: any, before: any) {
-		this.changed = this.initialValue !== this.value
-		if (this.lastValue != value) {
-			this.lastValue = value
-			this.state = {
-				...this.state,
-				value: this.formattedState({ value: this.formatter.toString(value), selection: this.state.selection }).value,
-			}
+	valueChange(value: any) {
+		const lastValue = this.action.getValue(this.state)
+		if (lastValue != value && this.inputElement) {
+			this.state = this.action.setValue(this.inputElement, this.state, value)
+			this.smoothlyInput.emit({ [this.name]: this.action.getValue(this.state) })
 		}
-		if (value != before)
-			this.smoothlyInput.emit({ [this.name]: await this.getValue() })
-		this.listener.changed?.(this)
 	}
 	@Watch("readonly")
 	readonlyChange() {
 		this.listener.changed?.(this)
 	}
-	@Watch("currency")
-	currencyChange() {
-		this.state = {
-			...this.state,
-			value: this.formattedState({
-				value: this.formatter.toString(this.value),
-				selection: this.state.selection,
-			}).value,
-			pattern: this.formattedState({
-				value: this.formatter.toString(this.value),
-				selection: this.state.selection,
-			}).pattern,
-		}
-	}
 	componentWillLoad() {
 		this.typeChange()
-		const value = this.formatter.toString(this.value) || ""
-		this.lastValue = this.initialValue = this.value
-		const start = value.length
-		this.state = this.formattedState({
-			value,
-			selection: { start, end: start, direction: "none" },
-		})
+		this.initialValue = this.value
 		this.smoothlyInputLooks.emit(
 			(looks, color) => ((this.looks = this.looks ?? looks), !this.color && (this.color = color))
 		)
@@ -155,140 +127,18 @@ export class SmoothlyInput implements Clearable, Input, Editable {
 		!this.readonly && this.smoothlyFormDisable.emit(readonly => (this.readonly = readonly))
 		this.listener.changed?.(this)
 	}
+	componentDidLoad() {
+		if (this.inputElement)
+			this.state = this.action.setValue(this.inputElement, this.state, this.value)
+	}
 	async disconnectedCallback() {
 		if (!this.element.isConnected)
 			await this.unregister()
 	}
-	private partialFormattedState(state: tidily.State) {
-		return this.formatter.partialFormat(
-			tidily.StateEditor.copy(this.formatter.unformat(tidily.StateEditor.copy(state)))
-		)
-	}
-	private formattedState(state: tidily.State) {
-		return this.formatter.format(tidily.StateEditor.copy(this.formatter.unformat(tidily.StateEditor.copy(state))))
-	}
-	onBlur(_: FocusEvent) {
-		this.state = this.formattedState(this.state)
-		this.smoothlyBlur.emit()
-		const value = typeof this.value == "string" ? this.value.trim() : this.value
-		this.smoothlyInput.emit({ [this.name]: value })
-		if (this.initialValue != this.value)
-			this.smoothlyChange.emit({ [this.name]: this.value })
-	}
-	onFocus(event: FocusEvent) {
-		const after = this.partialFormattedState(this.state)
-		if (event.target)
-			this.updateBackend(after, event.target as HTMLInputElement, false)
-	}
-	onClick(event: MouseEvent) {
-		const backend = event.target as HTMLInputElement
-		this.state = {
-			...this.state,
-			value: backend.value,
-			selection: {
-				start: backend.selectionStart ?? backend.value.length,
-				end: backend.selectionEnd ?? backend.value.length,
-				direction: backend.selectionDirection ?? "none",
-			},
-		}
-		const after = this.partialFormattedState({ ...this.state })
-		this.updateBackend(after, backend)
-	}
-	onKeyDown(event: KeyboardEvent) {
-		if (event.key && !(event.key == "Unidentified")) {
-			const backend = event.target as HTMLInputElement
-			this.state = {
-				...this.state,
-				value: backend.value,
-				selection: {
-					start: backend.selectionStart ?? backend.value.length,
-					end: backend.selectionEnd ?? backend.value.length,
-					direction: backend.selectionDirection ?? "none",
-				},
-			}
-			if (
-				(!((event.ctrlKey || event.metaKey) && (event.key == "v" || event.key == "x" || event.key == "c")) &&
-					event.key.length == 1) ||
-				event.key == "ArrowLeft" ||
-				event.key == "ArrowRight" ||
-				event.key == "Delete" ||
-				event.key == "Backspace" ||
-				event.key == "Home" ||
-				event.key == "End"
-			) {
-				event.preventDefault()
-				this.processKey(event, backend, "partial")
-			} else if (event.key == "ArrowUp" || event.key == "ArrowDown")
-				event.preventDefault()
-			else if (event.key == "Enter")
-				this.smoothlyBlur.emit()
-		}
-	}
-	onPaste(event: ClipboardEvent) {
-		event.preventDefault()
-		let pasted = event.clipboardData ? event.clipboardData.getData("text") : ""
-		const backend = event.target as HTMLInputElement
-		pasted = this.expiresAutocompleteFix(backend, pasted)
-		this.processPaste(pasted, backend)
-	}
-	onInput(event: InputEvent) {
-		if (event.inputType == "insertReplacementText") {
-			this.processKey({ key: "a", ctrlKey: true }, event.target as HTMLInputElement, "partial")
-			;[...(event.data ?? "")].forEach(c => this.processKey({ key: c }, event.target as HTMLInputElement, "partial"))
-		} else {
-			const backend = event.target as HTMLInputElement
-			let data = backend.value
-			if (data) {
-				event.preventDefault()
-				this.processKey({ key: "a", ctrlKey: true }, backend, "partial")
-				data = this.expiresAutocompleteFix(backend, data)
-				for (const letter of data)
-					this.processKey({ key: letter }, backend, "partial")
-			}
-		}
-	}
-	private expiresAutocompleteFix(backend: HTMLInputElement, value: string) {
-		if (backend.attributes.getNamedItem("autocomplete")?.value == "cc-exp")
-			value = value.match(/^20\d\d[.\D]*\d\d$/)
-				? value.substring(value.length - 2, value.length) + value.substring(2, 4)
-				: value.match(/^(1[3-9]|[2-9]\d)[.\D]*\d\d$/)
-				? value.substring(value.length - 2, value.length) + value.substring(0, 2)
-				: value.match(/^\d\d[.\D]*20\d\d$/)
-				? value.substring(0, 2) + value.substring(value.length - 2, value.length)
-				: value
-		return value
-	}
-	private processPaste(pasted: string, backend: HTMLInputElement) {
-		if (!this.readonly) {
-			const after = Action.paste(this.formatter, this.state, "partial", pasted)
-			this.updateBackend(after, backend)
-		}
-	}
-	private processKey(event: Action, backend: HTMLInputElement, formatted: "formatted" | "partial") {
-		if (!this.readonly) {
-			const after = Action.apply(this.formatter, this.state, formatted, event)
-			this.updateBackend(after, backend)
-		}
-	}
-	private updateBackend(
-		after: Readonly<tidily.State> & Readonly<tidily.Settings>,
-		backend: HTMLInputElement,
-		setSelection = true
-	) {
-		if (after.value != backend.value)
-			backend.value = after.value
-		if (setSelection) {
-			if (backend.selectionStart != undefined && after.selection.start != backend.selectionStart)
-				backend.selectionStart = after.selection.start
-			if (backend.selectionEnd != undefined && after.selection.end != backend.selectionEnd)
-				backend.selectionEnd = after.selection.end
-			if (backend.selectionDirection != null)
-				backend.selectionDirection = after.selection.direction ?? backend.selectionDirection
-		}
-		this.state = after
-		this.value = this.lastValue = this.formatter.fromString(
-			this.formatter.unformat(tidily.StateEditor.copy({ ...this.state })).value
-		)
+	@Listen("input")
+	@Listen("beforeinput")
+	onEvent(event: InputEvent) {
+		this.state = this.action.onInputEvent(event, this.state)
 	}
 
 	render() {
@@ -314,13 +164,9 @@ export class SmoothlyInput implements Clearable, Input, Editable {
 						disabled={this.disabled}
 						readOnly={this.readonly}
 						pattern={this.state?.pattern && this.state?.pattern.source}
-						value={this.state?.value}
-						onInput={e => this.onInput(e)}
-						onFocus={e => this.onFocus(e)}
-						onClick={e => this.onClick(e)}
-						onBlur={e => this.onBlur(e)}
-						onKeyDown={e => this.onKeyDown(e)}
-						onPaste={e => this.onPaste(e)}
+						onKeyDown={event => (this.state = this.action.onKeyDown(event, this.state))}
+						onFocus={event => (this.state = this.action.onFocus(event, this.state))}
+						onBlur={event => (this.state = this.action.onBlur(event, this.state))}
 					/>
 					<label class={"label float-on-focus"} htmlFor={this.name}>
 						<slot />

--- a/src/components/input/index.tsx
+++ b/src/components/input/index.tsx
@@ -164,9 +164,20 @@ export class SmoothlyInput implements Clearable, Input, Editable {
 						disabled={this.disabled}
 						readOnly={this.readonly}
 						pattern={this.state?.pattern && this.state?.pattern.source}
-						onKeyDown={event => (this.state = this.action.onKeyDown(event, this.state))}
+						onKeyDown={event => {
+							this.state = this.action.onKeyDown(event, this.state)
+							if (event.key == "Enter")
+								this.smoothlyBlur.emit() // TODO: this should be replaced by a smoothlyKeydown event
+						}}
 						onFocus={event => (this.state = this.action.onFocus(event, this.state))}
-						onBlur={event => (this.state = this.action.onBlur(event, this.state))}
+						onBlur={event => {
+							const lastValue = this.action.getValue(this.state)
+							this.state = this.action.onBlur(event, this.state)
+							this.smoothlyBlur.emit()
+							this.smoothlyInput.emit({ [this.name]: this.action.getValue(this.state) })
+							if (lastValue != this.action.getValue(this.state))
+								this.smoothlyChange.emit({ [this.name]: this.action.getValue(this.state) })
+						}}
 					/>
 					<label class={"label float-on-focus"} htmlFor={this.name}>
 						<slot />


### PR DESCRIPTION
This change will handle `event.inputType` (like `"insertText"`, `"insertFromPaste"`,`"deleteContentBackward"`) on `"input"` and `"beforeinput"` events instead, of handling keydown events. 
Keydown events are only handled where needed, which is for arrowLeft/Right to know how much to move the cursor.

The state change logic is also completely moved to it's own `InputStateHandler` class.