### PR TITLE
Add prop align to smoothly-modal

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -534,6 +534,7 @@ export namespace Components {
         "triggerMode": "scroll" | "intersection";
     }
     interface SmoothlyModal {
+        "align": "top" | "center";
         "closable": boolean;
         "open": boolean;
     }
@@ -2771,6 +2772,7 @@ declare namespace LocalJSX {
         "triggerMode"?: "scroll" | "intersection";
     }
     interface SmoothlyModal {
+        "align"?: "top" | "center";
         "closable"?: boolean;
         "onSmoothlyModalChange"?: (event: SmoothlyModalCustomEvent<boolean>) => void;
         "open"?: boolean;

--- a/src/components/dialog/demo/index.tsx
+++ b/src/components/dialog/demo/index.tsx
@@ -17,7 +17,7 @@ export class SmoothlyDialogDemo {
 					Open Modal
 				</smoothly-button>
 				<smoothly-button fill="solid" color="light" onClick={() => (this.openTallModal = true)}>
-					Open Modal with long text
+					Open Modal with long text and top-aligned.
 				</smoothly-button>
 				<smoothly-button fill="solid" color="light" onClick={() => (this.showFrame = !this.showFrame)}>
 					Show Frame
@@ -34,19 +34,26 @@ export class SmoothlyDialogDemo {
 					</smoothly-button>
 				</smoothly-modal>
 
-				<smoothly-modal closable open={this.openTallModal} onSmoothlyModalChange={e => (this.openTallModal = e.detail)}>
+				<smoothly-modal
+					closable
+					open={this.openTallModal}
+					onSmoothlyModalChange={e => (this.openTallModal = e.detail)}
+					align="top">
 					<h2 slot="header">Modal</h2>
-					<div>
-						{Array.from({ length: 10 }).map(() => (
-							<p>
-								Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et
-								dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip
-								ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu
-								fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia
-								deserunt mollit anim id est laborum.
-							</p>
-						))}
-					</div>
+					<smoothly-summary>
+						<div slot="summary">Lorem ipsum</div>
+						<div slot="content">
+							{Array.from({ length: 10 }).map(() => (
+								<p>
+									Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et
+									dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+									aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum
+									dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui
+									officia deserunt mollit anim id est laborum.
+								</p>
+							))}
+						</div>
+					</smoothly-summary>
 					<smoothly-button slot="actions" color="light" fill="outline" onClick={() => (this.openTallModal = false)}>
 						Cancel
 					</smoothly-button>

--- a/src/components/modal/index.tsx
+++ b/src/components/modal/index.tsx
@@ -8,6 +8,7 @@ import { Component, Event, EventEmitter, h, Host, Prop, Watch } from "@stencil/c
 export class SmoothlyModal {
 	@Prop({ mutable: true, reflect: true }) open = false
 	@Prop({ reflect: true }) closable = false
+	@Prop({ reflect: true }) align: "top" | "center" = "center"
 	@Event() smoothlyModalChange: EventEmitter<boolean>
 
 	@Watch("open")

--- a/src/components/modal/style.css
+++ b/src/components/modal/style.css
@@ -2,7 +2,6 @@
 	position: fixed;
 	display: flex;
 	justify-content: center;
-	align-items: center;
 	top: 0;
   left: 0;
   width: 100%;
@@ -14,6 +13,12 @@
 :host:not([open]),
 :host[hidden] {
 	display: none;
+}
+:host[align=center] {
+	align-items: center;
+}
+:host[align=top]>div.modal{
+	margin-top: calc((100dvh - var(--smoothly-modal-max-height)) / 2);
 }
 
 :host>div.modal {


### PR DESCRIPTION

## align="center"
![Screenshot from 2025-01-23 14-59-25](https://github.com/user-attachments/assets/537e471f-fffa-46f1-9ae9-e7213d10cdcd)


## align="top"
Align end will adapt to `--smoothly-modal-max-height` so it will be centered when the modal is maximally expanded.
![Screenshot from 2025-01-23 14-59-29](https://github.com/user-attachments/assets/2c82236d-2b60-4d89-8bfa-1db6fe5b0ac9)
![Screenshot from 2025-01-23 14-59-36](https://github.com/user-attachments/assets/1a16e37c-619d-4883-aa09-7567dfc67474)

