### PR TITLE
Add Tabs Prop hideTabsIfSingle

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -655,6 +655,7 @@ export namespace Components {
         "open": boolean;
     }
     interface SmoothlyTabs {
+        "hideTabsIfSingle": boolean;
     }
     interface SmoothlyTabsDemo {
     }
@@ -2816,6 +2817,7 @@ declare namespace LocalJSX {
         "open"?: boolean;
     }
     interface SmoothlyTabs {
+        "hideTabsIfSingle"?: boolean;
         "onSmoothlyTabOpen"?: (event: SmoothlyTabsCustomEvent<string>) => void;
     }
     interface SmoothlyTabsDemo {

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -655,7 +655,7 @@ export namespace Components {
         "open": boolean;
     }
     interface SmoothlyTabs {
-        "hideTabsIfSingle": boolean;
+        "tabs": "always" | "multiple";
     }
     interface SmoothlyTabsDemo {
     }
@@ -2817,8 +2817,8 @@ declare namespace LocalJSX {
         "open"?: boolean;
     }
     interface SmoothlyTabs {
-        "hideTabsIfSingle"?: boolean;
         "onSmoothlyTabOpen"?: (event: SmoothlyTabsCustomEvent<string>) => void;
+        "tabs"?: "always" | "multiple";
     }
     interface SmoothlyTabsDemo {
     }

--- a/src/components/tabs/demo/index.tsx
+++ b/src/components/tabs/demo/index.tsx
@@ -1,4 +1,4 @@
-import { Component, h } from "@stencil/core"
+import { Component, h, Host, State } from "@stencil/core"
 
 @Component({
 	tag: "smoothly-tabs-demo",
@@ -6,15 +6,38 @@ import { Component, h } from "@stencil/core"
 	scoped: true,
 })
 export class SmoothlyTabsDemo {
+	@State() extraTab: boolean
+
 	render() {
 		return (
-			<smoothly-tabs>
-				<smoothly-tab label="test1" open>
-					Hello world!
-				</smoothly-tab>
-				<smoothly-tab label="test2">this is a test message!</smoothly-tab>
-				<smoothly-tab label="test3">this is a test message again!</smoothly-tab>
-			</smoothly-tabs>
+			<Host>
+				<smoothly-tabs hideTabsIfSingle>
+					<smoothly-tab label="Single Tab" open>
+						<strong>Single Tab content here.</strong> If only one tab is available setting <code>hideTabsIfSingle</code>{" "}
+						to <code>true</code> will hide the tab navigation and display the single tab's content directly.
+						{!this.extraTab && (
+							<div>
+								<smoothly-button color="primary" onClick={() => (this.extraTab = true)}>
+									Click to add extra tab
+								</smoothly-button>
+							</div>
+						)}
+					</smoothly-tab>
+					{this.extraTab && (
+						<smoothly-tab label="Extra tab">
+							When there are more then one tab, the tab navigation will show.
+						</smoothly-tab>
+					)}
+				</smoothly-tabs>
+
+				<smoothly-tabs>
+					<smoothly-tab label="test1" open>
+						Hello world!
+					</smoothly-tab>
+					<smoothly-tab label="test2">this is a test message!</smoothly-tab>
+					<smoothly-tab label="test3">this is a test message again!</smoothly-tab>
+				</smoothly-tabs>
+			</Host>
 		)
 	}
 }

--- a/src/components/tabs/demo/index.tsx
+++ b/src/components/tabs/demo/index.tsx
@@ -11,10 +11,10 @@ export class SmoothlyTabsDemo {
 	render() {
 		return (
 			<Host>
-				<smoothly-tabs hideTabsIfSingle>
+				<smoothly-tabs tabs="multiple">
 					<smoothly-tab label="Single Tab" open>
-						<strong>Single Tab content here.</strong> If only one tab is available setting <code>hideTabsIfSingle</code>{" "}
-						to <code>true</code> will hide the tab navigation and display the single tab's content directly.
+						<strong>Single Tab content here.</strong> If only one tab is available setting <code>tabs</code> to{" "}
+						<code>"multiple"</code> will hide the tab navigation and display the single tab's content directly.
 						{!this.extraTab && (
 							<div>
 								<smoothly-button color="primary" onClick={() => (this.extraTab = true)}>

--- a/src/components/tabs/demo/style.css
+++ b/src/components/tabs/demo/style.css
@@ -8,4 +8,11 @@
 	margin: auto;
 	max-width: 1200px;
 	width: 100%;
+	margin-block: 5rem;
+}
+:host code {
+	color: rgb(var(--smoothly-medium-contrast));
+	background-color: rgb(var(--smoothly-medium-color));
+	padding-inline: 0.25rem;
+	border-radius: 0.25rem;
 }

--- a/src/components/tabs/index.tsx
+++ b/src/components/tabs/index.tsx
@@ -1,4 +1,4 @@
-import { Component, Element, Event, EventEmitter, h, Host, Listen, State, Watch } from "@stencil/core"
+import { Component, Element, Event, EventEmitter, h, Host, Listen, Prop, State, Watch } from "@stencil/core"
 
 @Component({
 	tag: "smoothly-tabs",
@@ -7,6 +7,7 @@ import { Component, Element, Event, EventEmitter, h, Host, Listen, State, Watch 
 })
 export class SmoothlyTabs {
 	@Element() element: HTMLSmoothlyTabsElement
+	@Prop({ reflect: true }) hideTabsIfSingle: boolean
 	@State() tabs: HTMLElement[] = []
 	@State() selectedElement: HTMLSmoothlyTabElement
 	@Event() smoothlyTabOpen: EventEmitter<string>
@@ -34,7 +35,9 @@ export class SmoothlyTabs {
 
 	render() {
 		return (
-			<Host style={{ "--tabs": `${this.tabs.length}` }}>
+			<Host
+				class={{ "hide-tabs": this.hideTabsIfSingle && this.tabs.length == 1 }}
+				style={{ "--tabs": `${this.tabs.length}` }}>
 				<slot />
 			</Host>
 		)

--- a/src/components/tabs/index.tsx
+++ b/src/components/tabs/index.tsx
@@ -7,15 +7,15 @@ import { Component, Element, Event, EventEmitter, h, Host, Listen, Prop, State, 
 })
 export class SmoothlyTabs {
 	@Element() element: HTMLSmoothlyTabsElement
-	@Prop({ reflect: true }) hideTabsIfSingle: boolean
-	@State() tabs: HTMLElement[] = []
+	@Prop({ reflect: true }) tabs: "always" | "multiple" = "always"
+	@State() tabElements: HTMLElement[] = []
 	@State() selectedElement: HTMLSmoothlyTabElement
 	@Event() smoothlyTabOpen: EventEmitter<string>
 
 	@Listen("smoothlyTabLoad")
 	onInputLoad(event: CustomEvent) {
-		if (event.target instanceof HTMLElement && !this.tabs.includes(event.target)) {
-			this.tabs = [...this.tabs, event.target]
+		if (event.target instanceof HTMLElement && !this.tabElements.includes(event.target)) {
+			this.tabElements = [...this.tabElements, event.target]
 		}
 	}
 
@@ -36,8 +36,8 @@ export class SmoothlyTabs {
 	render() {
 		return (
 			<Host
-				class={{ "hide-tabs": this.hideTabsIfSingle && this.tabs.length == 1 }}
-				style={{ "--tabs": `${this.tabs.length}` }}>
+				class={{ "hide-tabs": this.tabs == "multiple" && this.tabElements.length == 1 }}
+				style={{ "--tabs": `${this.tabElements.length}` }}>
 				<slot />
 			</Host>
 		)

--- a/src/components/tabs/style.css
+++ b/src/components/tabs/style.css
@@ -3,3 +3,6 @@
 	grid-template-columns: repeat(var(--tabs), auto);
 	grid-template-rows: auto auto;
 }
+:host.hide-tabs::slotted(smoothly-tab>div:first-child) {
+	display: none;
+}


### PR DESCRIPTION
Add Prop to hide tabs if there is only one.
This is useful e.g. if some users don't have to see one of the tabs, then showing the tab-navigation is sort of pointless.

[Screencast from 2025-03-28 09:47:03.webm](https://github.com/user-attachments/assets/cbe15388-5f62-4fd3-8290-1016cfb1dd36)
