### PR TITLE
Summary chrome fix

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -231,7 +231,7 @@ export namespace Components {
     interface SmoothlyIconDemo {
     }
     interface SmoothlyInput {
-        "autocomplete": boolean;
+        "autocomplete"?: Exclude<tidily.Settings["autocomplete"], undefined>;
         "changed": boolean;
         "clear": () => Promise<void>;
         "color"?: Color;
@@ -2455,7 +2455,7 @@ declare namespace LocalJSX {
         "onNotice"?: (event: SmoothlyIconDemoCustomEvent<Notice>) => void;
     }
     interface SmoothlyInput {
-        "autocomplete"?: boolean;
+        "autocomplete"?: Exclude<tidily.Settings["autocomplete"], undefined>;
         "changed"?: boolean;
         "color"?: Color;
         "currency"?: isoly.Currency;

--- a/src/components/summary/index.tsx
+++ b/src/components/summary/index.tsx
@@ -38,10 +38,10 @@ export class SmoothlySummary {
 		return (
 			<details onToggle={e => this.toggleHandler(e)} open={this.open}>
 				<summary>
-					<smoothly-icon name="caret-forward" color={this.color} fill={this.fill} size={this.size}></smoothly-icon>
-					<slot name="summary"></slot>
+					<smoothly-icon name="caret-forward" color={this.color} fill={this.fill} size={this.size} />
+					<slot name="summary" />
 				</summary>
-				<slot name="content"></slot>
+				<slot name="content" />
 			</details>
 		)
 	}

--- a/src/components/summary/style.css
+++ b/src/components/summary/style.css
@@ -33,8 +33,14 @@
 	grid-column: 2;
 }
 
-@media screen and (min-width: 900px) {
-	:host>details>summary:hover {
-		cursor: pointer;
+@media (prefers-reduced-motion) { 
+	:host>details>summary>smoothly-icon {
+		transition: none;
+	}
+}
+ /* chromium specific */
+@supports selector(details::details-content) {
+	:host>details::details-content {
+		grid-column: 2;
 	}
 }


### PR DESCRIPTION
## Also 
- set no transition for `prefers-reduced-motion`
- Remove `cursor` styling for smaller screens, seems unnecessary.

## Bug
![image](https://github.com/user-attachments/assets/b2d897cf-bea9-4e91-b9c5-98e21a52480d)


Showing grid
![image](https://github.com/user-attachments/assets/153c8e4a-98db-437b-a65c-5befb321145a)



## More info about the bug

### Chrome
Chrome as a special pseudo element for `::details-content` that has to be styled for this to work.
You can see this Console settings (3 dots) → preferences → check `Show user agent shadow DOM`
![image](https://github.com/user-attachments/assets/36582346-7a6e-47de-bc7c-9211749b680a)

### Firefox
The equivalent to showing agent shadow DOM in Firefox is going to `about:config` and setting `devtools.inspector.showAllAnonymousContent: true`
![image](https://github.com/user-attachments/assets/af12c333-7891-4206-b15f-947be8369554)


