### PR TITLE
Make JSON fully selectable to copy even when collapsed

### DIFF
--- a/src/components/display/json/object/style.css
+++ b/src/components/display/json/object/style.css
@@ -11,7 +11,10 @@
 	border-left: 1px solid rgba(var(--smoothly-default-contrast), 0.3);
 }
 :host(:not(.open)) .content {
-	display: none;
+	/* Hide content so it's still selectable and you can copy the full JSON */
+	opacity: 0;
+	position: absolute;
+	pointer-events: none;
 }
 :host>.content>.indent:last-child>.comma {
 	display: none;


### PR DESCRIPTION
Before it would just copy empty object/array if you copied a collapsed part.

[Screencast from 2025-03-27 17:03:31.webm](https://github.com/user-attachments/assets/1182f50e-eee3-45a8-8aea-39cd15bb7336)

