### PR TITLE
Update input-radio event name

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -1558,7 +1558,7 @@ declare global {
     };
     interface HTMLSmoothlyInputRadioItemElementEventMap {
         "smoothlySelect": Selectable;
-        "smoothlyRadioButtonRegister": (name: string) => void;
+        "smoothlyRadioItemRegister": (name: string) => void;
     }
     interface HTMLSmoothlyInputRadioItemElement extends Components.SmoothlyInputRadioItem, HTMLStencilElement {
         addEventListener<K extends keyof HTMLSmoothlyInputRadioItemElementEventMap>(type: K, listener: (this: HTMLSmoothlyInputRadioItemElement, ev: SmoothlyInputRadioItemCustomEvent<HTMLSmoothlyInputRadioItemElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -2668,7 +2668,7 @@ declare namespace LocalJSX {
     interface SmoothlyInputRadioItem {
         "looks"?: Looks;
         "name"?: string;
-        "onSmoothlyRadioButtonRegister"?: (event: SmoothlyInputRadioItemCustomEvent<(name: string) => void>) => void;
+        "onSmoothlyRadioItemRegister"?: (event: SmoothlyInputRadioItemCustomEvent<(name: string) => void>) => void;
         "onSmoothlySelect"?: (event: SmoothlyInputRadioItemCustomEvent<Selectable>) => void;
         "selected"?: boolean;
         "value"?: any;

--- a/src/components/input/radio/index.tsx
+++ b/src/components/input/radio/index.tsx
@@ -53,7 +53,7 @@ export class SmoothlyInputRadio implements Input, Clearable, Editable, Component
 		this.smoothlyInputLoad.emit(parent => (this.parent = parent))
 		this.initialValue = this.active
 	}
-	@Listen("smoothlyRadioButtonRegister")
+	@Listen("smoothlyRadioItemRegister")
 	handleRegister(event: CustomEvent<(name: string) => void>) {
 		event.stopPropagation()
 		event.detail(this.name)

--- a/src/components/input/radio/item/index.tsx
+++ b/src/components/input/radio/item/index.tsx
@@ -10,13 +10,13 @@ import { Selectable } from "../Selected"
 export class SmoothlyInputRadioItem {
 	@Element() element: HTMLInputElement
 	@Prop({ mutable: true }) value: any
-	@Prop({ mutable: true }) selected = false
+	@Prop({ mutable: true, reflect: true }) selected = false
 	@Prop({ mutable: true, reflect: true }) looks?: Looks
 	@Prop({ mutable: true }) name: string
 	@Event() smoothlySelect: EventEmitter<Selectable>
-	@Event() smoothlyRadioButtonRegister: EventEmitter<(name: string) => void>
+	@Event() smoothlyRadioItemRegister: EventEmitter<(name: string) => void>
 	componentWillLoad(): void | Promise<void> {
-		this.smoothlyRadioButtonRegister.emit(name => (this.name = name))
+		this.smoothlyRadioItemRegister.emit(name => (this.name = name))
 		this.selected && this.inputHandler()
 	}
 	inputHandler(): void {


### PR DESCRIPTION
- `smoothlyRadioItemRegister` is more consistent with the component.
- Also make `selected` reflect, so it can be used for styling purposes.