### PR TITLE
Clean up input standard demo

### DIFF
--- a/src/assets/style/mapping.css
+++ b/src/assets/style/mapping.css
@@ -25,6 +25,9 @@ smoothly-color {
 	--smoothly-input-foreground: var(--smoothly-default-contrast);
 	--smoothly-input-background: var(--smoothly-default-tint);
 	--smoothly-input-border: var(--smoothly-default-shade);
+	--smoothly-input-disabled-foreground: var(--smoothly-default-contrast);
+	--smoothly-input-disabled-background: var(--smoothly-default-shade);
+	--smoothly-input-disabled-border: var(--smoothly-default-shade);
 	--smoothly-input-border-readonly: var(--smoothly-input-border), 50%;
 	--smoothly-input-border-radius: 0;
 

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -510,6 +510,7 @@ export namespace Components {
         "clearable": boolean;
         "color"?: Color;
         "defined": boolean;
+        "disabled": boolean;
         "edit": (editable: boolean) => Promise<void>;
         "errorMessage"?: string;
         "getItems": () => Promise<HTMLSmoothlyItemElement[]>;
@@ -2666,6 +2667,7 @@ declare namespace LocalJSX {
         "clearable"?: boolean;
         "color"?: Color;
         "defined"?: boolean;
+        "disabled"?: boolean;
         "errorMessage"?: string;
         "inCalendar"?: boolean;
         "invalid"?: boolean;

--- a/src/components/input/Input.ts
+++ b/src/components/input/Input.ts
@@ -18,6 +18,7 @@ export namespace Input {
 		register: () => Promise<void>
 		unregister: () => Promise<void>
 		getValue: GetValue
+		disabled?: boolean
 		color?: Color
 		name: string
 		invalid?: boolean
@@ -30,6 +31,7 @@ export namespace Input {
 			register: isly.function<() => Promise<void>>(),
 			unregister: isly.function<() => Promise<void>>(),
 			getValue: isly.function<GetValue>(),
+			disabled: isly.boolean().optional(),
 			color: Color.type.optional(),
 			name: isly.string(),
 			invalid: isly.boolean().optional(),

--- a/src/components/input/clear/index.tsx
+++ b/src/components/input/clear/index.tsx
@@ -30,7 +30,8 @@ export class SmoothlyInputClear {
 				if (Editable.Element.is(parent)) {
 					parent.listen("changed", async p => {
 						if (Input.is(p)) {
-							this.display = !p.readonly && (typeof p.defined == "boolean" ? p.defined : Boolean(await p.getValue()))
+							this.display =
+								!p.readonly && !p.disabled && (typeof p.defined == "boolean" ? p.defined : Boolean(await p.getValue()))
 						}
 						if (p instanceof SmoothlyForm) {
 							this.disabled = p.readonly || Object.values(p.value).filter(val => val).length < 1

--- a/src/components/input/demo/standard/index.tsx
+++ b/src/components/input/demo/standard/index.tsx
@@ -6,6 +6,7 @@ import { Looks } from "../../Looks"
 type Options = {
 	looks?: Looks
 	readonly?: boolean
+	disabled?: boolean
 	color?: Color
 	vertical?: boolean
 	showLabel?: boolean
@@ -67,6 +68,7 @@ export class SmoothlyInputDemoStandard {
 							))}
 							<smoothly-input-clear slot="end" />
 						</smoothly-input-select>
+						<smoothly-input-checkbox name="disabled">Disabled</smoothly-input-checkbox>
 						<smoothly-input-checkbox name="vertical">Vertical Layout</smoothly-input-checkbox>
 						<smoothly-input-checkbox name="showLabel" checked>
 							Show Label
@@ -89,6 +91,7 @@ export class SmoothlyInputDemoStandard {
 						invalid={this.options.invalid}
 						errorMessage={this.options.errorMessage}
 						readonly={this.options.readonly}
+						disabled={this.options.disabled}
 						color={this.options.color}
 						showLabel={this.options.showLabel}>
 						{this.options.showLabel && <span>Text</span>}
@@ -103,6 +106,7 @@ export class SmoothlyInputDemoStandard {
 						invalid={this.options.invalid}
 						errorMessage={this.options.errorMessage}
 						readonly={this.options.readonly}
+						disabled={this.options.disabled}
 						color={this.options.color}>
 						{this.options.showLabel && <label slot="label">Select</label>}
 						<smoothly-item value="1">January</smoothly-item>
@@ -124,6 +128,7 @@ export class SmoothlyInputDemoStandard {
 					<smoothly-input-checkbox
 						looks={this.options.looks}
 						readonly={this.options.readonly}
+						disabled={this.options.disabled}
 						color={this.options.color}>
 						Check
 					</smoothly-input-checkbox>
@@ -134,6 +139,7 @@ export class SmoothlyInputDemoStandard {
 						clearable
 						looks={this.options.looks}
 						readonly={this.options.readonly}
+						// TODO - disabled
 						color={this.options.color}
 						showLabel={this.options.showLabel}>
 						{this.options.showLabel && <label slot="label">Radio</label>}
@@ -149,6 +155,7 @@ export class SmoothlyInputDemoStandard {
 					<smoothly-input-file
 						looks={this.options.looks}
 						readonly={this.options.readonly}
+						// TODO - disabled
 						color={this.options.color}
 						placeholder={placeholder}
 						showLabel={this.options.showLabel}>
@@ -162,6 +169,7 @@ export class SmoothlyInputDemoStandard {
 						label={this.options.showLabel ? "Range" : undefined}
 						looks={this.options.looks}
 						readonly={this.options.readonly}
+						// TODO - disabled
 						color={this.options.color}>
 						<smoothly-input-clear slot="end" />
 					</smoothly-input-range>
@@ -170,6 +178,7 @@ export class SmoothlyInputDemoStandard {
 					<smoothly-input-color
 						looks={this.options.looks}
 						readonly={this.options.readonly}
+						// TODO - disabled
 						color={this.options.color}
 						showLabel={this.options.showLabel}>
 						{this.options.showLabel && <span>Color</span>}
@@ -180,6 +189,7 @@ export class SmoothlyInputDemoStandard {
 					<smoothly-input-date
 						looks={this.options.looks}
 						readonly={this.options.readonly}
+						// TODO - disabled
 						invalid={this.options.invalid}
 						color={this.options.color}
 						showLabel={this.options.showLabel}>
@@ -191,6 +201,7 @@ export class SmoothlyInputDemoStandard {
 					<smoothly-input-date-time
 						looks={this.options.looks}
 						readonly={this.options.readonly}
+						// TODO - disabled
 						invalid={this.options.invalid}
 						errorMessage={this.options.errorMessage}
 						color={this.options.color}
@@ -203,6 +214,7 @@ export class SmoothlyInputDemoStandard {
 					<smoothly-input-date-range
 						looks={this.options.looks}
 						readonly={this.options.readonly}
+						// TODO - disabled
 						invalid={this.options.invalid}
 						color={this.options.color}
 						placeholder={placeholder}

--- a/src/components/input/demo/standard/index.tsx
+++ b/src/components/input/demo/standard/index.tsx
@@ -4,16 +4,15 @@ import { Color } from "../../../../model"
 import { Looks } from "../../Looks"
 
 type Options = {
+	color?: Color
 	looks?: Looks
+	borderRadius?: number
 	readonly?: boolean
 	disabled?: boolean
-	color?: Color
-	vertical?: boolean
-	showLabel?: boolean
-	placeholder?: boolean
 	invalid?: boolean
 	errorMessage?: string
-	borderRadius?: number
+	showLabel?: boolean
+	placeholder?: string
 }
 
 @Component({
@@ -42,9 +41,8 @@ export class SmoothlyInputDemoStandard {
 	}
 
 	render() {
-		const placeholder = this.options.placeholder ? "placeholder" : undefined
 		return (
-			<Host class={{ vertical: !!this.options.vertical }}>
+			<Host>
 				<div class="description">
 					<h2>Input Standard</h2>
 					<p>
@@ -52,13 +50,6 @@ export class SmoothlyInputDemoStandard {
 						100% zoom, assuming a root font-size of 16 pixels.
 					</p>
 					<smoothly-form looks={"grid"} onSmoothlyFormInput={(e: CustomEvent<Options>) => (this.options = e.detail)}>
-						<smoothly-input-select name="looks">
-							<span slot="label">Looks</span>
-							{Looks.values.map(l => (
-								<smoothly-item value={l}>{l}</smoothly-item>
-							))}
-						</smoothly-input-select>
-						<smoothly-input-checkbox name="readonly">Readonly</smoothly-input-checkbox>
 						<smoothly-input-select name="color">
 							<span slot="label">Color</span>
 							{Color.values.map(c => (
@@ -68,32 +59,38 @@ export class SmoothlyInputDemoStandard {
 							))}
 							<smoothly-input-clear slot="end" />
 						</smoothly-input-select>
+						<smoothly-input-select name="looks">
+							<span slot="label">Looks</span>
+							{Looks.values.map(l => (
+								<smoothly-item value={l}>{l}</smoothly-item>
+							))}
+						</smoothly-input-select>
+						<smoothly-input-range label={"Border Radius (rem)"} name={"borderRadius"} min={0} max={2} step={0.25} />
+						<smoothly-input-checkbox name="readonly">Readonly</smoothly-input-checkbox>
 						<smoothly-input-checkbox name="disabled">Disabled</smoothly-input-checkbox>
-						<smoothly-input-checkbox name="vertical">Vertical Layout</smoothly-input-checkbox>
-						<smoothly-input-checkbox name="showLabel" checked>
-							Show Label
-						</smoothly-input-checkbox>
-						<smoothly-input-checkbox name="placeholder">Placeholder</smoothly-input-checkbox>
 						<smoothly-input-checkbox name="invalid">Invalid</smoothly-input-checkbox>
 						<smoothly-input name="errorMessage" value="This is not a valid value">
 							Error Message
 						</smoothly-input>
-						<smoothly-input-range label={"Border Radius (rem)"} name={"borderRadius"} min={0} max={2} step={0.25} />
+						<smoothly-input-checkbox name="showLabel" checked>
+							Show Label
+						</smoothly-input-checkbox>
+						<smoothly-input name="placeholder">Placeholder</smoothly-input>
 					</smoothly-form>
 				</div>
 				<div class="input-wrapper" style={{ "--smoothly-input-border-radius": `${this.options.borderRadius}rem` }}>
-					<div class="width">100%</div>
-					<div class="left-padding">0.5rem - left padding</div>
+					<div class="width">width: 100%</div>
+					<div class="left-padding">padding-left: 0.5rem</div>
 					<smoothly-input
 						name="text"
+						color={this.options.color}
 						looks={this.options.looks}
-						placeholder={placeholder}
-						invalid={this.options.invalid}
-						errorMessage={this.options.errorMessage}
 						readonly={this.options.readonly}
 						disabled={this.options.disabled}
-						color={this.options.color}
-						showLabel={this.options.showLabel}>
+						invalid={this.options.invalid}
+						errorMessage={this.options.errorMessage}
+						showLabel={this.options.showLabel}
+						placeholder={this.options.placeholder}>
 						{this.options.showLabel && <span>Text</span>}
 						<smoothly-input-clear slot="end" />
 					</smoothly-input>
@@ -101,13 +98,13 @@ export class SmoothlyInputDemoStandard {
 
 					<smoothly-input-select
 						name="month"
+						color={this.options.color}
 						looks={this.options.looks}
-						placeholder={placeholder}
-						invalid={this.options.invalid}
-						errorMessage={this.options.errorMessage}
 						readonly={this.options.readonly}
 						disabled={this.options.disabled}
-						color={this.options.color}>
+						invalid={this.options.invalid}
+						errorMessage={this.options.errorMessage}
+						placeholder={this.options.placeholder}>
 						{this.options.showLabel && <label slot="label">Select</label>}
 						<smoothly-item value="1">January</smoothly-item>
 						<smoothly-item value="2">February</smoothly-item>
@@ -126,21 +123,22 @@ export class SmoothlyInputDemoStandard {
 					<div class="height" />
 
 					<smoothly-input-checkbox
+						name={"checkbox"}
+						color={this.options.color}
 						looks={this.options.looks}
 						readonly={this.options.readonly}
-						disabled={this.options.disabled}
-						color={this.options.color}>
+						disabled={this.options.disabled}>
 						Check
 					</smoothly-input-checkbox>
 					<div class="height" />
 
 					<smoothly-input-radio
-						name="radio"
+						name={"radio"}
 						clearable
+						color={this.options.color}
 						looks={this.options.looks}
 						readonly={this.options.readonly}
 						// TODO - disabled
-						color={this.options.color}
 						showLabel={this.options.showLabel}>
 						{this.options.showLabel && <label slot="label">Radio</label>}
 						<smoothly-input-radio-item value={"first"}>Label 1</smoothly-input-radio-item>
@@ -153,12 +151,15 @@ export class SmoothlyInputDemoStandard {
 					<div class="height" />
 
 					<smoothly-input-file
+						name={"file"}
+						color={this.options.color}
 						looks={this.options.looks}
 						readonly={this.options.readonly}
 						// TODO - disabled
-						color={this.options.color}
-						placeholder={placeholder}
-						showLabel={this.options.showLabel}>
+						// TODO - invalid
+						// TODO - errorMessage
+						showLabel={this.options.showLabel}
+						placeholder={this.options.placeholder}>
 						{this.options.showLabel && <span slot={"label"}>File</span>}
 						<smoothly-input-clear slot="end" />
 					</smoothly-input-file>
@@ -166,67 +167,81 @@ export class SmoothlyInputDemoStandard {
 
 					<smoothly-input-range
 						name={"range"}
-						label={this.options.showLabel ? "Range" : undefined}
+						color={this.options.color}
 						looks={this.options.looks}
 						readonly={this.options.readonly}
 						// TODO - disabled
-						color={this.options.color}>
+						// TODO - invalid
+						// TODO - errorMessage
+						label={this.options.showLabel ? "Range" : undefined}
+						// TODO - disabled
+						// TODO - placeholder
+					>
 						<smoothly-input-clear slot="end" />
 					</smoothly-input-range>
 					<div class="height" />
 
 					<smoothly-input-color
+						name={"color"}
+						color={this.options.color}
 						looks={this.options.looks}
 						readonly={this.options.readonly}
 						// TODO - disabled
-						color={this.options.color}
-						showLabel={this.options.showLabel}>
+						// TODO - invalid
+						// TODO - errorMessage
+						showLabel={this.options.showLabel}
+						// TODO - placeholder
+					>
 						{this.options.showLabel && <span>Color</span>}
 						<smoothly-input-clear slot="end" />
 					</smoothly-input-color>
 					<div class="height" />
 
 					<smoothly-input-date
+						color={this.options.color}
 						looks={this.options.looks}
 						readonly={this.options.readonly}
 						// TODO - disabled
 						invalid={this.options.invalid}
-						color={this.options.color}
-						showLabel={this.options.showLabel}>
+						// TODO - errorMessage
+						showLabel={this.options.showLabel}
+						// TODO - placeholder
+					>
 						{this.options.showLabel && <span>Date</span>}
 						<smoothly-input-clear slot="end" />
 					</smoothly-input-date>
 					<div class="height" />
 
 					<smoothly-input-date-time
+						color={this.options.color}
 						looks={this.options.looks}
 						readonly={this.options.readonly}
 						// TODO - disabled
 						invalid={this.options.invalid}
 						errorMessage={this.options.errorMessage}
-						color={this.options.color}
-						showLabel={this.options.showLabel}>
+						showLabel={this.options.showLabel}
+						// TODO - placeholder
+					>
 						DateTime
 						<smoothly-input-clear slot="end" />
 					</smoothly-input-date-time>
 					<div class="height" />
 
 					<smoothly-input-date-range
+						color={this.options.color}
 						looks={this.options.looks}
 						readonly={this.options.readonly}
 						// TODO - disabled
 						invalid={this.options.invalid}
-						color={this.options.color}
-						placeholder={placeholder}
-						showLabel={this.options.showLabel}>
+						// TODO - errorMessage
+						placeholder={this.options.placeholder}
+						showLabel={this.options.showLabel}
+						// TODO - placeholder
+					>
 						{this.options.showLabel && <span>Date Range</span>}
 						<smoothly-input-clear slot="end" />
 					</smoothly-input-date-range>
 					<div class="height" />
-
-					<div class={{ "guide-lines": true, "show-label": !!this.options.showLabel }}>
-						{this.options.showLabel ? "Aligned labels & values" : "Center values"}
-					</div>
 				</div>
 			</Host>
 		)

--- a/src/components/input/demo/standard/style.css
+++ b/src/components/input/demo/standard/style.css
@@ -7,6 +7,9 @@
 :host p {
 	margin: .5rem 0;
 }
+:host smoothly-input-range[name=borderRadius] {
+	flex-basis: 100%;
+}
 div.input-wrapper {
 	display: grid;
 	margin-top: 1rem;
@@ -49,58 +52,4 @@ div.input-wrapper > .left-padding::before {
 }
 div.input-wrapper > .left-padding:hover::before { 
 	bottom: -100vh;
-}
-
-
-/* --- vertical --- */
-
-:host.vertical {
-	width: 100%;
-	row-gap: 0;
-	position: relative;
-}
-:host.vertical > div.input-wrapper {
-	display: grid;
-	grid-template-columns: repeat(auto-fill, 14rem);
-	gap: .5rem;
-}
-:host.vertical > div.input-wrapper > .width,
-:host.vertical > div.input-wrapper > .height,
-:host.vertical > div.input-wrapper > .left-padding {
-	display: none;
-}
-
-
-:host.vertical > div.input-wrapper > .guide-lines::before,
-:host.vertical > div.input-wrapper > .guide-lines::after {
-	content: "";
-	pointer-events: none;
-	right: 0;
-	width: 100vw;
-	position: absolute;
-	z-index: 2;
-	border-top: 1px dotted black;
-}
-
-:host:not(.vertical) .guide-lines {
-	display: none;
-}
-
-.guide-lines {
-	text-align: end;
-	justify-self: center;
-  align-content: center;
-}
-
-.guide-lines::before {
-	top: 1rem;
-}
-.guide-lines::after {
-	top: 2rem;
-}
-.guide-lines.show-label::before {
-	top: 1.05rem;
-}
-.guide-lines.show-label::after {
-	top: 2.3rem;
 }

--- a/src/components/input/reset/index.tsx
+++ b/src/components/input/reset/index.tsx
@@ -30,7 +30,7 @@ export class SmoothlyInputReset {
 				this.readonlyAtLoad = parent.readonly
 				parent.listen("changed", async p => {
 					if (Input.is(p)) {
-						this.display = p.readonly ? false : p.changed
+						this.display = p.readonly || p.defined ? false : p.changed
 					}
 					if (p instanceof SmoothlyForm) {
 						this.display = !p.readonly

--- a/src/components/input/select/index.tsx
+++ b/src/components/input/select/index.tsx
@@ -348,7 +348,7 @@ export class SmoothlyInputSelect implements Input, Editable, Clearable, Componen
 	render(): VNode | VNode[] {
 		return (
 			<Host
-				tabIndex={0}
+				tabIndex={this.disabled ? undefined : 0}
 				class={{ "has-value": this.selected.length !== 0, open: this.open }}
 				onClick={(event: Event) => this.handleShowOptions(event)}>
 				<div class="select-display" ref={element => (this.displaySelectedElement = element)}>

--- a/src/components/input/select/index.tsx
+++ b/src/components/input/select/index.tsx
@@ -175,6 +175,7 @@ export class SmoothlyInputSelect implements Input, Editable, Clearable, Componen
 		value = value.toLowerCase()
 		await Promise.all(this.items.map(item => item.filter(value)))
 	}
+	@Watch("disabled")
 	@Watch("readonly")
 	watchingReadonly(): void {
 		this.listener.changed?.(this)

--- a/src/components/input/select/index.tsx
+++ b/src/components/input/select/index.tsx
@@ -45,6 +45,7 @@ export class SmoothlyInputSelect implements Input, Editable, Clearable, Componen
 	@Prop({ reflect: true }) showLabel = true
 	@Prop({ reflect: true, mutable: true }) showSelected?: boolean = true
 	@Prop({ reflect: true, mutable: true }) readonly = false
+	@Prop({ reflect: true }) disabled = false
 	@Prop({ reflect: true }) inCalendar = false
 	@Prop({ reflect: true }) ordered?: boolean
 	@Prop() multiple = false
@@ -229,6 +230,7 @@ export class SmoothlyInputSelect implements Input, Editable, Clearable, Componen
 			?.composedPath()
 			.find((el): el is HTMLSmoothlyItemElement => "tagName" in el && el.tagName == "SMOOTHLY-ITEM")
 		!this.readonly &&
+			!this.disabled &&
 			!(clickedItem && this.items.includes(clickedItem) && this.multiple) &&
 			!wasButtonClicked &&
 			(this.open = !this.open)

--- a/src/components/input/select/style.css
+++ b/src/components/input/select/style.css
@@ -24,7 +24,6 @@
 :host>div.select-display {
 	box-sizing: border-box;
 	display: flex;
-	cursor: pointer;
 	padding: var(--input-value-padding-top) .8rem var(--input-value-padding-bottom) 0;
 	overflow: hidden;
 	width: 100%;
@@ -32,15 +31,14 @@
 	gap: 1rem;
 	text-overflow: ellipsis;
 }
+:host:not([readonly]):not([disabled])>div.select-display {
+	cursor: pointer;
+}
 
 :host:not(:has([slot=label]))>div.select-display,
 :host:not([show-label])>div.select-display  {
 	padding: .6rem .8rem .6rem 0;
 	align-items: center;
-}
-
-:host[readonly]>div.select-display {
-	cursor: not-allowed;
 }
 
 :host>div.select-display smoothly-icon {
@@ -62,9 +60,12 @@
 :host>div.icons>smoothly-icon[name=caret-down-outline],
 :host>div.icons>smoothly-icon[name=caret-forward-outline] {
 	opacity: .7;
-	cursor: pointer;
 	height: 100%;
 	padding-inline: var(--input-padding-side);
+}
+:host:not([readonly]):not([disabled])>div.icons>smoothly-icon[name=caret-down-outline],
+:host:not([readonly]):not([disabled])>div.icons>smoothly-icon[name=caret-forward-outline] {
+	cursor: pointer;
 }
 
 :host[invalid]>div>smoothly-icon.smoothly-invalid {

--- a/src/components/input/select/style.css
+++ b/src/components/input/select/style.css
@@ -55,13 +55,6 @@
 	align-items: center;
 }
 
-:host>div.icons::slotted(smoothly-icon):not("color") {
-	color: rgb(var(--smoothly-input-foreground));
-	fill: rgb(var(--smoothly-input-foreground));
-	stroke: rgb(var(--smoothly-input-foreground));
-	filter: opacity(60%);
-}
-
 :host:hover>div.icons::slotted(smoothly-icon) {
 	filter: opacity(100%);
 }

--- a/src/components/input/shared.css
+++ b/src/components/input/shared.css
@@ -53,6 +53,12 @@
 :host[looks="transparent"]:not([readonly]):focus-within {
 	outline: 1px solid rgb(var(--smoothly-input-border));
 }
+:host([disabled]) {
+	cursor: not-allowed;
+	--smoothly-input-foreground: var(--smoothly-input-disabled-foreground);
+	--smoothly-input-background: var(--smoothly-input-disabled-background);
+	--smoothly-input-border: var(--smoothly-input-disabled-border);
+}
 
 /* --- label --- */
 

--- a/src/components/input/shared.css
+++ b/src/components/input/shared.css
@@ -55,6 +55,7 @@
 }
 :host([disabled]) {
 	cursor: not-allowed;
+	user-select: none;
 	--smoothly-input-foreground: var(--smoothly-input-disabled-foreground);
 	--smoothly-input-background: var(--smoothly-input-disabled-background);
 	--smoothly-input-border: var(--smoothly-input-disabled-border);

--- a/src/components/input/shared.css
+++ b/src/components/input/shared.css
@@ -8,7 +8,6 @@
 	border-radius: var(--smoothly-input-border-radius);
 }
 
-:host[looks="border"]::slotted(smoothly-picker-menu smoothly-input),
 :host[looks="border"] {
 	border: rgb(var(--smoothly-input-border)) solid 1px;
 }
@@ -17,7 +16,6 @@
 	border: transparent solid 1px;
 }
 
-:host[looks="line"]::slotted(smoothly-picker-menu smoothly-input),
 :host[looks="line"] {
 	border-bottom: rgb(var(--smoothly-input-border)) solid 1px;
 }

--- a/src/components/input/shared.css
+++ b/src/components/input/shared.css
@@ -45,12 +45,13 @@
 
 :host[looks="transparent"][readonly]>input,
 :host[looks="transparent"]:not(:focus-within)>input {
-	background: transparent;
+	background-color: transparent;
 }
 
 :host[looks="transparent"]:not([readonly]):focus-within {
 	outline: 1px solid rgb(var(--smoothly-input-border));
 }
+
 :host([disabled]) {
 	cursor: not-allowed;
 	user-select: none;


### PR DESCRIPTION
- [ ] https://github.com/utily/smoothly/pull/994

## Changes
- Set same order of props on all inputs.
- Add TODOs for missing props
- Remove `vertical layout` toggle - it was broken.
- Make placeholder text input

![image](https://github.com/user-attachments/assets/3838f68c-3d15-4412-b46a-0ae7db1fb5fc)
