### PR TITLE
smoothly-next-table-header: expansion content is ontop of header.

### DIFF
--- a/src/components/next/table/expandable/cell/style.scss
+++ b/src/components/next/table/expandable/cell/style.scss
@@ -40,6 +40,7 @@
 	grid-column: 1 / -1;
 	grid-row: 2;
 	position: relative;
+	z-index: 0;
 }
 
 :host[open]>div.content {

--- a/src/components/next/table/expandable/row/style.scss
+++ b/src/components/next/table/expandable/row/style.scss
@@ -10,6 +10,7 @@
 
 :host::slotted(*) {
 	cursor: pointer;
+	z-index: 0;
 }
 
 :host:has(>:not(:last-child):hover)> :not(:last-child) {


### PR DESCRIPTION
### Before
![Screenshot from 2024-12-09 13-15-59](https://github.com/user-attachments/assets/63ba1c36-8be7-4dae-b64a-0f719c09efec)
### After
![Screenshot from 2024-12-09 13-16-07](https://github.com/user-attachments/assets/48883724-afbc-4608-9513-a51a65b0a5b5)
