### PR TITLE
Don't apply input focus within styling for checkbox

### DIFF
--- a/src/components/input/checkbox/style.css
+++ b/src/components/input/checkbox/style.css
@@ -43,3 +43,11 @@
 	border-color: rgb(var(--smoothly-color-contrast), 0.3);
 	color: rgb(var(--smoothly-color-contrast), 0.4);
 }
+
+:host[looks="transparent"] {
+	background-color: transparent;
+}
+/* overwrite shared.css styling */
+:host[looks="transparent"]:not([readonly]):focus-within {
+	outline-color: transparent;
+}


### PR DESCRIPTION

For `<smoothly-input-checkbox looks="transparent" />` when focus-within remove `background-color` and `outline`.
**Before**
![image](https://github.com/user-attachments/assets/32f2a888-48bd-4843-a528-ae35b779e269)

**After**
![image](https://github.com/user-attachments/assets/1d784a31-93ba-4802-9207-c82442f1cdbf)
