### PR TITLE
Don't alter state in readonly mode

### DIFF
--- a/src/components/input/index.tsx
+++ b/src/components/input/index.tsx
@@ -173,14 +173,16 @@ export class SmoothlyInput implements Clearable, Input, Editable {
 							if (event.key == "Enter")
 								this.smoothlyBlur.emit() // TODO: this should be replaced by a smoothlyKeydown event
 						}}
-						onFocus={event => (this.state = this.stateHandler.onFocus(event, this.state))}
+						onFocus={event => !this.readonly && (this.state = this.stateHandler.onFocus(event, this.state))}
 						onBlur={event => {
-							const lastValue = this.stateHandler.getValue(this.state)
-							this.state = this.stateHandler.onBlur(event, this.state)
-							this.smoothlyBlur.emit()
-							this.smoothlyInput.emit({ [this.name]: this.stateHandler.getValue(this.state) })
-							if (Deep.notEqual(lastValue, this.stateHandler.getValue(this.state)))
-								this.smoothlyChange.emit({ [this.name]: this.stateHandler.getValue(this.state) })
+							if (!this.readonly) {
+								const lastValue = this.stateHandler.getValue(this.state)
+								this.state = this.stateHandler.onBlur(event, this.state)
+								this.smoothlyBlur.emit()
+								this.smoothlyInput.emit({ [this.name]: this.stateHandler.getValue(this.state) })
+								if (Deep.notEqual(lastValue, this.stateHandler.getValue(this.state)))
+									this.smoothlyChange.emit({ [this.name]: this.stateHandler.getValue(this.state) })
+							}
 						}}
 					/>
 					<label class={"label float-on-focus"} htmlFor={this.name}>


### PR DESCRIPTION
## Bug Example
When focusing/un-focusing on input it formats `type="price"` as if it was being edited.
This is not an issue for `disabled` which should make the element un-focusable.

(cursor is not visible in clip below - but I'm clicking and clicking away)

[Screencast from 2024-12-05 17:55:49.webm](https://github.com/user-attachments/assets/d716cf23-b590-42af-a5f5-fd2a11e304c9)
