### PR TITLE
revert smoothly-next-table-header: expansion content is ontop of header.

### DIFF
--- a/src/components/next/table/expandable/cell/style.scss
+++ b/src/components/next/table/expandable/cell/style.scss
@@ -40,7 +40,6 @@
 	grid-column: 1 / -1;
 	grid-row: 2;
 	position: relative;
-	z-index: 0;
 }
 
 :host[open]>div.content {

--- a/src/components/next/table/expandable/row/style.scss
+++ b/src/components/next/table/expandable/row/style.scss
@@ -10,7 +10,6 @@
 
 :host::slotted(*) {
 	cursor: pointer;
-	z-index: 0;
 }
 
 :host:has(>:not(:last-child):hover)> :not(:last-child) {


### PR DESCRIPTION
![Screenshot from 2024-12-09 16-24-40](https://github.com/user-attachments/assets/ac11e711-ed43-410c-aab0-21343ab35930)
