### PR TITLE
smoothly-notifier does not block mouse events

### DIFF
--- a/src/components/notifier/index.tsx
+++ b/src/components/notifier/index.tsx
@@ -22,11 +22,11 @@ export class Notifier {
 		return (
 			<Host>
 				<slot />
-				<aside>
+				<div class="smoothly-notifier-wrapper">
 					{this.notices.map(n => (
 						<smoothly-notification notice={n} icon={this.icon} />
 					))}
-				</aside>
+				</div>
 			</Host>
 		)
 	}

--- a/src/components/notifier/style.css
+++ b/src/components/notifier/style.css
@@ -4,7 +4,8 @@
 :host[hidden] {
 	display: none;
 }
-:host > aside {
+:host > .smoothly-notifier-wrapper {
+	pointer-events: none;
 	display: flex;
 	flex-wrap: wrap-reverse;
 	align-content: stretch;
@@ -13,4 +14,8 @@
 	left: 0;
 	text-align: center;
 	z-index: 100;
+}
+
+:host > .smoothly-notifier-wrapper > smoothly-notification {
+	pointer-events: all;
 }


### PR DESCRIPTION


## Example
Purple area would block all mouse clicks even tho it's transparent.
![image](https://github.com/user-attachments/assets/583bdf61-b8ee-4eab-b244-ea7da76a442d)
