### PR TITLE
Make smoothly modal be scrollable when content does not fit

### DIFF
--- a/src/assets/style/mapping.css
+++ b/src/assets/style/mapping.css
@@ -52,4 +52,6 @@ smoothly-color {
 	--smoothly-modal-border: var(--smoothly-default-shade);
 	--smoothly-modal-border-radius: 0.5rem;
 	--smoothly-modal-shadow: 0 0.5rem 1rem -0.5rem rgba(var(--smoothly-dark-shade), 0.2);
+	--smoothly-modal-width: 30rem;
+	--smoothly-modal-max-height: calc(100dvh - 2rem);
 }

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -534,7 +534,6 @@ export namespace Components {
     }
     interface SmoothlyModal {
         "closable": boolean;
-        "color": Color | undefined;
         "open": boolean;
     }
     interface SmoothlyNextDemo {
@@ -2771,7 +2770,6 @@ declare namespace LocalJSX {
     }
     interface SmoothlyModal {
         "closable"?: boolean;
-        "color"?: Color | undefined;
         "onSmoothlyModalChange"?: (event: SmoothlyModalCustomEvent<boolean>) => void;
         "open"?: boolean;
     }

--- a/src/components/dialog/demo/index.tsx
+++ b/src/components/dialog/demo/index.tsx
@@ -7,6 +7,7 @@ import { Component, h, Host, State } from "@stencil/core"
 })
 export class SmoothlyDialogDemo {
 	@State() openModal = false
+	@State() openTallModal = false
 	@State() showFrame = false
 
 	render() {
@@ -14,6 +15,9 @@ export class SmoothlyDialogDemo {
 			<Host>
 				<smoothly-button fill="solid" color="light" onClick={() => (this.openModal = true)}>
 					Open Modal
+				</smoothly-button>
+				<smoothly-button fill="solid" color="light" onClick={() => (this.openTallModal = true)}>
+					Open Modal with long text
 				</smoothly-button>
 				<smoothly-button fill="solid" color="light" onClick={() => (this.showFrame = !this.showFrame)}>
 					Show Frame
@@ -26,6 +30,24 @@ export class SmoothlyDialogDemo {
 						Confirm
 					</smoothly-button>
 					<smoothly-button slot="actions" color="light" fill="outline" onClick={() => (this.openModal = false)}>
+						Cancel
+					</smoothly-button>
+				</smoothly-modal>
+
+				<smoothly-modal closable open={this.openTallModal} onSmoothlyModalChange={e => (this.openTallModal = e.detail)}>
+					<h2 slot="header">Modal</h2>
+					<div>
+						{Array.from({ length: 10 }).map(() => (
+							<p>
+								Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et
+								dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip
+								ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu
+								fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia
+								deserunt mollit anim id est laborum.
+							</p>
+						))}
+					</div>
+					<smoothly-button slot="actions" color="light" fill="outline" onClick={() => (this.openTallModal = false)}>
 						Cancel
 					</smoothly-button>
 				</smoothly-modal>

--- a/src/components/dialog/demo/index.tsx
+++ b/src/components/dialog/demo/index.tsx
@@ -20,7 +20,7 @@ export class SmoothlyDialogDemo {
 				</smoothly-button>
 
 				<smoothly-modal closable open={this.openModal} onSmoothlyModalChange={e => (this.openModal = e.detail)}>
-					{<h2 slot="header">Modal</h2>}
+					<h2 slot="header">Modal</h2>
 					<span>Are you sure you want to confirm this action?</span>
 					<smoothly-button slot="actions" color="success">
 						Confirm

--- a/src/components/modal/index.tsx
+++ b/src/components/modal/index.tsx
@@ -1,5 +1,4 @@
 import { Component, Event, EventEmitter, h, Host, Prop, Watch } from "@stencil/core"
-import { Color } from "../../model"
 
 @Component({
 	tag: "smoothly-modal",
@@ -7,7 +6,6 @@ import { Color } from "../../model"
 	scoped: true,
 })
 export class SmoothlyModal {
-	@Prop({ reflect: true }) color: Color | undefined
 	@Prop({ mutable: true, reflect: true }) open = false
 	@Prop({ reflect: true }) closable = false
 	@Event() smoothlyModalChange: EventEmitter<boolean>
@@ -23,16 +21,7 @@ export class SmoothlyModal {
 				<div class="modal">
 					<div class="header">
 						<slot name="header" />
-						{this.closable && (
-							<smoothly-icon
-								name="close-outline"
-								fill="solid"
-								color={this.color}
-								onClick={() => {
-									this.open = false
-								}}
-							/>
-						)}
+						{this.closable && <smoothly-icon name="close-outline" fill="solid" onClick={() => (this.open = false)} />}
 					</div>
 					<slot />
 					<div class="actions">

--- a/src/components/modal/style.css
+++ b/src/components/modal/style.css
@@ -9,6 +9,7 @@
   height: 100%;
 	background-color: rgba(var(--smoothly-modal-backdrop));
 	color: rgb(var(--smoothly-modal-foreground));
+	z-index: 5;
 }
 :host:not([open]),
 :host[hidden] {
@@ -20,14 +21,15 @@
 	flex-direction: column;
 	padding: 2rem;
 	gap: 1.5rem;
-	width: var(--smoothly-modal-width);
-	max-width: 100dvw;
+	width: var(--smoothly-modal-width, 40rem);
+	max-width: calc(100dvw - 1rem);
 	height: fit-content;
 	max-height: min(var(--smoothly-modal-max-height), 100dvh);
 	background: rgb(var(--smoothly-modal-background, var(--smoothly-color)));
 	border: 1px solid rgb(var(--smoothly-modal-border));
 	border-radius: var(--smoothly-modal-border-radius);
 	box-shadow: var(--smoothly-modal-shadow);
+	box-sizing: border-box;
 }
 :host > div.modal > div.header:empty,
 :host > div.modal > div.actions:empty {

--- a/src/components/modal/style.css
+++ b/src/components/modal/style.css
@@ -20,8 +20,10 @@
 	flex-direction: column;
 	padding: 2rem;
 	gap: 1.5rem;
-	max-width: 40rem;
+	width: var(--smoothly-modal-width);
+	max-width: 100dvw;
 	height: fit-content;
+	max-height: min(var(--smoothly-modal-max-height), 100dvh);
 	background: rgb(var(--smoothly-modal-background, var(--smoothly-color)));
 	border: 1px solid rgb(var(--smoothly-modal-border));
 	border-radius: var(--smoothly-modal-border-radius);
@@ -39,6 +41,9 @@
 :host > div.modal > *,
 :host > div.modal > div.header > * {
 	margin-block: 0;
+}
+:host > div.modal > *:not(.header):not(.actions) {
+	overflow-y: auto;
 }
 :host > div.modal > div.header:not(:has([slot="header"])) {
 	justify-content: end;

--- a/src/components/modal/style.css
+++ b/src/components/modal/style.css
@@ -46,6 +46,7 @@
 :host > div.modal > div.header > smoothly-icon:not([slot="header"]) {
 	cursor: pointer;
 	opacity: 0.7;
+	color: rgb(var(--smoothly-default-contrast));
 }
 :host > div.modal > div.header > smoothly-icon:not([slot="header"]):hover {
 	opacity: 1;


### PR DESCRIPTION
- Fix so modal won't be taller then viewport, and will get scrollable when content is to large.
- Add css vars `--smoothly-modal-width` and `--smoothly-modal-max-height`
- Remove Prop Color - made no sense for this component.