### PR TITLE
Change input autocomplete to be literal

### DIFF
--- a/src/components/input/index.tsx
+++ b/src/components/input/index.tsx
@@ -23,7 +23,7 @@ export class SmoothlyInput implements Clearable, Input, Editable {
 	@Prop({ reflect: true }) type: tidily.Type = "text"
 	@Prop({ reflect: true }) required = false
 	@Prop({ reflect: true }) showLabel = true
-	@Prop() autocomplete = true
+	@Prop() autocomplete?: Exclude<tidily.Settings["autocomplete"], undefined>
 	@Prop({ reflect: true }) placeholder: string | undefined
 	@Prop() disabled = false
 	@Prop({ mutable: true, reflect: true }) readonly = false
@@ -310,7 +310,7 @@ export class SmoothlyInput implements Clearable, Input, Editable {
 						inputmode={this.state?.inputmode}
 						placeholder={this.placeholder}
 						required={this.required}
-						autocomplete={this.autocomplete ? this.state?.autocomplete : "off"}
+						autocomplete={this.autocomplete ?? this.state?.autocomplete}
 						disabled={this.disabled}
 						readOnly={this.readonly}
 						pattern={this.state?.pattern && this.state?.pattern.source}


### PR DESCRIPTION
This is to add more flexibility to use the `smoothly-input` component.


Two examples of when you would wanna set `autocomplete` for `password`:
1. If you have a toggle to show and hide password, you might change to type between `"password"` and  `"text"`.
2. When having an input to set password you should use `autocomplete="new-password'` instead of `"current-password"`, this way the browser can suggest to generate a password for you.