### PR TITLE
Fix input-clear inside an input for several input types

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -437,6 +437,7 @@ export namespace Components {
         "changed": boolean;
         "clear": () => Promise<void>;
         "color"?: Color;
+        "defined": boolean;
         "edit": (editable: boolean) => Promise<void>;
         "getValue": () => Promise<number | undefined>;
         "label": string;
@@ -2676,6 +2677,7 @@ declare namespace LocalJSX {
     interface SmoothlyInputRange {
         "changed"?: boolean;
         "color"?: Color;
+        "defined"?: boolean;
         "label"?: string;
         "looks"?: Looks;
         "max"?: number;

--- a/src/components/input/Input.ts
+++ b/src/components/input/Input.ts
@@ -56,4 +56,11 @@ export namespace Input {
 	export function formAdd(self: Input) {
 		self.smoothlyInputLoad.emit(parent => (self.parent = parent))
 	}
+	/* For adding clear, edit, reset that is inside input etc. - should be called on smoothlyInputLoad */
+	export function registerSubAction(self: Input & Editable, event: CustomEvent<(parent: Editable) => void>) {
+		if (!(event.target && "name" in event.target && event.target.name === self.name)) {
+			event.stopPropagation()
+			event.detail(self)
+		}
+	}
 }

--- a/src/components/input/color/index.tsx
+++ b/src/components/input/color/index.tsx
@@ -18,7 +18,6 @@ import { HSL } from "../../../model/Color/HSL"
 import { RGB } from "../../../model/Color/RGB"
 import { Clearable } from "../Clearable"
 import { Editable } from "../Editable"
-import { SmoothlyInput } from "../index"
 import { Input } from "../Input"
 import { Looks } from "../Looks"
 
@@ -62,9 +61,8 @@ export class SmoothlyInputColor implements Input, Clearable, Editable, Component
 			event.stopPropagation()
 	}
 	@Listen("smoothlyInputLoad")
-	smoothlyInputLoadHandler(event: CustomEvent<(parent: SmoothlyInput) => void>): void {
-		if (event.target != this.element)
-			event.stopPropagation()
+	smoothlyInputLoadHandler(event: CustomEvent<(parent: SmoothlyInputColor) => void>): void {
+		Input.registerSubAction(this, event)
 	}
 	@Listen("click", { target: "window" })
 	onWindowClick(event: Event): void {
@@ -211,6 +209,10 @@ export class SmoothlyInputColor implements Input, Clearable, Editable, Component
 					size="small"
 					onClick={() => !this.readonly && this.openDropdown()}
 				/>
+				<div>
+					{/* Extra div needed otherwise stencil sets hidden on the slot for no apparent reason */}
+					<slot name="end" />
+				</div>
 				{this.open && !this.readonly && (
 					<div class="rgb-sliders">
 						<smoothly-toggle-switch

--- a/src/components/input/date/index.tsx
+++ b/src/components/input/date/index.tsx
@@ -97,11 +97,8 @@ export class SmoothlyInputDate implements ComponentWillLoad, Clearable, Input, E
 			event.stopPropagation()
 	}
 	@Listen("smoothlyInputLoad")
-	SmoothlyInputLoadHandler(event: CustomEvent<(parent: SmoothlyInputDate) => void>): void {
-		if (!(event.target && "name" in event.target && event.target.name === this.name)) {
-			event.stopPropagation()
-			event.detail(this)
-		}
+	smoothlyInputLoadHandler(event: CustomEvent<(parent: SmoothlyInputDate) => void>): void {
+		Input.registerSubAction(this, event)
 	}
 	@Listen("click", { target: "window" })
 	onWindowClick(event: Event): void {

--- a/src/components/input/date/range/index.tsx
+++ b/src/components/input/date/range/index.tsx
@@ -67,11 +67,8 @@ export class SmoothlyInputDateRange implements Clearable, Input, Editable {
 		this.listener.changed?.(this)
 	}
 	@Listen("smoothlyInputLoad")
-	SmoothlyInputLoadHandler(event: CustomEvent<(parent: SmoothlyInputDateRange) => void>): void {
-		if (!(event.target && "name" in event.target && event.target.name === this.name)) {
-			event.stopPropagation()
-			event.detail(this)
-		}
+	smoothlyInputLoadHandler(event: CustomEvent<(parent: SmoothlyInputDateRange) => void>): void {
+		Input.registerSubAction(this, event)
 	}
 	@Listen("smoothlyInputLooks")
 	smoothlyInputLooksHandler(event: CustomEvent<(looks: Looks) => void>) {

--- a/src/components/input/demo/standard/index.tsx
+++ b/src/components/input/demo/standard/index.tsx
@@ -129,6 +129,8 @@ export class SmoothlyInputDemoStandard {
 					<div class="height"></div>
 
 					<smoothly-input-radio
+						name="radio"
+						clearable
 						looks={this.options.looks}
 						readonly={this.options.readonly}
 						color={this.options.color}

--- a/src/components/input/index.tsx
+++ b/src/components/input/index.tsx
@@ -66,7 +66,7 @@ export class SmoothlyInput implements Clearable, Input, Editable {
 	}
 	@Method()
 	async clear(): Promise<void> {
-		!this.uneditable && (this.value = undefined)
+		!this.uneditable && (this.state = this.stateHandler.initialState(undefined))
 	}
 	@Method()
 	async edit(editable: boolean): Promise<void> {
@@ -74,7 +74,7 @@ export class SmoothlyInput implements Clearable, Input, Editable {
 	}
 	@Method()
 	async reset(): Promise<void> {
-		!this.uneditable && (this.value = this.initialValue)
+		!this.uneditable && (this.state = this.stateHandler.initialState(this.initialValue))
 	}
 	@Method()
 	async setInitialValue(): Promise<void> {
@@ -84,10 +84,7 @@ export class SmoothlyInput implements Clearable, Input, Editable {
 	}
 	@Listen("smoothlyInputLoad")
 	async smoothlyInputLoadHandler(event: CustomEvent<(parent: SmoothlyInput) => void>): Promise<void> {
-		if (!(event.target && "name" in event.target && event.target.name == this.name)) {
-			event.stopPropagation()
-			event.detail(this)
-		}
+		Input.registerSubAction(this, event)
 	}
 	@Watch("currency")
 	@Watch("type")

--- a/src/components/input/radio/index.tsx
+++ b/src/components/input/radio/index.tsx
@@ -59,11 +59,8 @@ export class SmoothlyInputRadio implements Input, Clearable, Editable, Component
 		event.detail(this.name)
 	}
 	@Listen("smoothlyInputLoad")
-	SmoothlyInputLoadHandler(event: CustomEvent<(parent: SmoothlyInputRadio) => void>): void {
-		if (!(event.target && "name" in event.target && event.target.name === this.name)) {
-			event.stopPropagation()
-			event.detail(this)
-		}
+	smoothlyInputLoadHandler(event: CustomEvent<(parent: SmoothlyInputRadio) => void>): void {
+		Input.registerSubAction(this, event)
 	}
 	@Listen("smoothlySelect")
 	smoothlyRadioInputHandler(event: CustomEvent<Selectable>): void {

--- a/src/components/input/range/index.tsx
+++ b/src/components/input/range/index.tsx
@@ -35,6 +35,7 @@ export class SmoothlyInputRange implements Input, Clearable, Editable, Component
 	@Prop({ reflect: true, mutable: true }) looks?: Looks
 	@Prop({ reflect: true, mutable: true }) color?: Color
 	@Prop({ mutable: true }) changed = false
+	@Prop({ mutable: true }) defined = false
 	@Prop({ reflect: true, mutable: true }) readonly = false
 	@Prop() type: Extract<tidily.Type, "text" | "percent"> = "text"
 	@Prop() min = 0
@@ -111,6 +112,7 @@ export class SmoothlyInputRange implements Input, Clearable, Editable, Component
 		const decimals = !this.step ? undefined : this.step.toString().split(".")[1]?.length ?? 0
 		this.value = Number.isNaN(this.value) || this.value == undefined ? undefined : +this.value.toFixed(decimals)
 		this.changed = this.initialValue !== this.value
+		this.defined = typeof this.value === "number"
 		this.listener.changed?.(this)
 		this.smoothlyInput.emit({ [this.name]: this.value })
 	}

--- a/src/components/input/select/index.tsx
+++ b/src/components/input/select/index.tsx
@@ -186,7 +186,7 @@ export class SmoothlyInputSelect implements Input, Editable, Clearable, Componen
 			event.target.deselectable = !this.required
 			this.items.push(event.target as HTMLSmoothlyItemElement)
 		}
-		event.detail(this)
+		Input.registerSubAction(this, event)
 	}
 	@Listen("click", { target: "window" })
 	onWindowClick(event: Event): void {


### PR DESCRIPTION
Add `Input.registerSubAction` function that can be used by all inputs - this is for when listening to e.g. input-clear inside an input.

And make sure input-clear works for:
- input
- select
- radio
- range
- color
- date
- date-range

![image](https://github.com/user-attachments/assets/4a6ef3a5-dab5-49ff-ae8c-6abd07054ac8)
