### PR TITLE
Add smoothly-modal

### DIFF
--- a/src/assets/style/mapping.css
+++ b/src/assets/style/mapping.css
@@ -20,6 +20,7 @@ smoothly-color {
 
 	--smoothly-table-expanded-foreground: var(--smoothly-default-contrast);
 	--smoothly-table-expanded-background: var(--smoothly-default-tint);
+	
 	/* smoothly input */
 	--smoothly-input-foreground: var(--smoothly-default-contrast);
 	--smoothly-input-background: var(--smoothly-default-tint);
@@ -33,12 +34,22 @@ smoothly-color {
 	--smoothly-input-selected-background: var(--smoothly-primary-color);
 	--smoothly-input-selected-border: var(--smoothly-primary-shade);
 	--smoothly-input-selected-foreground: var(--smoothly-primary-contrast);
+	
 	/* smoothly-button */
 	--smoothly-button-background: var(--smoothly-color);
 	--smoothly-button-foreground: var(--smoothly-color-shade);
 	--smoothly-button-hover-background: var(--smoothly-color-tint);
 	--smoothly-button-focus-border: var(--smoothly-color-shade);
 	--smoothly-button-border-radius: 0.25rem;
+	
 	/* smoothly-calendar */
 	--smoothly-calendar-weekend-foreground: var(--smoothly-danger-color);
+	
+	/* smoothly-modal */
+	--smoothly-modal-backdrop: var(--smoothly-default-color), var(--smoothly-semitransparent);
+	--smoothly-modal-background: var(--smoothly-default-color);
+	--smoothly-modal-foreground: var(--smoothly-default-contrast);
+	--smoothly-modal-border: var(--smoothly-default-shade);
+	--smoothly-modal-border-radius: 0.5rem;
+	--smoothly-modal-shadow: 0 0.5rem 1rem -0.5rem rgba(var(--smoothly-dark-shade), 0.2);
 }

--- a/src/assets/style/smoothly.css
+++ b/src/assets/style/smoothly.css
@@ -4,7 +4,7 @@
 
 :root {
 	--smoothly-font-family: "Open Sans", Verdana;
-	--smoothly-semitransparent: .8;
+	--smoothly-semitransparent: .5;
 
 	--smoothly-default-tint: 246, 249, 254;
 	--smoothly-default-color: 255, 255, 255;

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -531,6 +531,11 @@ export namespace Components {
         "name": string;
         "triggerMode": "scroll" | "intersection";
     }
+    interface SmoothlyModal {
+        "closable": boolean;
+        "color": Color | undefined;
+        "open": boolean;
+    }
     interface SmoothlyNextDemo {
     }
     interface SmoothlyNextDemoColspan {
@@ -823,6 +828,10 @@ export interface SmoothlyLoadMoreCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLSmoothlyLoadMoreElement;
 }
+export interface SmoothlyModalCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLSmoothlyModalElement;
+}
 export interface SmoothlyNextTableExpandableCellCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLSmoothlyNextTableExpandableCellElement;
@@ -830,6 +839,10 @@ export interface SmoothlyNextTableExpandableCellCustomEvent<T> extends CustomEve
 export interface SmoothlyNextTableExpandableRowCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLSmoothlyNextTableExpandableRowElement;
+}
+export interface SmoothlyNextTableRowGroupCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLSmoothlyNextTableRowGroupElement;
 }
 export interface SmoothlyNotificationCustomEvent<T> extends CustomEvent<T> {
     detail: T;
@@ -1689,6 +1702,23 @@ declare global {
         prototype: HTMLSmoothlyLoadMoreElement;
         new (): HTMLSmoothlyLoadMoreElement;
     };
+    interface HTMLSmoothlyModalElementEventMap {
+        "smoothlyModalChange": boolean;
+    }
+    interface HTMLSmoothlyModalElement extends Components.SmoothlyModal, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLSmoothlyModalElementEventMap>(type: K, listener: (this: HTMLSmoothlyModalElement, ev: SmoothlyModalCustomEvent<HTMLSmoothlyModalElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLSmoothlyModalElementEventMap>(type: K, listener: (this: HTMLSmoothlyModalElement, ev: SmoothlyModalCustomEvent<HTMLSmoothlyModalElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
+    }
+    var HTMLSmoothlyModalElement: {
+        prototype: HTMLSmoothlyModalElement;
+        new (): HTMLSmoothlyModalElement;
+    };
     interface HTMLSmoothlyNextDemoElement extends Components.SmoothlyNextDemo, HTMLStencilElement {
     }
     var HTMLSmoothlyNextDemoElement: {
@@ -1802,7 +1832,18 @@ declare global {
         prototype: HTMLSmoothlyNextTableRowElement;
         new (): HTMLSmoothlyNextTableRowElement;
     };
+    interface HTMLSmoothlyNextTableRowGroupElementEventMap {
+        "smoothlyNextTableRowGroupChange": boolean;
+    }
     interface HTMLSmoothlyNextTableRowGroupElement extends Components.SmoothlyNextTableRowGroup, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLSmoothlyNextTableRowGroupElementEventMap>(type: K, listener: (this: HTMLSmoothlyNextTableRowGroupElement, ev: SmoothlyNextTableRowGroupCustomEvent<HTMLSmoothlyNextTableRowGroupElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLSmoothlyNextTableRowGroupElementEventMap>(type: K, listener: (this: HTMLSmoothlyNextTableRowGroupElement, ev: SmoothlyNextTableRowGroupCustomEvent<HTMLSmoothlyNextTableRowGroupElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
     }
     var HTMLSmoothlyNextTableRowGroupElement: {
         prototype: HTMLSmoothlyNextTableRowGroupElement;
@@ -2185,6 +2226,7 @@ declare global {
         "smoothly-label": HTMLSmoothlyLabelElement;
         "smoothly-lazy": HTMLSmoothlyLazyElement;
         "smoothly-load-more": HTMLSmoothlyLoadMoreElement;
+        "smoothly-modal": HTMLSmoothlyModalElement;
         "smoothly-next-demo": HTMLSmoothlyNextDemoElement;
         "smoothly-next-demo-colspan": HTMLSmoothlyNextDemoColspanElement;
         "smoothly-next-demo-group": HTMLSmoothlyNextDemoGroupElement;
@@ -2725,6 +2767,12 @@ declare namespace LocalJSX {
         "onSmoothlyLoadMore"?: (event: SmoothlyLoadMoreCustomEvent<string>) => void;
         "triggerMode"?: "scroll" | "intersection";
     }
+    interface SmoothlyModal {
+        "closable"?: boolean;
+        "color"?: Color | undefined;
+        "onSmoothlyModalChange"?: (event: SmoothlyModalCustomEvent<boolean>) => void;
+        "open"?: boolean;
+    }
     interface SmoothlyNextDemo {
     }
     interface SmoothlyNextDemoColspan {
@@ -2771,6 +2819,7 @@ declare namespace LocalJSX {
     }
     interface SmoothlyNextTableRowGroup {
         "align"?: boolean;
+        "onSmoothlyNextTableRowGroupChange"?: (event: SmoothlyNextTableRowGroupCustomEvent<boolean>) => void;
         "open"?: boolean;
     }
     interface SmoothlyNotification {
@@ -2973,6 +3022,7 @@ declare namespace LocalJSX {
         "smoothly-label": SmoothlyLabel;
         "smoothly-lazy": SmoothlyLazy;
         "smoothly-load-more": SmoothlyLoadMore;
+        "smoothly-modal": SmoothlyModal;
         "smoothly-next-demo": SmoothlyNextDemo;
         "smoothly-next-demo-colspan": SmoothlyNextDemoColspan;
         "smoothly-next-demo-group": SmoothlyNextDemoGroup;
@@ -3091,6 +3141,7 @@ declare module "@stencil/core" {
             "smoothly-label": LocalJSX.SmoothlyLabel & JSXBase.HTMLAttributes<HTMLSmoothlyLabelElement>;
             "smoothly-lazy": LocalJSX.SmoothlyLazy & JSXBase.HTMLAttributes<HTMLSmoothlyLazyElement>;
             "smoothly-load-more": LocalJSX.SmoothlyLoadMore & JSXBase.HTMLAttributes<HTMLSmoothlyLoadMoreElement>;
+            "smoothly-modal": LocalJSX.SmoothlyModal & JSXBase.HTMLAttributes<HTMLSmoothlyModalElement>;
             "smoothly-next-demo": LocalJSX.SmoothlyNextDemo & JSXBase.HTMLAttributes<HTMLSmoothlyNextDemoElement>;
             "smoothly-next-demo-colspan": LocalJSX.SmoothlyNextDemoColspan & JSXBase.HTMLAttributes<HTMLSmoothlyNextDemoColspanElement>;
             "smoothly-next-demo-group": LocalJSX.SmoothlyNextDemoGroup & JSXBase.HTMLAttributes<HTMLSmoothlyNextDemoGroupElement>;

--- a/src/components/dialog/demo/index.tsx
+++ b/src/components/dialog/demo/index.tsx
@@ -1,14 +1,41 @@
-import { Component, h } from "@stencil/core"
+import { Component, h, Host, State } from "@stencil/core"
 
 @Component({
 	tag: "smoothly-dialog-demo",
+	styleUrl: "style.css",
+	scoped: true,
 })
 export class SmoothlyDialogDemo {
+	@State() openModal = false
+	@State() showFrame = false
+
 	render() {
 		return (
-			<smoothly-dialog color="default" closable>
-				<smoothly-frame url="https://www.wikipedia.org/" name="parent" style={{ height: "80vh" }}></smoothly-frame>
-			</smoothly-dialog>
+			<Host>
+				<smoothly-button fill="solid" color="light" onClick={() => (this.openModal = true)}>
+					Open Modal
+				</smoothly-button>
+				<smoothly-button fill="solid" color="light" onClick={() => (this.showFrame = !this.showFrame)}>
+					Show Frame
+				</smoothly-button>
+
+				<smoothly-modal closable open={this.openModal} onSmoothlyModalChange={e => (this.openModal = e.detail)}>
+					{<h2 slot="header">Modal</h2>}
+					<span>Are you sure you want to confirm this action?</span>
+					<smoothly-button slot="actions" color="success">
+						Confirm
+					</smoothly-button>
+					<smoothly-button slot="actions" color="light" fill="outline" onClick={() => (this.openModal = false)}>
+						Cancel
+					</smoothly-button>
+				</smoothly-modal>
+
+				{this.showFrame && (
+					<smoothly-dialog closable>
+						<smoothly-frame url="https://www.wikipedia.org/" name="parent" style={{ height: "80vh" }} />
+					</smoothly-dialog>
+				)}
+			</Host>
 		)
 	}
 }

--- a/src/components/dialog/demo/style.css
+++ b/src/components/dialog/demo/style.css
@@ -1,0 +1,5 @@
+
+:host > smoothly-button {
+	display: block;
+	margin-block: 2rem;
+}

--- a/src/components/modal/index.tsx
+++ b/src/components/modal/index.tsx
@@ -1,0 +1,47 @@
+import { Component, Event, EventEmitter, h, Host, Prop, Watch } from "@stencil/core"
+import { Color } from "../../model"
+
+@Component({
+	tag: "smoothly-modal",
+	styleUrl: "style.css",
+	scoped: true,
+})
+export class SmoothlyModal {
+	@Prop({ reflect: true }) color: Color | undefined
+	@Prop({ mutable: true, reflect: true }) open = false
+	@Prop({ reflect: true }) closable = false
+	@Event() smoothlyModalChange: EventEmitter<boolean>
+
+	@Watch("open")
+	openChanged() {
+		this.smoothlyModalChange.emit(this.open)
+	}
+
+	render() {
+		return (
+			<Host>
+				<div class="modal">
+					<div class="header">
+						<slot name="header" />
+						{this.closable && (
+							<smoothly-icon
+								name="close-outline"
+								fill="solid"
+								color={this.color}
+								onClick={() => {
+									this.open = false
+								}}
+							/>
+						)}
+					</div>
+					<div class="content">
+						<slot />
+					</div>
+					<div class="actions">
+						<slot name="actions" />
+					</div>
+				</div>
+			</Host>
+		)
+	}
+}

--- a/src/components/modal/index.tsx
+++ b/src/components/modal/index.tsx
@@ -34,9 +34,7 @@ export class SmoothlyModal {
 							/>
 						)}
 					</div>
-					<div class="content">
-						<slot />
-					</div>
+					<slot />
 					<div class="actions">
 						<slot name="actions" />
 					</div>

--- a/src/components/modal/index.tsx
+++ b/src/components/modal/index.tsx
@@ -19,7 +19,7 @@ export class SmoothlyModal {
 
 	render() {
 		return (
-			<Host>
+			<Host role="alertdialog">
 				<div class="modal">
 					<div class="header">
 						<slot name="header" />

--- a/src/components/modal/style.css
+++ b/src/components/modal/style.css
@@ -1,0 +1,60 @@
+:host {
+	position: fixed;
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+	background-color: rgba(var(--smoothly-modal-backdrop));
+	color: rgb(var(--smoothly-modal-foreground));
+}
+:host:not([open]),
+:host[hidden] {
+	display: none;
+}
+
+:host>div.modal {
+	display: flex;
+	flex-direction: column;
+	padding: 2rem;
+	gap: 1.5rem;
+	max-width: 40rem;
+	height: fit-content;
+	background: rgb(var(--smoothly-modal-background, var(--smoothly-color)));
+	border: 1px solid rgb(var(--smoothly-modal-border));
+	border-radius: var(--smoothly-modal-border-radius);
+	box-shadow: var(--smoothly-modal-shadow);
+}
+:host > div.modal > div.header:empty,
+:host > div.modal > div.content:empty,
+:host > div.modal > div.actions:empty {
+	display: none;
+}
+:host > div.modal > div.header {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+}
+:host > div.modal > div.header > * {
+	margin-block: 0;
+}
+:host > div.modal > div.header:not(:has([slot="header"])) {
+	justify-content: end;
+}
+:host > div.modal > div.header > smoothly-icon:not([slot="header"]) {
+	cursor: pointer;
+	opacity: 0.7;
+}
+:host > div.modal > div.header > smoothly-icon:not([slot="header"]):hover {
+	opacity: 1;
+}
+:host > div.modal > div.actions {
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	gap: 1rem;
+	flex-wrap: wrap;
+}
+

--- a/src/components/modal/style.css
+++ b/src/components/modal/style.css
@@ -28,7 +28,6 @@
 	box-shadow: var(--smoothly-modal-shadow);
 }
 :host > div.modal > div.header:empty,
-:host > div.modal > div.content:empty,
 :host > div.modal > div.actions:empty {
 	display: none;
 }
@@ -37,6 +36,7 @@
 	justify-content: space-between;
 	align-items: center;
 }
+:host > div.modal > *,
 :host > div.modal > div.header > * {
 	margin-block: 0;
 }


### PR DESCRIPTION

## Difference between dialog and modal
### Dialog
General term for a container that presents information or prompts user interaction, without necessarily restricting the user’s ability to interact with the rest of the page. - (Should use `role="alert"`)

### Modal
A type of dialog that enforces a blocking interaction pattern, requiring the user to engage with it before returning to the main content. - That's why it uses `role="alertdialog"`

## demo
![Screenshot from 2024-12-16 11-08-50](https://github.com/user-attachments/assets/408cc1a3-45e9-4a8d-917f-a43b9c34a15b)

## Examples 

![Screenshot from 2024-12-16 11-06-30](https://github.com/user-attachments/assets/427df28a-35a2-4573-9a4f-37ea3d6d5a4c)
![Screenshot from 2024-12-16 11-06-17](https://github.com/user-attachments/assets/1714cbb3-1ce1-42ad-b074-6c06d67aaa62)
![Screenshot from 2024-12-16 10-04-40](https://github.com/user-attachments/assets/599270dd-2696-400d-ac7b-79def6e93519)

## Before using smoothly-dialog
If you wanted to make something similar before using smoothly-dialog it would looks something like this.
![Screenshot from 2024-12-13 10-40-28](https://github.com/user-attachments/assets/60269a19-1f1b-4734-bbb2-e8f934ae7f5b)
