### PR TITLE
Input-date-range and calendar fixes

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -89,7 +89,7 @@ export namespace Components {
         "min": Date;
         "month"?: Date;
         "start"?: Date;
-        "value": Date;
+        "value"?: Date;
     }
     interface SmoothlyCheckbox {
         "checked": boolean;

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -394,8 +394,8 @@ export namespace Components {
         "inCalendar": boolean;
         "listen": (property: "changed", listener: (parent: Editable) => Promise<void>) => Promise<void>;
         "looks"?: Looks;
-        "max": isoly.Date;
-        "min": isoly.Date;
+        "max"?: isoly.Date;
+        "min"?: isoly.Date;
         "name": string;
         "next": boolean;
         "previous": boolean;

--- a/src/components/calendar/index.tsx
+++ b/src/components/calendar/index.tsx
@@ -109,20 +109,13 @@ export class Calendar {
 											? undefined
 											: () => this.onClick(date)
 									}
-									class={(date == this.value ? ["selected"] : [])
-										.concat(
-											...(date == Date.now() ? ["today"] : []),
-											Date.firstOfMonth(this.month ?? this.value) == Date.firstOfMonth(date) ? ["currentMonth"] : [],
-											this.doubleInput
-												? this.start == date || this.end == date
-													? ["selected"]
-													: date >= (this.start ?? "") && date <= (this.end ?? "")
-													? ["dateRange"]
-													: []
-												: ""
-										)
-										.concat(...(this.min || this.max ? (date < this.min || date > this.max ? ["disable"] : []) : ""))
-										.join(" ")}>
+									class={{
+										selected: date == this.value || (this.doubleInput && (date == this.start || date == this.end)),
+										today: date == Date.now(),
+										currentMonth: Date.firstOfMonth(this.month ?? this.value ?? Date.now()) == Date.firstOfMonth(date),
+										dateRange: this.doubleInput && date > (this.start ?? "") && date < (this.end ?? ""),
+										disable: (!!this.min && date < this.min) || (!!this.max && date > this.max),
+									}}>
 									{date.substring(8, 10)}
 								</td>
 							))}

--- a/src/components/calendar/index.tsx
+++ b/src/components/calendar/index.tsx
@@ -63,6 +63,9 @@ export class Calendar {
 			}
 		}
 	}
