### PR TITLE
Fix chrome autofill bug

### DIFF
--- a/src/components/input/InputStateHandler.ts
+++ b/src/components/input/InputStateHandler.ts
@@ -144,6 +144,8 @@ export class InputStateHandler {
 				this.type == "password" ? { ...state, value: (event.target as HTMLInputElement).value } : state,
 			deleteWordForward: (event, state) =>
 				this.type == "password" ? { ...state, value: (event.target as HTMLInputElement).value } : state,
+			// Chrome will dispatch an input event without inputType when auto-filling
+			undefined: (event, state) => ({ ...state, value: (event.target as HTMLInputElement).value }),
 		},
 	}
 


### PR DESCRIPTION
When Chrome autofills it will send an input event, without `event.inputType` set. 
This is the fix :)

## Bug
[Screencast from 2024-12-05 15:07:57.webm](https://github.com/user-attachments/assets/9cf87653-b5ea-46cc-abbd-a0b4babd8e24)
