### PR TITLE
Add extension to preview comma separated colors

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,7 @@
 {
 	"recommendations": [
 		"dbaeumer.vscode-eslint",
-		"stylelint.vscode-stylelint"
+		"stylelint.vscode-stylelint",
+		"magnusg93.css-comma-color"
 	]
 }


### PR DESCRIPTION
Was annoyed that I could not find any extensions to preview the comma separated colors. So I made one:
https://marketplace.visualstudio.com/items?itemName=magnusg93.css-comma-color

For now all it can do is show a preview - no color picker or anything fancy for now.


![Screenshot from 2024-12-18 10-00-34](https://github.com/user-attachments/assets/3ca29d21-070e-4308-abb1-d056e0f22a56)
