### PR TITLE
Fix weird reassignment bug of event.target in smoothly-form

### DIFF
--- a/src/components/form/index.tsx
+++ b/src/components/form/index.tsx
@@ -121,13 +121,14 @@ export class SmoothlyForm implements ComponentWillLoad, Clearable, Submittable, 
 	async smoothlyInputLoadHandler(event: CustomEvent<(parent: SmoothlyForm) => void>): Promise<void> {
 		event.stopPropagation()
 		event.detail(this)
-		if (Input.Element.is(event.target)) {
-			if (await event.target.binary?.())
+		const inputComponent = event.target
+		if (Input.Element.is(inputComponent)) {
+			if (await inputComponent.binary?.())
 				this.contentType = "form-data"
-			const inputValue = await event.target.getValue() // Needs to await value separately to avoid race condition
-			this.value = Data.merge(this.value, { [event.target.name]: inputValue })
+			const inputValue = await inputComponent.getValue() // Needs to await value separately to avoid race condition
+			this.value = Data.merge(this.value, { [inputComponent.name]: inputValue })
 			this.smoothlyFormInput.emit(Data.convertArrays(this.value))
-			this.inputs.set(event.target.name, event.target)
+			this.inputs.set(inputComponent.name, inputComponent)
 		}
 	}
 	@Listen("smoothlyFormDisable")


### PR DESCRIPTION
`event.target` can be changed before and after the `await event.target?.binary()`.

![image](https://github.com/user-attachments/assets/6ec089e9-0033-4349-bfdb-96a0e9f50222)


I have no clue where or how `event.target` is re-assigned. But apparently it can happen.
I guess await, means the event keeps going up the DOM and some element must listen to the event and change `event.target`, but I'm unable to find such that.

But to make sure it does not happen I assign `event.target` at the start to a local variable so I know it won't be changed.
