### PR TITLE
Add table-detail-border to next-table

### DIFF
--- a/src/assets/style/mapping.css
+++ b/src/assets/style/mapping.css
@@ -16,6 +16,7 @@ smoothly-color {
 	--smoothly-table-hover-background: var(--smoothly-color-tint);
 
 	--smoothly-table-border: var(--smoothly-color-shade);
+	--smoothly-table-detail-border: var(--smoothly-color-tint);
 
 	--smoothly-table-expanded-foreground: var(--smoothly-default-contrast);
 	--smoothly-table-expanded-background: var(--smoothly-default-tint);

--- a/src/components/next/table/expandable/cell/style.scss
+++ b/src/components/next/table/expandable/cell/style.scss
@@ -68,7 +68,7 @@
 	left: -1em;
 	width: 1em;
 	background-color: rgb(var(--smoothly-table-expanded-background));
-	border-left: 0.3em solid rgb(var(--smoothly-table-border));
+	border-left: 0.3em solid rgb(var(--smoothly-table-detail-border, var(--smoothly-table-border)));
 	box-shadow: 2px 0px 0px 0px rgb(var(--smoothly-table-expanded-background)),
 		0px 0px 1px 0px rgb(var(--smoothly-table-border));
 }

--- a/src/components/next/table/expandable/row/style.scss
+++ b/src/components/next/table/expandable/row/style.scss
@@ -63,7 +63,7 @@
 	left: -1em;
 	width: 1em;
 	background-color: rgb(var(--smoothly-table-expanded-background));
-	border-left: 0.3em solid rgb(var(--smoothly-table-border));
+	border-left: 0.3em solid rgb(var(--smoothly-table-detail-border, var(--smoothly-table-border)));
 	box-shadow: 2px 0px 0px 0px rgb(var(--smoothly-table-expanded-background)),
 		0px 0px 1px 0px rgb(var(--smoothly-table-border));
 }


### PR DESCRIPTION
Can set the detail border a different color.

`--smoothly-table-border` can still be used to se this color, since it's a fallback, if `--smoothly-table-detail-border` is not defined.


![image](https://github.com/user-attachments/assets/9294a8ff-b193-4c4d-a02b-ecd6d1afa26d)

![image](https://github.com/user-attachments/assets/a6670d3b-a050-4675-8545-65e49c767293)
