### PR TITLE
Fix common js export

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
 				"types": "./dist/types/index.d.ts"
 			},
 			"require": {
-				"default": "./dist/smoothly/index.cjs.js",
+				"default": "./dist/cjs/index.cjs.js",
 				"types": "./dist/types/index.d.ts"
 			}
 		},


### PR DESCRIPTION
exports.require.default points to a file that does not exist.