### PR TITLE
Support renaming input fields in form

### DIFF
--- a/src/components/input/Input.ts
+++ b/src/components/input/Input.ts
@@ -51,14 +51,19 @@ export namespace Input {
 	})
 	export const is = type.is
 
-	export function formRemove(self: Input) {
-		if (self.parent instanceof SmoothlyForm) {
-			self.parent.removeInput(self.name)
-		}
+	export function formRemove(self: Input, name?: string) {
+		if (self.parent instanceof SmoothlyForm)
+			self.parent.removeInput(name ?? self.name)
 	}
 	export function formAdd(self: Input) {
 		self.smoothlyInputLoad.emit(parent => (self.parent = parent))
 	}
+	export function formRename(self: Input, oldName?: string) {
+		if (oldName)
+			formRemove(self, oldName)
+		formAdd(self)
+	}
+
 	/* For adding clear, edit, reset that is inside input etc. - should be called on smoothlyInputLoad */
 	export function registerSubAction(self: Input & Editable, event: CustomEvent<(parent: Editable) => void>) {
 		if (!(event.target && "name" in event.target && event.target.name === self.name)) {

--- a/src/components/input/checkbox/index.tsx
+++ b/src/components/input/checkbox/index.tsx
@@ -41,6 +41,10 @@ export class SmoothlyInputCheckbox implements Input, Clearable, Editable, Compon
 		if (!this.element.isConnected)
 			await this.unregister()
 	}
+	@Watch("name")
+	nameChange(_: string | undefined, oldName: string | undefined) {
+		Input.formRename(this, oldName)
+	}
 	@Method()
 	async register() {
 		Input.formAdd(this)

--- a/src/components/input/color/index.tsx
+++ b/src/components/input/color/index.tsx
@@ -72,6 +72,10 @@ export class SmoothlyInputColor implements Input, Clearable, Editable, Component
 		if (!this.element.isConnected)
 			await this.unregister()
 	}
+	@Watch("name")
+	nameChange(_: string | undefined, oldName: string | undefined) {
+		Input.formRename(this, oldName)
+	}
 	@Method()
 	async register() {
 		Input.formAdd(this)

--- a/src/components/input/date/index.tsx
+++ b/src/components/input/date/index.tsx
@@ -59,6 +59,10 @@ export class SmoothlyInputDate implements ComponentWillLoad, Clearable, Input, E
 		if (!this.element.isConnected)
 			await this.unregister()
 	}
+	@Watch("name")
+	nameChange(_: string | undefined, oldName: string | undefined) {
+		Input.formRename(this, oldName)
+	}
 	@Method()
 	async register() {
 		Input.formAdd(this)

--- a/src/components/input/date/range/index.tsx
+++ b/src/components/input/date/range/index.tsx
@@ -83,6 +83,10 @@ export class SmoothlyInputDateRange implements Clearable, Input, Editable {
 		if (!this.element.isConnected)
 			await this.unregister()
 	}
+	@Watch("name")
+	nameChange(_: string | undefined, oldName: string | undefined) {
+		Input.formRename(this, oldName)
+	}
 	@Method()
 	async register() {
 		Input.formAdd(this)

--- a/src/components/input/date/time/index.tsx
+++ b/src/components/input/date/time/index.tsx
@@ -63,6 +63,10 @@ export class SmoothlyInputDateTime implements ComponentWillLoad, Clearable, Inpu
 		if (!this.element.isConnected)
 			await this.unregister()
 	}
+	@Watch("name")
+	nameChange(_: string | undefined, oldName: string | undefined) {
+		Input.formRename(this, oldName)
+	}
 	@Method()
 	async register() {
 		Input.formAdd(this)

--- a/src/components/input/file/index.tsx
+++ b/src/components/input/file/index.tsx
@@ -65,6 +65,10 @@ export class SmoothlyInputFile implements ComponentWillLoad, Input, Clearable, E
 		if (!this.element.isConnected)
 			await this.unregister()
 	}
+	@Watch("name")
+	nameChange(_: string | undefined, oldName: string | undefined) {
+		Input.formRename(this, oldName)
+	}
 	@Method()
 	async register() {
 		Input.formAdd(this)

--- a/src/components/input/index.tsx
+++ b/src/components/input/index.tsx
@@ -80,6 +80,10 @@ export class SmoothlyInput implements Clearable, Input, Editable {
 		this.listener[property] = listener
 		listener(this)
 	}
+	@Watch("name")
+	nameChange(_: string | undefined, oldName: string | undefined) {
+		Input.formRename(this, oldName)
+	}
 	@Method()
 	async register() {
 		Input.formAdd(this)

--- a/src/components/input/month/index.tsx
+++ b/src/components/input/month/index.tsx
@@ -86,6 +86,10 @@ export class SmoothlyInputMonth implements ComponentWillLoad, Input, Editable {
 		const maxMonth = this.max?.substring(0, 7)
 		this.allowNextMonth = !maxMonth || nextMonth <= maxMonth
 	}
+	@Watch("name")
+	nameChange(_: string | undefined, oldName: string | undefined) {
+		Input.formRename(this, oldName)
+	}
 	@Method()
 	async register() {
 		Input.formAdd(this)

--- a/src/components/input/radio/index.tsx
+++ b/src/components/input/radio/index.tsx
@@ -86,6 +86,10 @@ export class SmoothlyInputRadio implements Input, Clearable, Editable, Component
 		if (!this.element.isConnected)
 			await this.unregister()
 	}
+	@Watch("name")
+	nameChange(_: string | undefined, oldName: string | undefined) {
+		Input.formRename(this, oldName)
+	}
 	@Method()
 	async register() {
 		Input.formAdd(this)

--- a/src/components/input/range/index.tsx
+++ b/src/components/input/range/index.tsx
@@ -73,6 +73,10 @@ export class SmoothlyInputRange implements Input, Clearable, Editable, Component
 		if (!this.element.isConnected)
 			await this.unregister()
 	}
+	@Watch("name")
+	nameChange(_: string | undefined, oldName: string | undefined) {
+		Input.formRename(this, oldName)
+	}
 	@Method()
 	async register() {
 		Input.formAdd(this)

--- a/src/components/input/select/index.tsx
+++ b/src/components/input/select/index.tsx
@@ -100,6 +100,10 @@ export class SmoothlyInputSelect implements Input, Editable, Clearable, Componen
 		if (!this.element.isConnected)
 			await this.unregister()
 	}
+	@Watch("name")
+	nameChange(_: string | undefined, oldName: string | undefined) {
+		Input.formRename(this, oldName)
+	}
 	@Method()
 	async register() {
 		Input.formAdd(this)


### PR DESCRIPTION
This is especially important when dealing with lists.

## Example
A list of `pets.0`, `pets.1`, `pets.2`.
If `pets.1` get's removed then we will rename `pets.2` -> `pets.1`, and we want to make sure `pets.2` is gone from form.