### PR TITLE
Smoothly-item - add disabled prop and item-css-variables

### DIFF
--- a/src/assets/style/mapping.css
+++ b/src/assets/style/mapping.css
@@ -37,6 +37,7 @@ smoothly-color {
 
 	--smoothly-input-disabled-background: var(--smoothly-default-shade);
   --smoothly-input-disabled-foreground: var(--smoothly-default-contrast), 50%;
+	--smoothly-input-disabled-opacity: 0.6;
 	
 	/* smoothly-button */
 	--smoothly-button-background: var(--smoothly-color);

--- a/src/assets/style/mapping.css
+++ b/src/assets/style/mapping.css
@@ -21,7 +21,7 @@ smoothly-color {
 	--smoothly-table-expanded-foreground: var(--smoothly-default-contrast);
 	--smoothly-table-expanded-background: var(--smoothly-default-tint);
 	
-	/* smoothly-input */
+	/* smoothly inputs */
 	--smoothly-input-foreground: var(--smoothly-default-contrast);
 	--smoothly-input-background: var(--smoothly-default-tint);
 	--smoothly-input-border: var(--smoothly-default-shade);
@@ -31,14 +31,21 @@ smoothly-color {
 	--smoothly-input-hover-background: var(--smoothly-primary-tint);
 	--smoothly-input-hover-foreground: var(--smoothly-primary-contrast);
 
-	--smoothly-input-selected-background: var(--smoothly-primary-color);
-	--smoothly-input-selected-border: var(--smoothly-primary-shade);
-	--smoothly-input-selected-foreground: var(--smoothly-primary-contrast);
+	/* smoothly-item */
+	--smoothly-item-foreground: var(--smoothly-default-contrast);
+	--smoothly-item-background: var(--smoothly-default-tint);
 
-	--smoothly-input-disabled-background: var(--smoothly-default-shade);
-  --smoothly-input-disabled-foreground: var(--smoothly-default-contrast), 50%;
-	--smoothly-input-disabled-opacity: 0.6;
-	
+	--smoothly-item-hover-background: var(--smoothly-primary-tint);
+	--smoothly-item-hover-foreground: var(--smoothly-primary-contrast);
+
+	--smoothly-item-selected-background: var(--smoothly-primary-color);
+	--smoothly-item-selected-border: var(--smoothly-primary-shade);
+	--smoothly-item-selected-foreground: var(--smoothly-primary-contrast);
+
+	--smoothly-item-disabled-background: var(--smoothly-default-shade);
+  --smoothly-item-disabled-foreground: var(--smoothly-default-contrast), 50%;
+	--smoothly-item-disabled-opacity: 0.6;
+
 	/* smoothly-button */
 	--smoothly-button-background: var(--smoothly-color);
 	--smoothly-button-foreground: var(--smoothly-color-shade);

--- a/src/assets/style/mapping.css
+++ b/src/assets/style/mapping.css
@@ -21,11 +21,11 @@ smoothly-color {
 	--smoothly-table-expanded-foreground: var(--smoothly-default-contrast);
 	--smoothly-table-expanded-background: var(--smoothly-default-tint);
 	
-	/* smoothly input */
+	/* smoothly-input */
 	--smoothly-input-foreground: var(--smoothly-default-contrast);
 	--smoothly-input-background: var(--smoothly-default-tint);
 	--smoothly-input-border: var(--smoothly-default-shade);
-	--smoothly-input-border-readonly: var(--smoothly-input-border), 50% ;
+	--smoothly-input-border-readonly: var(--smoothly-input-border), 50%;
 	--smoothly-input-border-radius: 0;
 
 	--smoothly-input-hover-background: var(--smoothly-primary-tint);
@@ -34,6 +34,9 @@ smoothly-color {
 	--smoothly-input-selected-background: var(--smoothly-primary-color);
 	--smoothly-input-selected-border: var(--smoothly-primary-shade);
 	--smoothly-input-selected-foreground: var(--smoothly-primary-contrast);
+
+	--smoothly-input-disabled-background: var(--smoothly-default-shade);
+  --smoothly-input-disabled-foreground: var(--smoothly-default-contrast), 50%;
 	
 	/* smoothly-button */
 	--smoothly-button-background: var(--smoothly-color);

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -518,6 +518,7 @@ export namespace Components {
     }
     interface SmoothlyItem {
         "deselectable": boolean;
+        "disabled": boolean;
         "filter": (filter: string) => Promise<void>;
         "marked": boolean;
         "selectable": boolean;
@@ -2774,6 +2775,7 @@ declare namespace LocalJSX {
     }
     interface SmoothlyItem {
         "deselectable"?: boolean;
+        "disabled"?: boolean;
         "marked"?: boolean;
         "onSmoothlyInputLoad"?: (event: SmoothlyItemCustomEvent<(parent: Editable) => void>) => void;
         "onSmoothlyItemSelect"?: (event: SmoothlyItemCustomEvent<HTMLSmoothlyItemElement>) => void;

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -521,7 +521,6 @@ export namespace Components {
         "disabled": boolean;
         "filter": (filter: string) => Promise<void>;
         "marked": boolean;
-        "selectable": boolean;
         "selected": boolean;
         "value": any;
     }
@@ -2779,7 +2778,6 @@ declare namespace LocalJSX {
         "marked"?: boolean;
         "onSmoothlyInputLoad"?: (event: SmoothlyItemCustomEvent<(parent: Editable) => void>) => void;
         "onSmoothlyItemSelect"?: (event: SmoothlyItemCustomEvent<HTMLSmoothlyItemElement>) => void;
-        "selectable"?: boolean;
         "selected"?: boolean;
         "value"?: any;
     }

--- a/src/components/input/demo/index.tsx
+++ b/src/components/input/demo/index.tsx
@@ -62,7 +62,9 @@ export class SmoothlyInputDemo {
 						<smoothly-input-select name="select-dessert" looks="border">
 							<label slot="label">Select with clear button</label>
 							<smoothly-item value="1">Ice cream</smoothly-item>
-							<smoothly-item value="2">Sponge cake</smoothly-item>
+							<smoothly-item value="2" selectable={false}>
+								Sponge cake
+							</smoothly-item>
 							<smoothly-item value="3">Cookie</smoothly-item>
 							<smoothly-item value="4">Croissant</smoothly-item>
 							<smoothly-item value="5">Chocolate fondue</smoothly-item>

--- a/src/components/input/demo/index.tsx
+++ b/src/components/input/demo/index.tsx
@@ -62,12 +62,13 @@ export class SmoothlyInputDemo {
 						<smoothly-input-select name="select-dessert" looks="border">
 							<label slot="label">Select with clear button</label>
 							<smoothly-item value="1">Ice cream</smoothly-item>
-							<smoothly-item value="2" selectable={false}>
-								Sponge cake
+							<smoothly-item value="2">Sponge cake</smoothly-item>
+							<smoothly-item value="3" disabled>
+								Disabled Item
 							</smoothly-item>
-							<smoothly-item value="3">Cookie</smoothly-item>
-							<smoothly-item value="4">Croissant</smoothly-item>
-							<smoothly-item value="5">Chocolate fondue</smoothly-item>
+							<smoothly-item value="4">Cookie</smoothly-item>
+							<smoothly-item value="5">Croissant</smoothly-item>
+							<smoothly-item value="6">Chocolate fondue</smoothly-item>
 							<smoothly-input-clear size="icon" slot="end"></smoothly-input-clear>
 						</smoothly-input-select>
 						<smoothly-input-select multiple name="select-dessert-multiple" looks="border">

--- a/src/components/input/select/index.tsx
+++ b/src/components/input/select/index.tsx
@@ -363,7 +363,7 @@ export class SmoothlyInputSelect implements Input, Editable, Clearable, Componen
 				<slot name="label" />
 				<div class={{ hidden: !this.open, options: true }} ref={(el: HTMLDivElement) => (this.optionsDiv = el)}>
 					{this.filter.length > 0 && (
-						<smoothly-item selectable={false}>
+						<smoothly-item selectable={false} class="search-item">
 							<smoothly-icon name="search-outline" size="small" />
 							{this.filter}
 							<smoothly-icon

--- a/src/components/input/select/index.tsx
+++ b/src/components/input/select/index.tsx
@@ -259,7 +259,7 @@ export class SmoothlyInputSelect implements Input, Editable, Clearable, Componen
 							this.filter = ""
 						break
 					case "Backspace":
-						this.filter = this.filter.slice(0, -1)
+						this.filter = event.ctrlKey ? "" : this.filter.slice(0, -1)
 						break
 					case "Enter":
 						const result = this.items.find(item => item.marked)
@@ -312,19 +312,16 @@ export class SmoothlyInputSelect implements Input, Editable, Clearable, Componen
 		}
 	}
 	private move(direction: -1 | 1): void {
-		let markedIndex = this.items.findIndex(item => item.marked)
+		const selectableItems = this.items.filter(item => !item.hidden && !item.disabled)
+		let markedIndex = selectableItems.findIndex(item => item.marked)
 		if (markedIndex == -1)
 			markedIndex = 0
 		else {
-			this.items[markedIndex].marked = false
-			markedIndex = (markedIndex + direction + this.items.length) % this.items.length
+			selectableItems[markedIndex].marked = false
+			markedIndex = (markedIndex + direction + selectableItems.length) % selectableItems.length
 		}
-		if (this.items.some(item => !item.hidden))
-			while (this.items[markedIndex].hidden) {
-				markedIndex = (markedIndex + direction + this.items.length) % this.items.length
-			}
-		this.items[markedIndex].marked = true
-		this.scrollTo(this.items[markedIndex], "smooth")
+		selectableItems[markedIndex].marked = true
+		this.scrollTo(selectableItems[markedIndex], "smooth")
 	}
 	private scrollTo(item: HTMLSmoothlyItemElement, behavior?: "instant" | "smooth") {
 		this.optionsDiv?.scrollTo({
@@ -363,7 +360,7 @@ export class SmoothlyInputSelect implements Input, Editable, Clearable, Componen
 				<slot name="label" />
 				<div class={{ hidden: !this.open, options: true }} ref={(el: HTMLDivElement) => (this.optionsDiv = el)}>
 					{this.filter.length > 0 && (
-						<smoothly-item selectable={false} class="search-item">
+						<div class="search-preview">
 							<smoothly-icon name="search-outline" size="small" />
 							{this.filter}
 							<smoothly-icon
@@ -385,7 +382,7 @@ export class SmoothlyInputSelect implements Input, Editable, Clearable, Componen
 									}}
 								/>
 							)}
-						</smoothly-item>
+						</div>
 					)}
 					<slot />
 					{this.addedItems}

--- a/src/components/input/select/style.css
+++ b/src/components/input/select/style.css
@@ -127,7 +127,9 @@
 	display: flex;
 	gap: 1em;
 	background-color: rgba(var(--smoothly-primary-tint), .5);
-	color: var(--smoothly-color-contrast);
+	color: rgb(var(--smoothly-color-contrast));
+	fill: rgb(var(--smoothly-color-contrast));
+	stroke: rgb(var(--smoothly-color-contrast));
 }
 
 :host>div.options>div.search-preview>smoothly-icon[name="backspace-outline"] {

--- a/src/components/input/select/style.css
+++ b/src/components/input/select/style.css
@@ -122,14 +122,14 @@
 	padding: .7em .7em .7em .25em;
 }
 
-:host>div.options::slotted(smoothly-item:not([selectable])) {
+:host>div.options::slotted(smoothly-item.search-item) {
 	display: flex;
 	gap: 1em;
 	background-color: rgba(var(--smoothly-primary-tint), .5);
-	color: var(--smoothly-color-contrast)
+	color: var(--smoothly-color-contrast);
 }
 
-:host>div.options>smoothly-item:not([selectable])>smoothly-icon[name="backspace-outline"] {
+:host>div.options>smoothly-item.search-item>smoothly-icon[name="backspace-outline"] {
 	margin-left: auto;
 	margin-right: 0;
 }

--- a/src/components/input/select/style.css
+++ b/src/components/input/select/style.css
@@ -118,18 +118,19 @@
 	right: -1px;
 }
 
-:host>div.options::slotted(smoothly-item) {
+:host>div.options::slotted(smoothly-item),
+:host>div.options::slotted(div.search-preview) {
 	padding: .7em .7em .7em .25em;
 }
 
-:host>div.options::slotted(smoothly-item.search-item) {
+:host>div.options::slotted(div.search-preview) {
 	display: flex;
 	gap: 1em;
 	background-color: rgba(var(--smoothly-primary-tint), .5);
 	color: var(--smoothly-color-contrast);
 }
 
-:host>div.options>smoothly-item.search-item>smoothly-icon[name="backspace-outline"] {
+:host>div.options>div.search-preview>smoothly-icon[name="backspace-outline"] {
 	margin-left: auto;
 	margin-right: 0;
 }

--- a/src/components/item/index.tsx
+++ b/src/components/item/index.tsx
@@ -26,7 +26,6 @@ export class SmoothlyItem implements Item, ComponentWillLoad, ComponentDidLoad {
 	@Prop() value: any
 	@Prop({ reflect: true, mutable: true }) selected: boolean = false
 	@Prop({ reflect: true, mutable: true }) marked: boolean
-	@Prop({ reflect: true }) selectable = true
 	@Prop({ reflect: true }) disabled = false
 	@Prop() deselectable = true
 	@Event() smoothlyItemSelect: EventEmitter<HTMLSmoothlyItemElement>
@@ -34,7 +33,7 @@ export class SmoothlyItem implements Item, ComponentWillLoad, ComponentDidLoad {
 
 	@Listen("click")
 	clickHandler(): void {
-		if (this.selectable && !this.disabled && (!this.selected || this.deselectable))
+		if (!this.disabled && (!this.selected || this.deselectable))
 			this.selected = !this.selected
 	}
 	@Watch("selected")
@@ -45,16 +44,15 @@ export class SmoothlyItem implements Item, ComponentWillLoad, ComponentDidLoad {
 		this.smoothlyInputLoad.emit(() => {})
 	}
 	componentDidLoad(): void {
-		if (this.selected && this.selectable && !this.disabled)
+		if (this.selected && !this.disabled)
 			this.smoothlyItemSelect.emit(this.element)
 	}
 	@Method()
 	async filter(filter: string): Promise<void> {
 		const value = typeof this.value === "string" ? this.value : JSON.stringify(this.value ?? "")
-		this.element.hidden =
-			filter && this.selectable
-				? !(value.includes(filter) || this.element.innerText.toLowerCase().includes(filter))
-				: false
+		this.element.hidden = filter
+			? !(value.includes(filter) || this.element.innerText.toLowerCase().includes(filter))
+			: false
 	}
 	render(): VNode | VNode[] {
 		return (

--- a/src/components/item/index.tsx
+++ b/src/components/item/index.tsx
@@ -27,13 +27,14 @@ export class SmoothlyItem implements Item, ComponentWillLoad, ComponentDidLoad {
 	@Prop({ reflect: true, mutable: true }) selected: boolean = false
 	@Prop({ reflect: true, mutable: true }) marked: boolean
 	@Prop({ reflect: true }) selectable = true
+	@Prop({ reflect: true }) disabled = false
 	@Prop() deselectable = true
 	@Event() smoothlyItemSelect: EventEmitter<HTMLSmoothlyItemElement>
 	@Event() smoothlyInputLoad: EventEmitter<(parent: Editable) => void>
 
 	@Listen("click")
 	clickHandler(): void {
-		if (this.selectable && (!this.selected || this.deselectable))
+		if (this.selectable && !this.disabled && (!this.selected || this.deselectable))
 			this.selected = !this.selected
 	}
 	@Watch("selected")
@@ -44,7 +45,7 @@ export class SmoothlyItem implements Item, ComponentWillLoad, ComponentDidLoad {
 		this.smoothlyInputLoad.emit(() => {})
 	}
 	componentDidLoad(): void {
-		if (this.selected && this.selectable)
+		if (this.selected && this.selectable && !this.disabled)
 			this.smoothlyItemSelect.emit(this.element)
 	}
 	@Method()

--- a/src/components/item/style.css
+++ b/src/components/item/style.css
@@ -4,6 +4,13 @@
 	border-left: .3em solid rgb(var(--smoothly-input-selected-border));
 }
 
+:host([disabled]),
+:host([disabled])::slotted(*) {
+	background-color: rgb(var(--smoothly-input-disabled-background));
+	color: rgb(var(--smoothly-input-disabled-foreground));
+	cursor: not-allowed;
+}
+
 :host {
 	padding: 0.5em;
 	cursor: pointer;
@@ -22,15 +29,10 @@
 }
 
 :host([marked]),
-:host:hover {
-	background-color: rgb(var(--smoothly-input-hover-background));
-	color: rgb(var(--smoothly-input-hover-foreground));
-	fill: rgb(var(--smoothly-input-hover-foreground));
-	stroke: rgb(var(--smoothly-input-hover-foreground));
-}
-
+:host:hover,
 :host([marked])::slotted(*),
 :host:hover::slotted(*) {
+	background-color: rgb(var(--smoothly-input-hover-background));
 	color: rgb(var(--smoothly-input-hover-foreground));
 	fill: rgb(var(--smoothly-input-hover-foreground));
 	stroke: rgb(var(--smoothly-input-hover-foreground));

--- a/src/components/item/style.css
+++ b/src/components/item/style.css
@@ -8,6 +8,7 @@
 :host([disabled])::slotted(*) {
 	background-color: rgb(var(--smoothly-input-disabled-background));
 	color: rgb(var(--smoothly-input-disabled-foreground));
+	opacity: var(--smoothly-input-disabled-opacity);
 	cursor: not-allowed;
 }
 

--- a/src/components/item/style.css
+++ b/src/components/item/style.css
@@ -1,14 +1,14 @@
 :host([selected]) {
-	background-color: rgb(var(--smoothly-input-selected-background));
-	color: rgb(var(--smoothly-input-selected-foreground));
-	border-left: .3em solid rgb(var(--smoothly-input-selected-border));
+	background-color: rgb(var(--smoothly-item-selected-background));
+	color: rgb(var(--smoothly-item-selected-foreground));
+	border-left: .3em solid rgb(var(--smoothly-item-selected-border));
 }
 
 :host([disabled]),
 :host([disabled])::slotted(*) {
-	background-color: rgb(var(--smoothly-input-disabled-background));
-	color: rgb(var(--smoothly-input-disabled-foreground));
-	opacity: var(--smoothly-input-disabled-opacity);
+	background-color: rgb(var(--smoothly-item-disabled-background));
+	color: rgb(var(--smoothly-item-disabled-foreground));
+	opacity: var(--smoothly-item-disabled-opacity);
 	cursor: not-allowed;
 }
 
@@ -16,25 +16,25 @@
 	padding: 0.5em;
 	cursor: pointer;
 	border-left: .3em solid transparent;
-	color: rgb(var(--smoothly-input-foreground));
-	fill: rgb(var(--smoothly-input-foreground));
-	stroke: rgb(var(--smoothly-input-foreground));
+	color: rgb(var(--smoothly-item-foreground));
+	fill: rgb(var(--smoothly-item-foreground));
+	stroke: rgb(var(--smoothly-item-foreground));
 	box-sizing: border-box;
 	min-height: 3rem;
 }
 
 :host::slotted(*) {
-	color: rgb(var(--smoothly-input-foreground));
-	fill: rgb(var(--smoothly-input-foreground));
-	stroke: rgb(var(--smoothly-input-foreground));
+	color: rgb(var(--smoothly-item-foreground));
+	fill: rgb(var(--smoothly-item-foreground));
+	stroke: rgb(var(--smoothly-item-foreground));
 }
 
 :host:not([disabled])[marked],
 :host:not([disabled]):hover,
 :host:not([disabled])[marked]::slotted(*),
 :host:not([disabled]):hover::slotted(*) {
-	background-color: rgb(var(--smoothly-input-hover-background));
-	color: rgb(var(--smoothly-input-hover-foreground));
-	fill: rgb(var(--smoothly-input-hover-foreground));
-	stroke: rgb(var(--smoothly-input-hover-foreground));
+	background-color: rgb(var(--smoothly-item-hover-background));
+	color: rgb(var(--smoothly-item-hover-foreground));
+	fill: rgb(var(--smoothly-item-hover-foreground));
+	stroke: rgb(var(--smoothly-item-hover-foreground));
 }

--- a/src/components/item/style.css
+++ b/src/components/item/style.css
@@ -28,10 +28,10 @@
 	stroke: rgb(var(--smoothly-input-foreground));
 }
 
-:host([marked]),
-:host:hover,
-:host([marked])::slotted(*),
-:host:hover::slotted(*) {
+:host:not([disabled])[marked],
+:host:not([disabled]):hover,
+:host:not([disabled])[marked]::slotted(*),
+:host:not([disabled]):hover::slotted(*) {
 	background-color: rgb(var(--smoothly-input-hover-background));
 	color: rgb(var(--smoothly-input-hover-foreground));
 	fill: rgb(var(--smoothly-input-hover-foreground));


### PR DESCRIPTION
## smoothly-item
- Replaced Prop `selectable` with `disabled`.
- Added own item css variables

### CSS variable changes
Item was using a lot of "input" css variables used by no other input, and since item is not even an input, I changed so item has their own css-variables.

#### Removed :x: 
`--smoothly-input-selected-background`
`--smoothly-input-selected-border`
`--smoothly-input-selected-foreground`

#### Added ✅
`--smoothly-item-foreground`
`--smoothly-item-background`

`--smoothly-item-hover-background`
`--smoothly-item-hover-foreground`

`--smoothly-item-selected-background`
`--smoothly-item-selected-border`
`--smoothly-item-selected-foreground`

`--smoothly-item-disabled-background`
`--smoothly-item-disabled-foreground`
`--smoothly-item-disabled-opacity`
