### PR TITLE
Add custom css-variable for weekend-foreground color

### DIFF
--- a/src/assets/style/mapping.css
+++ b/src/assets/style/mapping.css
@@ -38,4 +38,6 @@ smoothly-color {
 	--smoothly-button-foreground: var(--smoothly-color-shade);
 	--smoothly-button-hover-background: var(--smoothly-color-tint);
 	--smoothly-button-focus-border: var(--smoothly-color-shade);
+	/* smoothly-calendar */
+	--smoothly-calendar-weekend-foreground: var(--smoothly-danger-color);
 }

--- a/src/components/calendar/style.css
+++ b/src/components/calendar/style.css
@@ -47,12 +47,12 @@
 
 :host>table>tr>td:nth-child(6),
 :host>table>tr>td:nth-child(7) {
-	color: rgb(var(--smoothly-danger-color));
+	color: rgb(var(--smoothly-calendar-weekend-foreground, var(--smoothly-danger-color)));
 }
 
 :host>table>tr>td:nth-child(6):not(.currentMonth),
 :host>table>tr>td:nth-child(7):not(.currentMonth) {
-	color: rgba(var(--smoothly-danger-color), var(--other-month-opacity));
+	color: rgba(var(--smoothly-calendar-weekend-foreground, var(--smoothly-danger-color)), var(--other-month-opacity));
 }
 
 :host>table>tr>td:not(.selected, .disable):hover {


### PR DESCRIPTION
There can't reasonable be a color that is always contrasting the background if weekends are gonna have their own special color.
So this gives the power in the mapping to be able to set a contrasting color with `--smoothly-calendar-weekend-foreground`.

## Example
### Before
![Screenshot from 2024-12-06 17-04-46](https://github.com/user-attachments/assets/589e2cc6-86a8-4857-96b0-be8119698f04)


### After
![Screenshot from 2024-12-06 17-04-55](https://github.com/user-attachments/assets/3fe7d05f-e4f7-4b5c-89ca-ec04096be4ec)