+	private withinLimit(date: Date) {
+		return (!this.min || date >= this.min) && (!this.max || date <= this.max)
+	}
 	render() {
 		return (
 			<Fragment>
@@ -99,22 +102,14 @@ export class Calendar {
 							{week.map(date => (
 								<td
 									tabindex={1}
-									onMouseOver={() => {
-										!this.doubleInput && (this.min || this.max) && (date < this.min || date > this.max)
-											? undefined
-											: this.onHover(date)
-									}}
-									onClick={
-										(this.min || this.max) && (date < this.min || date > this.max)
-											? undefined
-											: () => this.onClick(date)
-									}
+									onMouseOver={() => (this.withinLimit(date) ? this.onHover(date) : undefined)}
+									onClick={this.withinLimit(date) ? () => this.onClick(date) : undefined}
 									class={{
 										selected: date == this.value || (this.doubleInput && (date == this.start || date == this.end)),
 										today: date == Date.now(),
 										currentMonth: Date.firstOfMonth(this.month ?? this.value ?? Date.now()) == Date.firstOfMonth(date),
 										dateRange: this.doubleInput && date > (this.start ?? "") && date < (this.end ?? ""),
-										disable: (!!this.min && date < this.min) || (!!this.max && date > this.max),
+										disable: !this.withinLimit(date),
 									}}>
 									{date.substring(8, 10)}
 								</td>

--- a/src/components/calendar/index.tsx
+++ b/src/components/calendar/index.tsx
@@ -11,7 +11,7 @@ export class Calendar {
 	private frozenDate: Date
 	@Element() element: HTMLTableRowElement
 	@Prop({ mutable: true }) month?: Date
-	@Prop({ mutable: true }) value: Date = Date.now()
+	@Prop({ mutable: true }) value?: Date
 	@Prop({ mutable: true }) start?: Date
 	@Prop({ mutable: true }) end?: Date
 	@Prop({ mutable: true }) max: Date
@@ -94,7 +94,7 @@ export class Calendar {
 							))}
 						</tr>
 					</thead>
-					{generate.month(this.month ?? this.value).map(week => (
+					{generate.month(this.month ?? this.value ?? Date.now()).map(week => (
 						<tr>
 							{week.map(date => (
 								<td

--- a/src/components/calendar/style.css
+++ b/src/components/calendar/style.css
@@ -20,6 +20,7 @@
 	position: relative;
 	padding: 0.5em;
 	min-width: 2em;
+	box-sizing: border-box;
 	background-color: rgb(var(--smoothly-input-background));
 	color:rgb(var(--smoothly-input-foreground));
 	cursor: pointer;
@@ -63,7 +64,7 @@
 
 :host>table>tr>td.today::before {
 	content: "";
-	inset: 1px;
+	inset: 2px;
 	position: absolute;
 	border: 1px solid currentColor;
 }

--- a/src/components/calendar/style.css
+++ b/src/components/calendar/style.css
@@ -17,14 +17,17 @@
 :host>table>thead>tr>th,
 :host>table>tr>td {
 	text-align: center;
-	position: relative;
 	padding: 0.5em;
 	min-width: 2em;
 	box-sizing: border-box;
 	background-color: rgb(var(--smoothly-input-background));
-	color:rgb(var(--smoothly-input-foreground));
-	cursor: pointer;
+	color: rgb(var(--smoothly-input-foreground));
+	-webkit-user-select: none;
 	user-select: none;
+}
+:host>table>tr>td {
+	position: relative;
+	cursor: pointer;
 }
 
 :host>table>tr>td.currentMonth {

--- a/src/components/calendar/style.css
+++ b/src/components/calendar/style.css
@@ -17,6 +17,7 @@
 :host>table>thead>tr>th,
 :host>table>tr>td {
 	text-align: center;
+	position: relative;
 	padding: 0.5em;
 	min-width: 2em;
 	background-color: rgb(var(--smoothly-input-background));
@@ -60,9 +61,11 @@
 	background: rgb(var(--smoothly-primary-color));
 }
 
-:host>table>tr>td:not(.selected, .dateRange):not(:hover).today {
-	background: rgb(var(--smoothly-medium-tint));
-	color: rgb(var(--smoothly-medium-contrast));
+:host>table>tr>td.today::before {
+	content: "";
+	inset: 1px;
+	position: absolute;
+	border: 1px solid currentColor;
 }
 
 :host>table>tr>td.dateRange {

--- a/src/components/input/date/index.tsx
+++ b/src/components/input/date/index.tsx
@@ -153,7 +153,7 @@ export class SmoothlyInputDate implements ComponentWillLoad, Clearable, Input, E
 					<nav>
 						<smoothly-calendar
 							doubleInput={false}
-							value={this.value ?? Date.now()}
+							value={this.value}
 							onSmoothlyValueChange={event => {
 								this.value = event.detail
 								event.stopPropagation()

--- a/src/components/input/date/range/style.scss
+++ b/src/components/input/date/range/style.scss
@@ -2,7 +2,6 @@
 
 :host {
 	position: relative;
-	cursor: pointer;
 	display: flex;
 	background-color: rgb(var(--smoothly-input-background));
 

--- a/src/components/input/date/range/style.scss
+++ b/src/components/input/date/range/style.scss
@@ -4,7 +4,6 @@
 	position: relative;
 	cursor: pointer;
 	display: flex;
-	width: fit-content;
 	background-color: rgb(var(--smoothly-input-background));
 
 	&:focus-within smoothly-input {

--- a/src/components/input/date/style.css
+++ b/src/components/input/date/style.css
@@ -3,7 +3,6 @@
 :host {
 	display: flex;
 	position: relative;
-	cursor: pointer;
 	max-width: 100vw;
 	background-color: rgb(var(--smoothly-input-background));
 	box-sizing: border-box;

--- a/src/components/input/demo/index.tsx
+++ b/src/components/input/demo/index.tsx
@@ -22,8 +22,8 @@ export class SmoothlyInputDemo {
 						name="testing"
 						start={isoly.Date.now()}
 						end={isoly.Date.nextMonth(isoly.Date.now())}
-						min="2021-10-10"
-						max="2024-12-30"></smoothly-input-date-range>
+						min="2021-10-01"
+						max="2025-01-31"></smoothly-input-date-range>
 					<smoothly-input-date-range
 						name="testing"
 						start={isoly.Date.now()}

--- a/src/components/input/month/style.css
+++ b/src/components/input/month/style.css
@@ -23,14 +23,11 @@
 :host>smoothly-icon {
 	display: flex;
 	align-self: center;
-}
-:host >smoothly-icon.disabled {
-	opacity: 0.5;
-	pointer-events: none;
-}
-:host >smoothly-icon:hover,
-:host >div>smoothly-input-select>*:hover {
 	cursor: pointer;
+}
+:host>smoothly-icon.disabled {
+	opacity: 0.5;
+	cursor: not-allowed;
 }
 
 


### PR DESCRIPTION
- Mark today's date with a border, instead of background - this is to not confuse the user into thinking today is selected.
- Make date-range input full width
- Clean up whacky class array concat on calendar component
- Only show `cursor: pointer` on intractable elements and not on the whole calendar


### Before
<table>
<tr>
<td><img src=https://github.com/user-attachments/assets/be388407-d77b-48ca-b8e8-4823d5c86b46 /></td>
<td><img src=https://github.com/user-attachments/assets/40b0d7af-307b-404d-89bb-eff11da04658 /></td>
</tr>
</table>

### After

<table>
<tr>
<td><img src=https://github.com/user-attachments/assets/2de841a0-ada7-445c-8e87-84245b302ca8 /></td>
<td><img src=https://github.com/user-attachments/assets/d5a45f44-0a0c-4fe0-a5df-47b576ab6c93 /></td>
</tr>
</table>
