### PR TITLE
smoothly-app - code and performance improvements

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -877,8 +877,8 @@ declare global {
         new (): HTMLSmoothlyAppDemoElement;
     };
     interface HTMLSmoothlyAppRoomElementEventMap {
-        "smoothlyRoomSelected": { history: boolean };
-        "smoothlyRoomLoaded": { selected: boolean };
+        "smoothlyRoomSelect": { history: boolean };
+        "smoothlyRoomLoad": { selected: boolean };
     }
     interface HTMLSmoothlyAppRoomElement extends Components.SmoothlyAppRoom, HTMLStencilElement {
         addEventListener<K extends keyof HTMLSmoothlyAppRoomElementEventMap>(type: K, listener: (this: HTMLSmoothlyAppRoomElement, ev: SmoothlyAppRoomCustomEvent<HTMLSmoothlyAppRoomElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -2177,8 +2177,8 @@ declare namespace LocalJSX {
         "disabled"?: boolean;
         "icon"?: Icon;
         "label"?: string;
-        "onSmoothlyRoomLoaded"?: (event: SmoothlyAppRoomCustomEvent<{ selected: boolean }>) => void;
-        "onSmoothlyRoomSelected"?: (event: SmoothlyAppRoomCustomEvent<{ history: boolean }>) => void;
+        "onSmoothlyRoomLoad"?: (event: SmoothlyAppRoomCustomEvent<{ selected: boolean }>) => void;
+        "onSmoothlyRoomSelect"?: (event: SmoothlyAppRoomCustomEvent<{ history: boolean }>) => void;
         "path"?: string | URLPattern;
         "selected"?: boolean;
     }

--- a/src/components/app/index.tsx
+++ b/src/components/app/index.tsx
@@ -38,10 +38,10 @@ export class SmoothlyApp {
 			room => room?.element.path != this.selected?.element.path && room?.element.setSelected(false)
 		)
 		const content = await this.selected?.element.getContent()
-		if (this.mainElement && content) {
-			this.mainElement.innerHTML = ""
-			this.mainElement.appendChild(content)
-		}
+		requestAnimationFrame(() => {
+			if (this.mainElement && content)
+				this.mainElement.replaceChildren(content)
+		})
 	}
 	burgerVisibilityHandler(event: CustomEvent<boolean>) {
 		this.burgerVisibility = event.detail
@@ -54,7 +54,7 @@ export class SmoothlyApp {
 	async locationChangeHandler(event: PopStateEvent) {
 		this.rooms[event.state.smoothlyPath]?.element.setSelected(true, { history: true })
 	}
-	@Listen("smoothlyRoomSelected")
+	@Listen("smoothlyRoomSelect")
 	roomSelectedHandler(event: SmoothlyAppRoomCustomEvent<{ history: boolean }>) {
 		this.selected = { element: event.target }
 		if (this.burgerVisibility)
@@ -66,7 +66,7 @@ export class SmoothlyApp {
 			window.history.pushState({ smoothlyPath: path }, "", location.href)
 		}
 	}
-	@Listen("smoothlyRoomLoaded")
+	@Listen("smoothlyRoomLoad")
 	roomLoadedHandler(event: SmoothlyAppRoomCustomEvent<{ selected: boolean }>) {
 		const room = (this.rooms[event.target.path.toString()] = { element: event.target })
 		if (room.element.selected) {
@@ -76,11 +76,8 @@ export class SmoothlyApp {
 	}
 	@Listen("click", { target: "window" })
 	clickHandler(event: MouseEvent) {
-		if (this.burgerVisibility)
-			if (event.composedPath().some(e => e == this.burgerElement || e == this.navElement))
-				!this.menuOpen
-			else
-				this.menuOpen = false
+		if (this.burgerVisibility && !event.composedPath().some(e => e == this.burgerElement || e == this.navElement))
+			this.menuOpen = false
 	}
 	render() {
 		return (

--- a/src/components/app/index.tsx
+++ b/src/components/app/index.tsx
@@ -87,7 +87,7 @@ export class SmoothlyApp {
 						<a href={""}>{this.label}</a>
 					</h1>
 					<slot name="header" />
-					<nav ref={e => (this.navElement = e)} class={{ "menu-open": this.menuOpen }}>
+					<nav ref={e => (this.navElement = e)}>
 						<ul>
 							<div class={"nav-start-container"}>
 								<slot name="nav-start" />

--- a/src/components/app/room/index.tsx
+++ b/src/components/app/room/index.tsx
@@ -14,15 +14,15 @@ export class SmoothlyAppRoom {
 	@Prop() path: string | URLPattern = ""
 	@Prop({ reflect: true, mutable: true }) selected?: boolean
 	@Prop() content?: VNode | FunctionalComponent
-	@Event() smoothlyRoomSelected: EventEmitter<{ history: boolean }>
-	@Event() smoothlyRoomLoaded: EventEmitter<{ selected: boolean }>
+	@Event() smoothlyRoomSelect: EventEmitter<{ history: boolean }>
+	@Event() smoothlyRoomLoad: EventEmitter<{ selected: boolean }>
 	private contentElement?: HTMLElement
 
 	componentWillLoad() {
 		this.selected = (typeof this.path == "string" ? new URLPattern({ pathname: this.path }) : this.path).test(
 			window.location
 		)
-		this.smoothlyRoomLoaded.emit({ selected: this.selected })
+		this.smoothlyRoomLoad.emit({ selected: this.selected })
 	}
 
 	@Method()
@@ -33,7 +33,7 @@ export class SmoothlyAppRoom {
 	async setSelected(selected: boolean, options?: { history?: boolean }): Promise<void> {
 		this.selected = selected
 		if (selected)
-			this.smoothlyRoomSelected.emit({ history: !!options?.history })
+			this.smoothlyRoomSelect.emit({ history: !!options?.history })
 	}
 
 	clickHandler(event: MouseEvent) {

--- a/src/components/app/style.css
+++ b/src/components/app/style.css
@@ -149,7 +149,7 @@ smoothly-app>smoothly-notifier>header>nav>ul li a {
 	}
 }
 
-smoothly-app>smoothly-notifier>header>nav:not(.menu-open) {
+smoothly-app:not([menu-open])>smoothly-notifier>header>nav {
 	display: none;
 }
 


### PR DESCRIPTION
- Change event names to present tense 
- Remove code that does nothing (!this.menuOpen)
- Use replaceChildren and requestAnimationFrame, to not cause extra animation reflows and repaints and updating at the optimal part in the rendering cycle.
- Remove `"menu-open"` since `menuOpen` is already reflected.