### PR TITLE
Improved input-month - min/max + ordered select

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -405,6 +405,8 @@ export namespace Components {
         "inCalendar": boolean;
         "listen": (property: "changed", listener: (parent: Editable) => Promise<void>) => Promise<void>;
         "looks"?: Looks;
+        "max": isoly.Date;
+        "min": isoly.Date;
         "name": string;
         "next": boolean;
         "previous": boolean;
@@ -2784,6 +2786,8 @@ declare namespace LocalJSX {
         "color"?: Color;
         "inCalendar"?: boolean;
         "looks"?: Looks;
+        "max"?: isoly.Date;
+        "min"?: isoly.Date;
         "name"?: string;
         "next"?: boolean;
         "onSmoothlyFormDisable"?: (event: SmoothlyInputMonthCustomEvent<(disabled: boolean) => void>) => void;

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -494,6 +494,7 @@ export namespace Components {
         "multiple": boolean;
         "mutable": boolean;
         "name": string;
+        "ordered"?: boolean;
         "placeholder"?: string | any;
         "readonly": boolean;
         "register": () => Promise<void>;
@@ -2867,6 +2868,7 @@ declare namespace LocalJSX {
         "onSmoothlyInputLoad"?: (event: SmoothlyInputSelectCustomEvent<(parent: Editable) => void>) => void;
         "onSmoothlyInputLooks"?: (event: SmoothlyInputSelectCustomEvent<(looks?: Looks, color?: Color) => void>) => void;
         "onSmoothlyItemSelect"?: (event: SmoothlyInputSelectCustomEvent<HTMLSmoothlyItemElement>) => void;
+        "ordered"?: boolean;
         "placeholder"?: string | any;
         "readonly"?: boolean;
         "required"?: boolean;

--- a/src/components/calendar/generate.ts
+++ b/src/components/calendar/generate.ts
@@ -43,10 +43,14 @@ export function months(current: isoly.Date): { date: isoly.Date; name: string; s
 	}
 	return result
 }
-export function years(current: isoly.Date): { date: isoly.Date; name: string; selected?: boolean }[] {
+export function years(
+	current: isoly.Date,
+	min?: isoly.Date,
+	max?: isoly.Date
+): { date: isoly.Date; name: string; selected?: boolean }[] {
 	const day = new globalThis.Date(current)
-	const start = new Date().getFullYear() - 10
-	const end = new Date().getFullYear() + 10
+	const start = min ? isoly.Date.getYear(min) : new Date().getFullYear() - 50
+	const end = max ? isoly.Date.getYear(max) : new Date().getFullYear() + 50
 	const result: { date: isoly.Date; name: string; selected?: boolean }[] = []
 	for (let i = start; i <= end; i++) {
 		day.setFullYear(i)

--- a/src/components/calendar/index.tsx
+++ b/src/components/calendar/index.tsx
@@ -1,4 +1,4 @@
-import { Component, Element, Event, EventEmitter, h, Prop, State, Watch } from "@stencil/core"
+import { Component, Element, Event, EventEmitter, Fragment, h, Prop, State, Watch } from "@stencil/core"
 import { Date, DateRange } from "isoly"
 import * as generate from "./generate"
 
@@ -64,66 +64,72 @@ export class Calendar {
 		}
 	}
 	render() {
-		return [
-			<smoothly-input-month
-				name="month"
-				value={this.month ?? this.value}
-				inCalendar
-				next
-				previous
-				showLabel={false}
-				onSmoothlyInput={e => {
-					e.stopPropagation()
-					"month" in e.detail && typeof e.detail.month == "string" && (this.month = e.detail.month)
-				}}>
-				<div slot={"year-label"}>
-					<slot name={"year-label"} />
-				</div>
-				<div slot={"month-label"}>
-					<slot name={"month-label"} />
-				</div>
-			</smoothly-input-month>,
-			<table>
-				<thead>
-					<tr>
-						{generate.weekdays().map(day => (
-							<th>{day}</th>
-						))}
-					</tr>
-				</thead>
-				{generate.month(this.month ?? this.value).map(week => (
-					<tr>
-						{week.map(date => (
-							<td
-								tabindex={1}
-								onMouseOver={() => {
-									!this.doubleInput && (this.min || this.max) && (date < this.min || date > this.max)
-										? undefined
-										: this.onHover(date)
-								}}
-								onClick={
-									(this.min || this.max) && (date < this.min || date > this.max) ? undefined : () => this.onClick(date)
-								}
-								class={(date == this.value ? ["selected"] : [])
-									.concat(
-										...(date == Date.now() ? ["today"] : []),
-										Date.firstOfMonth(this.month ?? this.value) == Date.firstOfMonth(date) ? ["currentMonth"] : [],
-										this.doubleInput
-											? this.start == date || this.end == date
-												? ["selected"]
-												: date >= (this.start ?? "") && date <= (this.end ?? "")
-												? ["dateRange"]
-												: []
-											: ""
-									)
-									.concat(...(this.min || this.max ? (date < this.min || date > this.max ? ["disable"] : []) : ""))
-									.join(" ")}>
-								{date.substring(8, 10)}
-							</td>
-						))}
-					</tr>
-				))}
-			</table>,
-		]
+		return (
+			<Fragment>
+				<smoothly-input-month
+					name="month"
+					value={this.month ?? this.value}
+					min={this.min}
+					max={this.max}
+					inCalendar
+					next
+					previous
+					showLabel={false}
+					onSmoothlyInput={e => {
+						e.stopPropagation()
+						"month" in e.detail && typeof e.detail.month == "string" && (this.month = e.detail.month)
+					}}>
+					<div slot={"year-label"}>
+						<slot name={"year-label"} />
+					</div>
+					<div slot={"month-label"}>
+						<slot name={"month-label"} />
+					</div>
+				</smoothly-input-month>
+				<table>
+					<thead>
+						<tr>
+							{generate.weekdays().map(day => (
+								<th>{day}</th>
+							))}
+						</tr>
+					</thead>
+					{generate.month(this.month ?? this.value).map(week => (
+						<tr>
+							{week.map(date => (
+								<td
+									tabindex={1}
+									onMouseOver={() => {
+										!this.doubleInput && (this.min || this.max) && (date < this.min || date > this.max)
+											? undefined
+											: this.onHover(date)
+									}}
+									onClick={
+										(this.min || this.max) && (date < this.min || date > this.max)
+											? undefined
+											: () => this.onClick(date)
+									}
+									class={(date == this.value ? ["selected"] : [])
+										.concat(
+											...(date == Date.now() ? ["today"] : []),
+											Date.firstOfMonth(this.month ?? this.value) == Date.firstOfMonth(date) ? ["currentMonth"] : [],
+											this.doubleInput
+												? this.start == date || this.end == date
+													? ["selected"]
+													: date >= (this.start ?? "") && date <= (this.end ?? "")
+													? ["dateRange"]
+													: []
+												: ""
+										)
+										.concat(...(this.min || this.max ? (date < this.min || date > this.max ? ["disable"] : []) : ""))
+										.join(" ")}>
+									{date.substring(8, 10)}
+								</td>
+							))}
+						</tr>
+					))}
+				</table>
+			</Fragment>
+		)
 	}
 }

--- a/src/components/input/demo/index.tsx
+++ b/src/components/input/demo/index.tsx
@@ -98,6 +98,16 @@ export class SmoothlyInputDemo {
 								<smoothly-icon size="small" name="camera-outline" />
 							</smoothly-item>
 						</smoothly-input-select>
+						<smoothly-input-select ordered menuHeight="7.5items" placeholder="Select..." name="select-month">
+							<label slot="label">Alphabet ordered select</label>
+							{Array.from({ length: 26 })
+								.map((_, i) => String.fromCharCode(i + 65))
+								.map(char => (
+									<smoothly-item value={char} selected={char == "H"}>
+										{char}
+									</smoothly-item>
+								))}
+						</smoothly-input-select>
 						<smoothly-input-select multiple menuHeight="7.5items" placeholder="Select..." name="select-month">
 							<label slot="label">Month multiple select</label>
 							<smoothly-item value="1">January</smoothly-item>

--- a/src/components/input/month/index.tsx
+++ b/src/components/input/month/index.tsx
@@ -137,7 +137,12 @@ export class SmoothlyInputMonth implements ComponentWillLoad, Input, Editable {
 					size={"tiny"}
 					color={this.color}
 					fill={"default"}
-					class={{ disabled: this.readonly }}
+					class={{
+						disabled:
+							this.readonly ||
+							(!!this.min &&
+								isoly.Date.firstOfMonth(this.min) > isoly.Date.previousMonth(this.value ?? isoly.Date.now())),
+					}}
 					onClick={() => this.adjustMonth(-1)}
 				/>
 				<smoothly-input-select
@@ -189,7 +194,11 @@ export class SmoothlyInputMonth implements ComponentWillLoad, Input, Editable {
 					size={"tiny"}
 					color={this.color}
 					fill={"default"}
-					class={{ disabled: this.readonly }}
+					class={{
+						disabled:
+							this.readonly ||
+							(!!this.max && isoly.Date.lastOfMonth(this.max) < isoly.Date.nextMonth(this.value ?? isoly.Date.now())),
+					}}
 					onClick={() => this.adjustMonth(1)}
 				/>
 			</Host>

--- a/src/components/input/month/index.tsx
+++ b/src/components/input/month/index.tsx
@@ -34,6 +34,8 @@ export class SmoothlyInputMonth implements ComponentWillLoad, Input, Editable {
 	@Prop({ reflect: true, mutable: true }) looks?: Looks
 	@Prop({ reflect: true }) name: string
 	@Prop({ mutable: true }) value?: isoly.Date = isoly.Date.now()
+	@Prop({ mutable: true }) max: isoly.Date
+	@Prop({ mutable: true }) min: isoly.Date
 	@Prop({ reflect: true }) next = false
 	@Prop({ reflect: true }) previous = false
 	@Prop({ reflect: true }) inCalendar = false
@@ -153,7 +155,7 @@ export class SmoothlyInputMonth implements ComponentWillLoad, Input, Editable {
 					<div slot={"label"}>
 						<slot name={"year-label"} />
 					</div>
-					{generate.years(this.value ?? isoly.Date.now()).map(year => (
+					{generate.years(this.value ?? isoly.Date.now(), this.min, this.max).map(year => (
 						<smoothly-item key={year.date} value={year.date} selected={year.selected || this.value == year.date}>
 							{year.name}
 						</smoothly-item>

--- a/src/components/input/month/index.tsx
+++ b/src/components/input/month/index.tsx
@@ -145,6 +145,7 @@ export class SmoothlyInputMonth implements ComponentWillLoad, Input, Editable {
 					changed={this.changed}
 					menuHeight="5.5items"
 					required
+					ordered
 					inCalendar={this.inCalendar}
 					showLabel={this.showLabel}
 					onSmoothlyInput={e => this.inputHandler(e)}
@@ -167,6 +168,7 @@ export class SmoothlyInputMonth implements ComponentWillLoad, Input, Editable {
 					changed={this.changed}
 					menuHeight="5.5items"
 					required
+					ordered
 					inCalendar={this.inCalendar}
 					showLabel={this.showLabel}
 					onSmoothlyInput={e => this.inputHandler(e)}


### PR DESCRIPTION
## Add @Prop min/max to input-month
Also Props `min` and `max` are used to limit the years shown in `smoothly-input-month`.
![image](https://github.com/user-attachments/assets/ff364cfe-ab5e-4865-9670-cbe9a5bfb015)

Is also limits how far you can navigate with the arrows before they get disabled.
![image](https://github.com/user-attachments/assets/d5bbf5ab-cef2-4e72-921f-958b609e11b2)


## Add `@Prop ordered` to `smoothly-input-select`. 
for `<smoothly-input-select ordered multiple={false} >` the select will always scroll down to the selected values.
Also extended the calendar year values to be ±50 years since you no longer have to scroll down far to get to present year.
![image](https://github.com/user-attachments/assets/31f2aa09-c9b3-4f20-9584-0b6a17d6f423)



