### PR TITLE
Fix Invalid icon placement for input, select and date-range

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -485,6 +485,7 @@ export namespace Components {
         "color"?: Color;
         "defined": boolean;
         "edit": (editable: boolean) => Promise<void>;
+        "errorMessage"?: string;
         "getItems": () => Promise<HTMLSmoothlyItemElement[]>;
         "getValue": () => Promise<any | any[] | undefined>;
         "inCalendar": boolean;
@@ -2751,6 +2752,7 @@ declare namespace LocalJSX {
         "clearable"?: boolean;
         "color"?: Color;
         "defined"?: boolean;
+        "errorMessage"?: string;
         "inCalendar"?: boolean;
         "invalid"?: boolean;
         "looks"?: Looks;

--- a/src/components/icon/style.css
+++ b/src/components/icon/style.css
@@ -5,6 +5,7 @@
 	display: flex;
 	align-items: center;
 	justify-content: center;
+	box-sizing: content-box;
 }
 :host[rotate] {
 	--rotate: rotate(var(--rotation, 0deg));

--- a/src/components/input/date/range/style.scss
+++ b/src/components/input/date/range/style.scss
@@ -53,6 +53,7 @@
 
 :host>section>smoothly-input {
 	min-width: 15rem;
+	width: 100%;
 	background-color: transparent;
 	--input-min-height: calc(var(--input-min-height) - 2px);
 }

--- a/src/components/input/demo/standard/index.tsx
+++ b/src/components/input/demo/standard/index.tsx
@@ -10,6 +10,8 @@ type Options = {
 	vertical?: boolean
 	showLabel?: boolean
 	placeholder?: boolean
+	invalid?: boolean
+	errorMessage?: string
 	borderRadius?: number
 }
 
@@ -21,7 +23,7 @@ type Options = {
 export class SmoothlyInputDemoStandard {
 	@Element() element: HTMLElement
 	@State() duration: isoly.TimeSpan = { hours: 8 }
-	@State() options: Options = { showLabel: true }
+	@State() options: Options = {}
 
 	connectedCallback() {
 		this.updateInputHeightText()
@@ -66,20 +68,15 @@ export class SmoothlyInputDemoStandard {
 							<smoothly-input-clear slot="end" />
 						</smoothly-input-select>
 						<smoothly-input-checkbox name="vertical">Vertical Layout</smoothly-input-checkbox>
-						<smoothly-input-checkbox name="showLabel" checked={this.options.showLabel}>
+						<smoothly-input-checkbox name="showLabel" checked={true}>
 							Show Label
 						</smoothly-input-checkbox>
-						<smoothly-input-checkbox name="placeholder" checked={this.options.placeholder}>
-							Placeholder
-						</smoothly-input-checkbox>
-						<smoothly-input-range
-							label={"Border Radius (rem)"}
-							name={"borderRadius"}
-							value={this.options.borderRadius}
-							min={0}
-							max={2}
-							step={0.25}
-						/>
+						<smoothly-input-checkbox name="placeholder">Placeholder</smoothly-input-checkbox>
+						<smoothly-input-checkbox name="invalid">Invalid</smoothly-input-checkbox>
+						<smoothly-input name="errorMessage" value="This is not a valid value">
+							Error Message
+						</smoothly-input>
+						<smoothly-input-range label={"Border Radius (rem)"} name={"borderRadius"} min={0} max={2} step={0.25} />
 					</smoothly-form>
 				</div>
 				<div class="input-wrapper" style={{ "--smoothly-input-border-radius": `${this.options.borderRadius}rem` }}>
@@ -89,18 +86,22 @@ export class SmoothlyInputDemoStandard {
 						name="text"
 						looks={this.options.looks}
 						placeholder={placeholder}
+						invalid={this.options.invalid}
+						errorMessage={this.options.errorMessage}
 						readonly={this.options.readonly}
 						color={this.options.color}
 						showLabel={this.options.showLabel}>
 						{this.options.showLabel && <span>Text</span>}
 						<smoothly-input-clear slot="end" />
 					</smoothly-input>
-					<div class="height"></div>
+					<div class="height" />
 
 					<smoothly-input-select
 						name="month"
 						looks={this.options.looks}
 						placeholder={placeholder}
+						invalid={this.options.invalid}
+						errorMessage={this.options.errorMessage}
 						readonly={this.options.readonly}
 						color={this.options.color}>
 						{this.options.showLabel && <label slot="label">Select</label>}
@@ -118,7 +119,7 @@ export class SmoothlyInputDemoStandard {
 						<smoothly-item value="12">December</smoothly-item>
 						<smoothly-input-clear slot="end" />
 					</smoothly-input-select>
-					<div class="height"></div>
+					<div class="height" />
 
 					<smoothly-input-checkbox
 						looks={this.options.looks}
@@ -126,7 +127,7 @@ export class SmoothlyInputDemoStandard {
 						color={this.options.color}>
 						Check
 					</smoothly-input-checkbox>
-					<div class="height"></div>
+					<div class="height" />
 
 					<smoothly-input-radio
 						name="radio"
@@ -143,7 +144,7 @@ export class SmoothlyInputDemoStandard {
 						<smoothly-input-radio-item value={"third"}>Label 3</smoothly-input-radio-item>
 						<smoothly-input-clear slot="end" />
 					</smoothly-input-radio>
-					<div class="height"></div>
+					<div class="height" />
 
 					<smoothly-input-file
 						looks={this.options.looks}
@@ -154,7 +155,7 @@ export class SmoothlyInputDemoStandard {
 						{this.options.showLabel && <span slot={"label"}>File</span>}
 						<smoothly-input-clear slot="end" />
 					</smoothly-input-file>
-					<div class="height"></div>
+					<div class="height" />
 
 					<smoothly-input-range
 						name={"range"}
@@ -164,7 +165,7 @@ export class SmoothlyInputDemoStandard {
 						color={this.options.color}>
 						<smoothly-input-clear slot="end" />
 					</smoothly-input-range>
-					<div class="height"></div>
+					<div class="height" />
 
 					<smoothly-input-color
 						looks={this.options.looks}
@@ -174,28 +175,30 @@ export class SmoothlyInputDemoStandard {
 						{this.options.showLabel && <span>Color</span>}
 						<smoothly-input-clear slot="end" />
 					</smoothly-input-color>
-					<div class="height"></div>
+					<div class="height" />
 
 					<smoothly-input-date
 						looks={this.options.looks}
 						readonly={this.options.readonly}
+						invalid={this.options.invalid}
 						color={this.options.color}
 						showLabel={this.options.showLabel}>
 						{this.options.showLabel && <span>Date</span>}
 						<smoothly-input-clear slot="end" />
 					</smoothly-input-date>
-					<div class="height"></div>
+					<div class="height" />
 
 					<smoothly-input-date-range
 						looks={this.options.looks}
 						readonly={this.options.readonly}
+						invalid={this.options.invalid}
 						color={this.options.color}
 						placeholder={placeholder}
 						showLabel={this.options.showLabel}>
 						{this.options.showLabel && <span>Date Range</span>}
 						<smoothly-input-clear slot="end" />
 					</smoothly-input-date-range>
-					<div class="height"></div>
+					<div class="height" />
 					<div class={{ "guide-lines": true, "show-label": !!this.options.showLabel }}>
 						{this.options.showLabel ? "Aligned labels & values" : "Center values"}
 					</div>

--- a/src/components/input/demo/standard/index.tsx
+++ b/src/components/input/demo/standard/index.tsx
@@ -68,7 +68,7 @@ export class SmoothlyInputDemoStandard {
 							<smoothly-input-clear slot="end" />
 						</smoothly-input-select>
 						<smoothly-input-checkbox name="vertical">Vertical Layout</smoothly-input-checkbox>
-						<smoothly-input-checkbox name="showLabel" checked={true}>
+						<smoothly-input-checkbox name="showLabel" checked>
 							Show Label
 						</smoothly-input-checkbox>
 						<smoothly-input-checkbox name="placeholder">Placeholder</smoothly-input-checkbox>

--- a/src/components/input/index.tsx
+++ b/src/components/input/index.tsx
@@ -33,7 +33,7 @@ export class SmoothlyInput implements Clearable, Input, Editable {
 	@Prop({ reflect: true }) currency?: isoly.Currency
 	@Prop({ reflect: true }) invalid?: boolean = false
 	@Prop({ mutable: true }) changed = false
-	@Prop() errorMessage?: string
+	@Prop({ reflect: true }) errorMessage?: string
 	@State() initialValue?: any
 	@State() state: Readonly<tidily.State> & Readonly<tidily.Settings>
 	parent: Editable | undefined
@@ -175,7 +175,7 @@ export class SmoothlyInput implements Clearable, Input, Editable {
 				class={{ "has-value": this.state?.value != undefined && this.state?.value != "" }}
 				onclick={() => this.inputElement?.focus()}>
 				<slot name="start" />
-				<div>
+				<div class="smoothly-input-container">
 					<div class={"ghost"}>
 						<div class={"value"}>{this.state?.value}</div>
 						<div class={"remainder"}>{this.state?.remainder}</div>
@@ -212,6 +212,8 @@ export class SmoothlyInput implements Clearable, Input, Editable {
 					<label class={"label float-on-focus"} htmlFor={this.name}>
 						<slot />
 					</label>
+				</div>
+				<div class="smoothly-invalid">
 					<smoothly-icon name="alert-circle" color="danger" fill="clear" size="small" toolTip={this.errorMessage} />
 				</div>
 				<slot name="end" />

--- a/src/components/input/index.tsx
+++ b/src/components/input/index.tsx
@@ -213,9 +213,14 @@ export class SmoothlyInput implements Clearable, Input, Editable {
 						<slot />
 					</label>
 				</div>
-				<div class="smoothly-invalid">
-					<smoothly-icon name="alert-circle" color="danger" fill="clear" size="small" toolTip={this.errorMessage} />
-				</div>
+				<smoothly-icon
+					class="smoothly-invalid"
+					name="alert-circle"
+					color="danger"
+					fill="clear"
+					size="small"
+					toolTip={this.errorMessage}
+				/>
 				<slot name="end" />
 			</Host>
 		)

--- a/src/components/input/select/index.tsx
+++ b/src/components/input/select/index.tsx
@@ -348,14 +348,6 @@ export class SmoothlyInputSelect implements Input, Editable, Clearable, Componen
 					{this.placeholder}
 				</div>
 				<div class="icons" ref={element => (this.iconsDiv = element)}>
-					<slot name="end" />
-					{this.looks == "border" && !this.readonly && (
-						<smoothly-icon
-							ref={element => (this.toggle = element)}
-							size="tiny"
-							name={this.open ? "caret-down-outline" : "caret-forward-outline"}
-						/>
-					)}
 					<smoothly-icon
 						class="smoothly-invalid"
 						name="alert-circle"
@@ -364,6 +356,14 @@ export class SmoothlyInputSelect implements Input, Editable, Clearable, Componen
 						size="small"
 						toolTip={this.errorMessage}
 					/>
+					<slot name="end" />
+					{this.looks == "border" && !this.readonly && (
+						<smoothly-icon
+							ref={element => (this.toggle = element)}
+							size="tiny"
+							name={this.open ? "caret-down-outline" : "caret-forward-outline"}
+						/>
+					)}
 				</div>
 				<slot name="label" />
 				<div class={{ hidden: !this.open, options: true }} ref={(el: HTMLDivElement) => (this.optionsDiv = el)}>

--- a/src/components/input/select/index.tsx
+++ b/src/components/input/select/index.tsx
@@ -37,7 +37,8 @@ export class SmoothlyInputSelect implements Input, Editable, Clearable, Componen
 	private items: HTMLSmoothlyItemElement[] = []
 	private itemHeight: number | undefined
 	@Element() element: HTMLSmoothlyInputSelectElement
-	@Prop() invalid?: boolean = false
+	@Prop({ reflect: true }) invalid?: boolean = false
+	@Prop({ reflect: true }) errorMessage?: string
 	@Prop({ reflect: true }) name = "selected"
 	@Prop({ reflect: true, mutable: true }) color?: Color
 	@Prop({ reflect: true, mutable: true }) looks?: Looks
@@ -341,7 +342,7 @@ export class SmoothlyInputSelect implements Input, Editable, Clearable, Componen
 		return (
 			<Host
 				tabIndex={0}
-				class={{ "has-value": this.selected.length !== 0, open: this.open, invalid: !!this.invalid }}
+				class={{ "has-value": this.selected.length !== 0, open: this.open }}
 				onClick={(event: Event) => this.handleShowOptions(event)}>
 				<div class="select-display" ref={element => (this.displaySelectedElement = element)}>
 					{this.placeholder}
@@ -355,7 +356,14 @@ export class SmoothlyInputSelect implements Input, Editable, Clearable, Componen
 							name={this.open ? "caret-down-outline" : "caret-forward-outline"}
 						/>
 					)}
-					<smoothly-icon class="invalid" name="alert-circle" color="danger" fill="clear" size="small" />
+					<smoothly-icon
+						class="smoothly-invalid"
+						name="alert-circle"
+						color="danger"
+						fill="clear"
+						size="small"
+						toolTip={this.errorMessage}
+					/>
 				</div>
 				<slot name="label" />
 				<div class={{ hidden: !this.open, options: true }} ref={(el: HTMLDivElement) => (this.optionsDiv = el)}>

--- a/src/components/input/select/style.css
+++ b/src/components/input/select/style.css
@@ -77,6 +77,7 @@
 
 :host[invalid]>div>smoothly-icon.smoothly-invalid {
 	display: block;
+	padding: 0.5rem;
 }
 
 :host>div>smoothly-icon.smoothly-invalid {
@@ -138,8 +139,4 @@
 
 :host>div.options.hidden {
 	display: none;
-}
-
-:host[invalid]>div>smoothly-icon {
-	display: block;
 }

--- a/src/components/input/select/style.css
+++ b/src/components/input/select/style.css
@@ -72,7 +72,6 @@
 	opacity: .7;
 	cursor: pointer;
 	height: 100%;
-	box-sizing: content-box;
 	padding-inline: var(--input-padding-side);
 }
 

--- a/src/components/input/select/style.css
+++ b/src/components/input/select/style.css
@@ -76,11 +76,11 @@
 	padding-inline: var(--input-padding-side);
 }
 
-:host.invalid>div>smoothly-icon.invalid {
+:host[invalid]>div>smoothly-icon.smoothly-invalid {
 	display: block;
 }
 
-:host>div>smoothly-icon.invalid {
+:host>div>smoothly-icon.smoothly-invalid {
 	display: none
 }
 
@@ -141,6 +141,6 @@
 	display: none;
 }
 
-:host.invalid>div>smoothly-icon {
+:host[invalid]>div>smoothly-icon {
 	display: block;
 }

--- a/src/components/input/style.css
+++ b/src/components/input/style.css
@@ -70,7 +70,6 @@
 	display: none;
 	z-index: 2;
 	cursor: pointer;
-	box-sizing: content-box;
 }
 
 :host[invalid]>.smoothly-invalid {

--- a/src/components/input/style.css
+++ b/src/components/input/style.css
@@ -14,13 +14,13 @@
 	display: none;
 }
 
-:host>div {
+:host>.smoothly-input-container {
 	position: relative;
 	width: 100%;
 	height: 100%;
 }
 
-:host>div>label {
+:host>.smoothly-input-container>label {
 	left: var(--input-padding-side);
 }
 
@@ -28,7 +28,7 @@
 	padding: 0 var(--input-padding-side);
 }
 
-:host>div>div.ghost {
+:host>.smoothly-input-container>div.ghost {
 	position: absolute;
   box-sizing: border-box;
   align-content: center;
@@ -39,18 +39,18 @@
 		var(--input-value-padding-bottom) 
 		var(--input-padding-side);
 }
-:host>div>div.ghost>div.value {
+:host>.smoothly-input-container>div.ghost>div.value {
 	display: inline;
 	pointer-events: none;
 	opacity: 0;
 }
-:host>div>div.ghost>div.remainder {
+:host>.smoothly-input-container>div.ghost>div.remainder {
 	display: inline;
 	pointer-events: none;
 	opacity: 0.5;
 }
 
-:host>div>input {
+:host>.smoothly-input-container>input {
 	padding: 
 		var(--input-value-padding-top) 
 		var(--input-padding-side) 
@@ -66,17 +66,15 @@
 	font-family: var(--smoothly-font-family);
 }
 
-:host>div>smoothly-icon {
+:host>.smoothly-invalid {
 	display: none;
-	position: absolute;
-	right: 0.2em;
-	top: 0.6em;
-}
-
-:host[invalid]>div>smoothly-icon {
-	display: block;
 	z-index: 2;
 	cursor: pointer;
+	box-sizing: content-box;
+}
+
+:host[invalid]>.smoothly-invalid {
+	display: flex;
 }
 
 :host>div>label {

--- a/src/components/input/style.css
+++ b/src/components/input/style.css
@@ -16,7 +16,7 @@
 
 :host>.smoothly-input-container {
 	position: relative;
-	width: 100%;
+	flex-grow: 1;
 	height: 100%;
 }
 
@@ -70,6 +70,7 @@
 	display: none;
 	z-index: 2;
 	cursor: pointer;
+	padding: 0.5rem;
 }
 
 :host[invalid]>.smoothly-invalid {


### PR DESCRIPTION
- Consistent order in `smoothly-input` and `smoothly-input-select` (invalid icon, slot=end)
- Add Prop `errorMessage` to `smoothly-input-select`
- Reflect invalid Prop instead of adding invalid class.
- Make date-range expand full width.
- Fix so `smoothly-icon` uses content-box sizing - this way you can set padding on smoothly-icon without making the icon smaller.

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td><img src=https://github.com/user-attachments/assets/0935b403-86ff-410f-83ed-d7dfb8da8397 /></td>
<td><img src=https://github.com/user-attachments/assets/d0cd698b-3089-4cea-8b5e-fa86825f7ccd /></td>
</tr>
</table>
