### PR TITLE
display no h1 if no label

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -33,7 +33,7 @@ export namespace Components {
     interface SmoothlyApp {
         "color": Color;
         "home"?: string;
-        "label": string;
+        "label"?: string;
         "menuOpen": boolean;
         "selectRoom": (path: string) => Promise<void>;
     }

--- a/src/components/app/index.tsx
+++ b/src/components/app/index.tsx
@@ -11,7 +11,7 @@ type Room = {
 	scoped: false,
 })
 export class SmoothlyApp {
-	@Prop() label = "App"
+	@Prop({ reflect: true }) label?: string
 	@Prop() color: Color
 	@Prop() home?: string
 	@Prop({ mutable: true, reflect: true }) menuOpen = false
@@ -89,15 +89,15 @@ export class SmoothlyApp {
 					<h1>
 						<a href={""}>{this.label}</a>
 					</h1>
-					<slot name="header"></slot>
+					<slot name="header" />
 					<nav ref={e => (this.navElement = e)} class={{ "menu-open": this.menuOpen }}>
 						<ul>
 							<div class={"nav-start-container"}>
-								<slot name="nav-start"></slot>
+								<slot name="nav-start" />
 							</div>
-							<slot> </slot>
+							<slot />
 							<div class={"nav-end-container"}>
-								<slot name="nav-end"></slot>
+								<slot name="nav-end" />
 							</div>
 						</ul>
 					</nav>
@@ -108,7 +108,7 @@ export class SmoothlyApp {
 						onSmoothlyVisibleStatus={e => this.burgerVisibilityHandler(e)}
 					/>
 				</header>
-				<main ref={e => (this.mainElement = e)}></main>
+				<main ref={e => (this.mainElement = e)} />
 			</smoothly-notifier>
 		)
 	}

--- a/src/components/app/style.css
+++ b/src/components/app/style.css
@@ -46,6 +46,9 @@ smoothly-app>smoothly-notifier>header>nav>ul {
 	margin: 0;
 }
 
+smoothly-app:not([label])>smoothly-notifier>header>h1 {
+	display: none;
+}
 smoothly-app>smoothly-notifier>header>h1 {
 	margin-left: 1rem;
 	margin-bottom: 0.8em;


### PR DESCRIPTION
- smoothly-app label should not be set by default.
- Having both the h1-label element and a logo in slot="header" moves to logo off to the right side for small screens, so instead h1 just hidden if there is no label. The only way around this before was setting the logo with absolute.

## Before
![image](https://github.com/user-attachments/assets/8656dc30-d4d5-4dd3-8344-b130ee109f9b)



## After
![image](https://github.com/user-attachments/assets/5f466822-4e07-4b9e-a394-bb406b1a937d)
