### PR TITLE
Add disabled prop to inputs

### DIFF
--- a/src/assets/style/mapping.css
+++ b/src/assets/style/mapping.css
@@ -25,6 +25,9 @@ smoothly-color {
 	--smoothly-input-foreground: var(--smoothly-default-contrast);
 	--smoothly-input-background: var(--smoothly-default-tint);
 	--smoothly-input-border: var(--smoothly-default-shade);
+	--smoothly-input-disabled-foreground: var(--smoothly-default-contrast);
+	--smoothly-input-disabled-background: var(--smoothly-default-shade);
+	--smoothly-input-disabled-border: var(--smoothly-default-shade);
 	--smoothly-input-border-readonly: var(--smoothly-input-border), 50%;
 	--smoothly-input-border-radius: 0;
 

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -368,6 +368,7 @@ export namespace Components {
         "changed": boolean;
         "clear": () => Promise<void>;
         "color"?: Color;
+        "disabled"?: boolean;
         "edit": (editable: boolean) => Promise<void>;
         "errorMessage"?: string;
         "getValue": () => Promise<isoly.DateTime | undefined>;
@@ -2543,6 +2544,7 @@ declare namespace LocalJSX {
     interface SmoothlyInputDateTime {
         "changed"?: boolean;
         "color"?: Color;
+        "disabled"?: boolean;
         "errorMessage"?: string;
         "invalid"?: boolean;
         "looks"?: Looks;

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -303,6 +303,7 @@ export namespace Components {
         "changed": boolean;
         "clear": () => Promise<void>;
         "color"?: Color;
+        "disabled"?: boolean;
         "edit": (editable: boolean) => Promise<void>;
         "getValue": () => Promise<RGB | string | undefined>;
         "listen": (property: "changed", listener: (parent: Editable) => Promise<void>) => Promise<void>;
@@ -2493,6 +2494,7 @@ declare namespace LocalJSX {
     interface SmoothlyInputColor {
         "changed"?: boolean;
         "color"?: Color;
+        "disabled"?: boolean;
         "looks"?: Looks;
         "name"?: string;
         "onSmoothlyFormDisable"?: (event: SmoothlyInputColorCustomEvent<(disabled: boolean) => void>) => void;

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -477,6 +477,7 @@ export namespace Components {
         "clear": () => Promise<void>;
         "color"?: Color;
         "defined": boolean;
+        "disabled"?: boolean;
         "edit": (editable: boolean) => Promise<void>;
         "getValue": () => Promise<number | undefined>;
         "label": string;
@@ -2641,6 +2642,7 @@ declare namespace LocalJSX {
         "changed"?: boolean;
         "color"?: Color;
         "defined"?: boolean;
+        "disabled"?: boolean;
         "label"?: string;
         "looks"?: Looks;
         "max"?: number;

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -323,6 +323,7 @@ export namespace Components {
         "changed": boolean;
         "clear": () => Promise<void>;
         "color"?: Color;
+        "disabled"?: boolean;
         "edit": (editable: boolean) => Promise<void>;
         "errorMessage"?: string;
         "getValue": () => Promise<isoly.Date | undefined>;
@@ -2504,6 +2505,7 @@ declare namespace LocalJSX {
     interface SmoothlyInputDate {
         "changed"?: boolean;
         "color"?: Color;
+        "disabled"?: boolean;
         "errorMessage"?: string;
         "invalid"?: boolean;
         "looks"?: Looks;

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -410,6 +410,7 @@ export namespace Components {
         "changed": boolean;
         "clear": () => Promise<void>;
         "color"?: Color;
+        "disabled"?: boolean;
         "edit": (editable: boolean) => Promise<void>;
         "getValue": () => Promise<File | undefined>;
         "listen": (property: "changed", listener: (parent: Editable) => Promise<void>) => Promise<void>;
@@ -2585,6 +2586,7 @@ declare namespace LocalJSX {
         "camera"?: "front" | "back";
         "changed"?: boolean;
         "color"?: Color;
+        "disabled"?: boolean;
         "looks"?: Looks;
         "name"?: string;
         "onSmoothlyFormDisable"?: (event: SmoothlyInputFileCustomEvent<(disabled: boolean) => void>) => void;

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -346,6 +346,7 @@ export namespace Components {
         "changed": boolean;
         "clear": () => Promise<void>;
         "color"?: Color;
+        "disabled"?: boolean;
         "edit": (editable: boolean) => Promise<void>;
         "end": isoly.Date | undefined;
         "getValue": () => Promise<isoly.DateRange | undefined>;
@@ -2526,6 +2527,7 @@ declare namespace LocalJSX {
     interface SmoothlyInputDateRange {
         "changed"?: boolean;
         "color"?: Color;
+        "disabled"?: boolean;
         "end"?: isoly.Date | undefined;
         "invalid"?: boolean;
         "looks"?: Looks;

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -510,6 +510,7 @@ export namespace Components {
         "clearable": boolean;
         "color"?: Color;
         "defined": boolean;
+        "disabled": boolean;
         "edit": (editable: boolean) => Promise<void>;
         "errorMessage"?: string;
         "getItems": () => Promise<HTMLSmoothlyItemElement[]>;
@@ -2666,6 +2667,7 @@ declare namespace LocalJSX {
         "clearable"?: boolean;
         "color"?: Color;
         "defined"?: boolean;
+        "disabled"?: boolean;
         "errorMessage"?: string;
         "inCalendar"?: boolean;
         "invalid"?: boolean;

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -449,6 +449,7 @@ export namespace Components {
         "clear": () => Promise<void>;
         "clearable"?: boolean;
         "color"?: Color;
+        "disabled"?: boolean;
         "edit": (editable: boolean) => Promise<void>;
         "getValue": () => Promise<any | undefined>;
         "listen": (property: "changed", listener: (parent: Editable) => Promise<void>) => Promise<void>;
@@ -2611,6 +2612,7 @@ declare namespace LocalJSX {
         "changed"?: boolean;
         "clearable"?: boolean;
         "color"?: Color;
+        "disabled"?: boolean;
         "looks"?: Looks;
         "name"?: string;
         "onSmoothlyFormDisable"?: (event: SmoothlyInputRadioCustomEvent<(disabled: boolean) => void>) => void;

--- a/src/components/input/Input.ts
+++ b/src/components/input/Input.ts
@@ -18,6 +18,7 @@ export namespace Input {
 		register: () => Promise<void>
 		unregister: () => Promise<void>
 		getValue: GetValue
+		disabled?: boolean
 		color?: Color
 		name: string
 		invalid?: boolean
@@ -30,6 +31,7 @@ export namespace Input {
 			register: isly.function<() => Promise<void>>(),
 			unregister: isly.function<() => Promise<void>>(),
 			getValue: isly.function<GetValue>(),
+			disabled: isly.boolean().optional(),
 			color: Color.type.optional(),
 			name: isly.string(),
 			invalid: isly.boolean().optional(),

--- a/src/components/input/checkbox/index.tsx
+++ b/src/components/input/checkbox/index.tsx
@@ -96,7 +96,7 @@ export class SmoothlyInputCheckbox implements Input, Clearable, Editable, Compon
 				onMouseUp={(e: MouseEvent) =>
 					this.mouseDownPosition?.x == e.clientX && this.mouseDownPosition.y == e.clientY && this.click()
 				}>
-				<input type="checkbox" checked={this.checked} />
+				<input type="checkbox" checked={this.checked} disabled={this.disabled} />
 				{this.checked && <smoothly-icon name="checkmark-outline" size="tiny" />}
 				<label>
 					<slot />

--- a/src/components/input/checkbox/index.tsx
+++ b/src/components/input/checkbox/index.tsx
@@ -19,11 +19,11 @@ export class SmoothlyInputCheckbox implements Input, Clearable, Editable, Compon
 	@Prop({ reflect: true }) name: string
 	@Prop({ mutable: true }) changed = false
 	@Prop({ reflect: true, mutable: true }) readonly = false
+	@Prop({ reflect: true }) disabled: boolean
 	@Prop({ mutable: true }) checked = false
 	@Prop() value = this.checked
 	@Prop({ reflect: true, mutable: true }) looks?: Looks
 	@Prop({ reflect: true, mutable: true }) color?: Color
-	@Prop({ reflect: true }) disabled: boolean
 	@Event() smoothlyInputLooks: EventEmitter<(looks?: Looks, color?: Color) => void>
 	@Event() smoothlyInput: EventEmitter<Data>
 	@Event() smoothlyInputLoad: EventEmitter<(parent: Editable) => void>

--- a/src/components/input/checkbox/style.css
+++ b/src/components/input/checkbox/style.css
@@ -9,6 +9,8 @@
 	padding: 0 var(--input-padding-side);
 	background-color: rgb(var(--smoothly-input-background));
 	box-sizing: border-box;
+	background-color: rgb(var(--smoothly-input-background));
+	color: rgb(var(--smoothly-input-foreground));
 }
 
 :host>smoothly-icon {
@@ -22,26 +24,23 @@
 	appearance: none;
 	height: 1.25rem;
 	width: 1.25rem;
-	border: 1px solid black;
+	border: 1px solid rgb(var(--smoothly-input-foreground));
+	color: rgb(var(--smoothly-input-foreground));
 	display: block;
 }
 
-:host:not([readonly]),
-:host:not([readonly])>* {
+:host:not([readonly]):not([disabled]),
+:host:not([readonly]):not([disabled])>* {
 	cursor: pointer;
 }
 
-:host([readonly]),
-:host([readonly])>* {
+:host([disabled]),
+:host([disabled])>* {
 	cursor: not-allowed;
 }
 
-
-:host[disabled]>input,
-:host[disabled]>smoothly-icon {
-	cursor: not-allowed;
-	border-color: rgb(var(--smoothly-color-contrast), 0.3);
-	color: rgb(var(--smoothly-color-contrast), 0.4);
+:host>smoothly-icon { 
+	--smoothly-color-contrast: var(--smoothly-input-foreground);
 }
 
 :host[looks="transparent"] {

--- a/src/components/input/clear/index.tsx
+++ b/src/components/input/clear/index.tsx
@@ -30,7 +30,8 @@ export class SmoothlyInputClear {
 				if (Editable.Element.is(parent)) {
 					parent.listen("changed", async p => {
 						if (Input.is(p)) {
-							this.display = !p.readonly && (typeof p.defined == "boolean" ? p.defined : Boolean(await p.getValue()))
+							this.display =
+								!p.readonly && !p.disabled && (typeof p.defined == "boolean" ? p.defined : Boolean(await p.getValue()))
 						}
 						if (p instanceof SmoothlyForm) {
 							this.disabled = p.readonly || Object.values(p.value).filter(val => val).length < 1

--- a/src/components/input/color/index.tsx
+++ b/src/components/input/color/index.tsx
@@ -37,6 +37,7 @@ export class SmoothlyInputColor implements Input, Clearable, Editable, Component
 	@Prop({ reflect: true, mutable: true }) color?: Color
 	@Prop({ mutable: true }) changed = false
 	@Prop({ reflect: true, mutable: true }) readonly = false
+	@Prop({ reflect: true }) disabled?: boolean
 	@Prop() output: "rgb" | "hex" = "rgb"
 	@Prop({ reflect: true }) name: string
 	@Prop({ reflect: true }) showLabel = true
@@ -75,6 +76,11 @@ export class SmoothlyInputColor implements Input, Clearable, Editable, Component
 	@Watch("name")
 	nameChange(_: string | undefined, oldName: string | undefined) {
 		Input.formRename(this, oldName)
+	}
+	@Watch("disabled")
+	@Watch("readonly")
+	watchingReadonly(): void {
+		this.listener.changed?.(this)
 	}
 	@Method()
 	async register() {
@@ -197,12 +203,13 @@ export class SmoothlyInputColor implements Input, Clearable, Editable, Component
 				}}>
 				<smoothly-input
 					value={this.value}
-					name={this.name}
-					looks={undefined}
 					color={this.color}
+					looks={undefined}
+					name={this.name}
 					type={"hex-color"}
-					showLabel={this.showLabel}
 					readonly={this.readonly}
+					disabled={this.disabled}
+					showLabel={this.showLabel}
 					onSmoothlyInput={event => (event?.stopPropagation(), this.hexInputHandler(event.detail[this.name]))}>
 					<slot />
 				</smoothly-input>
@@ -211,13 +218,13 @@ export class SmoothlyInputColor implements Input, Clearable, Editable, Component
 					color={this.color}
 					name="options-outline"
 					size="small"
-					onClick={() => !this.readonly && this.openDropdown()}
+					onClick={() => !this.readonly && !this.disabled && this.openDropdown()}
 				/>
 				<div>
 					{/* Extra div needed otherwise stencil sets hidden on the slot for no apparent reason */}
 					<slot name="end" />
 				</div>
-				{this.open && !this.readonly && (
+				{this.open && !this.readonly && !this.disabled && (
 					<div class="rgb-sliders">
 						<smoothly-toggle-switch
 							title={`${this.sliderMode === "rgb" ? "To HSL" : "To RGB"}`}

--- a/src/components/input/color/style.css
+++ b/src/components/input/color/style.css
@@ -22,8 +22,12 @@
 :host smoothly-icon[name=options-outline] {
 	padding-right: var(--input-padding-side);
 }
-:host[readonly] smoothly-icon[name=options-outline] {
-	filter: opacity(60%)
+:host[readonly] smoothly-icon[name=options-outline],
+:host[disabled] smoothly-icon[name=options-outline] {
+	display: none;
+}
+:host:not([readonly]):not([disabled]) smoothly-icon[name=options-outline] {
+	cursor: pointer;
 }
 :host>div.rgb-sliders {
 	background-color: rgb(var(--smoothly-input-background));

--- a/src/components/input/date/index.tsx
+++ b/src/components/input/date/index.tsx
@@ -30,6 +30,7 @@ export class SmoothlyInputDate implements ComponentWillLoad, Clearable, Input, E
 	@Prop({ reflect: true }) name: string
 	@Prop({ mutable: true }) changed = false
 	@Prop({ reflect: true, mutable: true }) readonly = false
+	@Prop({ reflect: true }) disabled?: boolean
 	@Prop() invalid?: boolean = false
 	@Prop({ reflect: true }) errorMessage?: string
 	parent: Editable | undefined
@@ -91,6 +92,11 @@ export class SmoothlyInputDate implements ComponentWillLoad, Clearable, Input, E
 		this.smoothlyInput.emit({ [this.name]: next })
 		this.listener.changed?.(this)
 	}
+	@Watch("disabled")
+	@Watch("readonly")
+	watchingReadonly(): void {
+		this.listener.changed?.(this)
+	}
 	@Listen("smoothlyInput")
 	smoothlyInputHandler(event: CustomEvent<Record<string, any>>) {
 		if (event.target != this.element)
@@ -134,9 +140,10 @@ export class SmoothlyInputDate implements ComponentWillLoad, Clearable, Input, E
 					color={this.color}
 					looks={this.looks == "transparent" ? this.looks : undefined}
 					name={this.name}
-					onFocus={() => !this.readonly && (this.open = !this.open)}
-					onClick={() => !this.readonly && (this.open = !this.open)}
+					onFocus={() => !this.readonly && !this.disabled && (this.open = !this.open)}
+					onClick={() => !this.readonly && !this.disabled && (this.open = !this.open)}
 					readonly={this.readonly}
+					disabled={this.disabled}
 					errorMessage={this.errorMessage}
 					invalid={this.invalid}
 					type="date"

--- a/src/components/input/date/range/index.tsx
+++ b/src/components/input/date/range/index.tsx
@@ -134,7 +134,7 @@ export class SmoothlyInputDateRange implements Clearable, Input, Editable {
 	render() {
 		const locale = navigator.language as isoly.Locale
 		return (
-			<Host tabindex={0}>
+			<Host tabindex={this.disabled ? undefined : 0}>
 				<section onClick={() => !this.readonly && !this.disabled && (this.open = !this.open)}>
 					<smoothly-input
 						type="text" // TODO: date-range tidily thing

--- a/src/components/input/date/range/index.tsx
+++ b/src/components/input/date/range/index.tsx
@@ -18,6 +18,7 @@ export class SmoothlyInputDateRange implements Clearable, Input, Editable {
 	@Prop({ reflect: true, mutable: true }) color?: Color
 	@Prop({ reflect: true, mutable: true }) looks?: Looks
 	@Prop({ reflect: true, mutable: true }) readonly = false
+	@Prop({ reflect: true }) disabled?: boolean
 	@Prop({ reflect: true }) showLabel = true
 	@Prop({ mutable: true }) start: isoly.Date | undefined
 	@Prop({ mutable: true }) end: isoly.Date | undefined
@@ -64,6 +65,11 @@ export class SmoothlyInputDateRange implements Clearable, Input, Editable {
 	@Watch("value")
 	valueChanged() {
 		this.changed = this.initialStart != this.start || this.initialEnd != this.end
+		this.listener.changed?.(this)
+	}
+	@Watch("disabled")
+	@Watch("readonly")
+	watchingReadonly(): void {
 		this.listener.changed?.(this)
 	}
 	@Listen("smoothlyInputLoad")
@@ -129,11 +135,12 @@ export class SmoothlyInputDateRange implements Clearable, Input, Editable {
 		const locale = navigator.language as isoly.Locale
 		return (
 			<Host tabindex={0}>
-				<section onClick={() => !this.readonly && (this.open = !this.open)}>
+				<section onClick={() => !this.readonly && !this.disabled && (this.open = !this.open)}>
 					<smoothly-input
 						type="text" // TODO: date-range tidily thing
 						name="dateRangeInput"
 						readonly={this.readonly}
+						disabled={this.disabled}
 						value={
 							this.start && this.end
 								? `${tidily.format(this.start, "date", locale)} — ${tidily.format(this.end, "date", locale)}`

--- a/src/components/input/date/range/style.scss
+++ b/src/components/input/date/range/style.scss
@@ -10,12 +10,12 @@
 	}
 }
 
-:host>section>smoothly-input>div>input {
+:host:not([readonly])>section>smoothly-input {
 	cursor: pointer;
 }
 
-:host[readonly],
-:host[readonly]>section>smoothly-input>div>input {
+:host[disabled],
+:host[disabled]>section>smoothly-input {
 	cursor: not-allowed;
 }
 

--- a/src/components/input/date/range/style.scss
+++ b/src/components/input/date/range/style.scss
@@ -22,10 +22,10 @@
 :host>nav {
 	position: absolute;
 	z-index: 10;
-	top: 4em;
+	top: 4rem;
 	background-color: rgb(var(--smoothly-input-background));
-	max-width: 22em;
-	min-width: 18em;
+	max-width: 22rem;
+	min-width: 18rem;
 }
 
 :host>nav>smoothly-calendar::before {
@@ -33,11 +33,11 @@
 	position: absolute;
 	box-sizing: border-box;
 	top: 1px;
-	left: -7em;
+	left: -7rem;
 	z-index: 9;
-	transform: translate(10em, -0.55em) rotate(45deg);
-	width: 1em;
-	height: 1em;
+	transform: translate(10em, -0.55rem) rotate(45deg);
+	width: 1rem;
+	height: 1rem;
 	background-color: rgb(var(--smoothly-input-background));
 	border-top: 1px solid rgb(var(--smoothly-input-border));
 	border-left: 1px solid rgb(var(--smoothly-input-border));
@@ -59,7 +59,8 @@
 }
 
 :host>section>span {
-	padding: 0.5em 0.2em 0.5em 0.2em;
+	padding-block: 0.5rem;
+	padding-inline: 0.2rem;
 	align-self: center;
 }
 

--- a/src/components/input/date/style.css
+++ b/src/components/input/date/style.css
@@ -14,12 +14,12 @@
 	--input-min-height: calc(var(--input-min-height) - 2px);
 }
 
-:host>smoothly-input>div>input {
+:host:not([readonly])>smoothly-input>div>input {
 	cursor: pointer;
 }
 
-:host[readonly],
-:host[readonly]>smoothly-input>div>input {
+:host[disabled],
+:host[disabled]>smoothly-input>div>input {
 	cursor: not-allowed;
 }
 

--- a/src/components/input/date/time/index.tsx
+++ b/src/components/input/date/time/index.tsx
@@ -31,6 +31,7 @@ export class SmoothlyInputDateTime implements ComponentWillLoad, Clearable, Inpu
 	@Prop({ reflect: true }) name: string
 	@Prop({ mutable: true }) changed = false
 	@Prop({ reflect: true, mutable: true }) readonly = false
+	@Prop({ reflect: true }) disabled?: boolean
 	@Prop({ reflect: true }) invalid?: boolean = false
 	@Prop({ reflect: true }) errorMessage?: string
 	parent: Editable | undefined
@@ -118,6 +119,11 @@ export class SmoothlyInputDateTime implements ComponentWillLoad, Clearable, Inpu
 		this.smoothlyInput.emit({ [this.name]: value })
 		this.listener.changed?.(this)
 	}
+	@Watch("disabled")
+	@Watch("readonly")
+	watchingReadonly(): void {
+		this.listener.changed?.(this)
+	}
 	@Listen("smoothlyInput")
 	smoothlyInputHandler(event: CustomEvent<Record<string, any>>) {
 		if (event.target != this.element)
@@ -164,9 +170,10 @@ export class SmoothlyInputDateTime implements ComponentWillLoad, Clearable, Inpu
 					color={this.color}
 					looks={this.looks == "transparent" ? this.looks : undefined}
 					name={"date"}
-					onFocus={() => !this.readonly && (this.open = !this.open)}
-					onClick={() => !this.readonly && (this.open = !this.open)}
+					onFocus={() => !this.readonly && !this.disabled && (this.open = !this.open)}
+					onClick={() => !this.readonly && !this.disabled && (this.open = !this.open)}
 					readonly={this.readonly}
+					disabled={this.disabled}
 					type="date"
 					value={this.date}
 					showLabel={this.showLabel}
@@ -183,6 +190,8 @@ export class SmoothlyInputDateTime implements ComponentWillLoad, Clearable, Inpu
 					max={23}
 					pad={2}
 					value={this.hour}
+					readonly={this.readonly}
+					disabled={this.disabled}
 					placeholder="hh"
 					onSmoothlyInputLoad={e => e.stopPropagation()}
 					onSmoothlyInput={e => {
@@ -197,6 +206,8 @@ export class SmoothlyInputDateTime implements ComponentWillLoad, Clearable, Inpu
 					max={59}
 					pad={2}
 					value={this.minute}
+					readonly={this.readonly}
+					disabled={this.disabled}
 					placeholder="mm"
 					onSmoothlyInputLoad={e => e.stopPropagation()}
 					onSmoothlyInput={e => {

--- a/src/components/input/date/time/style.css
+++ b/src/components/input/date/time/style.css
@@ -13,12 +13,12 @@
 	--input-min-height: calc(var(--input-min-height) - 2px);
 }
 
-:host>smoothly-input>div>input {
+:host:not([readonly])>smoothly-input>div>input {
 	cursor: pointer;
 }
 
-:host[readonly],
-:host[readonly]>smoothly-input>div>input {
+:host[disabled],
+:host[disabled]>smoothly-input>div>input {
 	cursor: not-allowed;
 }
 

--- a/src/components/input/demo/standard/index.tsx
+++ b/src/components/input/demo/standard/index.tsx
@@ -198,10 +198,11 @@ export class SmoothlyInputDemoStandard {
 					<div class="height" />
 
 					<smoothly-input-date
+						name={"date"}
 						color={this.options.color}
 						looks={this.options.looks}
 						readonly={this.options.readonly}
-						// TODO - disabled
+						disabled={this.options.disabled}
 						invalid={this.options.invalid}
 						// TODO - errorMessage
 						showLabel={this.options.showLabel}
@@ -213,6 +214,7 @@ export class SmoothlyInputDemoStandard {
 					<div class="height" />
 
 					<smoothly-input-date-time
+						name={"dateTime"}
 						color={this.options.color}
 						looks={this.options.looks}
 						readonly={this.options.readonly}
@@ -228,6 +230,7 @@ export class SmoothlyInputDemoStandard {
 					<div class="height" />
 
 					<smoothly-input-date-range
+						name={"dateRange"}
 						color={this.options.color}
 						looks={this.options.looks}
 						readonly={this.options.readonly}

--- a/src/components/input/demo/standard/index.tsx
+++ b/src/components/input/demo/standard/index.tsx
@@ -6,6 +6,7 @@ import { Looks } from "../../Looks"
 type Options = {
 	looks?: Looks
 	readonly?: boolean
+	disabled?: boolean
 	color?: Color
 	vertical?: boolean
 	showLabel?: boolean
@@ -67,6 +68,7 @@ export class SmoothlyInputDemoStandard {
 							))}
 							<smoothly-input-clear slot="end" />
 						</smoothly-input-select>
+						<smoothly-input-checkbox name="disabled">Disabled</smoothly-input-checkbox>
 						<smoothly-input-checkbox name="vertical">Vertical Layout</smoothly-input-checkbox>
 						<smoothly-input-checkbox name="showLabel" checked>
 							Show Label
@@ -89,6 +91,7 @@ export class SmoothlyInputDemoStandard {
 						invalid={this.options.invalid}
 						errorMessage={this.options.errorMessage}
 						readonly={this.options.readonly}
+						disabled={this.options.disabled}
 						color={this.options.color}
 						showLabel={this.options.showLabel}>
 						{this.options.showLabel && <span>Text</span>}
@@ -103,6 +106,7 @@ export class SmoothlyInputDemoStandard {
 						invalid={this.options.invalid}
 						errorMessage={this.options.errorMessage}
 						readonly={this.options.readonly}
+						disabled={this.options.disabled}
 						color={this.options.color}>
 						{this.options.showLabel && <label slot="label">Select</label>}
 						<smoothly-item value="1">January</smoothly-item>
@@ -124,6 +128,7 @@ export class SmoothlyInputDemoStandard {
 					<smoothly-input-checkbox
 						looks={this.options.looks}
 						readonly={this.options.readonly}
+						disabled={this.options.disabled}
 						color={this.options.color}>
 						Check
 					</smoothly-input-checkbox>
@@ -134,6 +139,7 @@ export class SmoothlyInputDemoStandard {
 						clearable
 						looks={this.options.looks}
 						readonly={this.options.readonly}
+						// TODO - disabled
 						color={this.options.color}
 						showLabel={this.options.showLabel}>
 						{this.options.showLabel && <label slot="label">Radio</label>}
@@ -149,6 +155,7 @@ export class SmoothlyInputDemoStandard {
 					<smoothly-input-file
 						looks={this.options.looks}
 						readonly={this.options.readonly}
+						// TODO - disabled
 						color={this.options.color}
 						placeholder={placeholder}
 						showLabel={this.options.showLabel}>
@@ -162,6 +169,7 @@ export class SmoothlyInputDemoStandard {
 						label={this.options.showLabel ? "Range" : undefined}
 						looks={this.options.looks}
 						readonly={this.options.readonly}
+						// TODO - disabled
 						color={this.options.color}>
 						<smoothly-input-clear slot="end" />
 					</smoothly-input-range>
@@ -170,6 +178,7 @@ export class SmoothlyInputDemoStandard {
 					<smoothly-input-color
 						looks={this.options.looks}
 						readonly={this.options.readonly}
+						// TODO - disabled
 						color={this.options.color}
 						showLabel={this.options.showLabel}>
 						{this.options.showLabel && <span>Color</span>}
@@ -180,6 +189,7 @@ export class SmoothlyInputDemoStandard {
 					<smoothly-input-date
 						looks={this.options.looks}
 						readonly={this.options.readonly}
+						// TODO - disabled
 						invalid={this.options.invalid}
 						color={this.options.color}
 						showLabel={this.options.showLabel}>
@@ -191,6 +201,7 @@ export class SmoothlyInputDemoStandard {
 					<smoothly-input-date-time
 						looks={this.options.looks}
 						readonly={this.options.readonly}
+						// TODO - disabled
 						invalid={this.options.invalid}
 						errorMessage={this.options.errorMessage}
 						color={this.options.color}
@@ -203,6 +214,7 @@ export class SmoothlyInputDemoStandard {
 					<smoothly-input-date-range
 						looks={this.options.looks}
 						readonly={this.options.readonly}
+						// TODO - disabled
 						invalid={this.options.invalid}
 						color={this.options.color}
 						placeholder={placeholder}

--- a/src/components/input/demo/standard/index.tsx
+++ b/src/components/input/demo/standard/index.tsx
@@ -218,7 +218,7 @@ export class SmoothlyInputDemoStandard {
 						color={this.options.color}
 						looks={this.options.looks}
 						readonly={this.options.readonly}
-						// TODO - disabled
+						disabled={this.options.disabled}
 						invalid={this.options.invalid}
 						errorMessage={this.options.errorMessage}
 						showLabel={this.options.showLabel}

--- a/src/components/input/demo/standard/index.tsx
+++ b/src/components/input/demo/standard/index.tsx
@@ -4,16 +4,15 @@ import { Color } from "../../../../model"
 import { Looks } from "../../Looks"
 
 type Options = {
+	color?: Color
 	looks?: Looks
+	borderRadius?: number
 	readonly?: boolean
 	disabled?: boolean
-	color?: Color
-	vertical?: boolean
-	showLabel?: boolean
-	placeholder?: boolean
 	invalid?: boolean
 	errorMessage?: string
-	borderRadius?: number
+	showLabel?: boolean
+	placeholder?: string
 }
 
 @Component({
@@ -42,9 +41,8 @@ export class SmoothlyInputDemoStandard {
 	}
 
 	render() {
-		const placeholder = this.options.placeholder ? "placeholder" : undefined
 		return (
-			<Host class={{ vertical: !!this.options.vertical }}>
+			<Host>
 				<div class="description">
 					<h2>Input Standard</h2>
 					<p>
@@ -52,13 +50,6 @@ export class SmoothlyInputDemoStandard {
 						100% zoom, assuming a root font-size of 16 pixels.
 					</p>
 					<smoothly-form looks={"grid"} onSmoothlyFormInput={(e: CustomEvent<Options>) => (this.options = e.detail)}>
-						<smoothly-input-select name="looks">
-							<span slot="label">Looks</span>
-							{Looks.values.map(l => (
-								<smoothly-item value={l}>{l}</smoothly-item>
-							))}
-						</smoothly-input-select>
-						<smoothly-input-checkbox name="readonly">Readonly</smoothly-input-checkbox>
 						<smoothly-input-select name="color">
 							<span slot="label">Color</span>
 							{Color.values.map(c => (
@@ -68,32 +59,38 @@ export class SmoothlyInputDemoStandard {
 							))}
 							<smoothly-input-clear slot="end" />
 						</smoothly-input-select>
+						<smoothly-input-select name="looks">
+							<span slot="label">Looks</span>
+							{Looks.values.map(l => (
+								<smoothly-item value={l}>{l}</smoothly-item>
+							))}
+						</smoothly-input-select>
+						<smoothly-input-range label={"Border Radius (rem)"} name={"borderRadius"} min={0} max={2} step={0.25} />
+						<smoothly-input-checkbox name="readonly">Readonly</smoothly-input-checkbox>
 						<smoothly-input-checkbox name="disabled">Disabled</smoothly-input-checkbox>
-						<smoothly-input-checkbox name="vertical">Vertical Layout</smoothly-input-checkbox>
-						<smoothly-input-checkbox name="showLabel" checked>
-							Show Label
-						</smoothly-input-checkbox>
-						<smoothly-input-checkbox name="placeholder">Placeholder</smoothly-input-checkbox>
 						<smoothly-input-checkbox name="invalid">Invalid</smoothly-input-checkbox>
 						<smoothly-input name="errorMessage" value="This is not a valid value">
 							Error Message
 						</smoothly-input>
-						<smoothly-input-range label={"Border Radius (rem)"} name={"borderRadius"} min={0} max={2} step={0.25} />
+						<smoothly-input-checkbox name="showLabel" checked>
+							Show Label
+						</smoothly-input-checkbox>
+						<smoothly-input name="placeholder">Placeholder</smoothly-input>
 					</smoothly-form>
 				</div>
 				<div class="input-wrapper" style={{ "--smoothly-input-border-radius": `${this.options.borderRadius}rem` }}>
-					<div class="width">100%</div>
-					<div class="left-padding">0.5rem - left padding</div>
+					<div class="width">width: 100%</div>
+					<div class="left-padding">padding-left: 0.5rem</div>
 					<smoothly-input
 						name="text"
+						color={this.options.color}
 						looks={this.options.looks}
-						placeholder={placeholder}
-						invalid={this.options.invalid}
-						errorMessage={this.options.errorMessage}
 						readonly={this.options.readonly}
 						disabled={this.options.disabled}
-						color={this.options.color}
-						showLabel={this.options.showLabel}>
+						invalid={this.options.invalid}
+						errorMessage={this.options.errorMessage}
+						showLabel={this.options.showLabel}
+						placeholder={this.options.placeholder}>
 						{this.options.showLabel && <span>Text</span>}
 						<smoothly-input-clear slot="end" />
 					</smoothly-input>
@@ -101,13 +98,13 @@ export class SmoothlyInputDemoStandard {
 
 					<smoothly-input-select
 						name="month"
+						color={this.options.color}
 						looks={this.options.looks}
-						placeholder={placeholder}
-						invalid={this.options.invalid}
-						errorMessage={this.options.errorMessage}
 						readonly={this.options.readonly}
 						disabled={this.options.disabled}
-						color={this.options.color}>
+						invalid={this.options.invalid}
+						errorMessage={this.options.errorMessage}
+						placeholder={this.options.placeholder}>
 						{this.options.showLabel && <label slot="label">Select</label>}
 						<smoothly-item value="1">January</smoothly-item>
 						<smoothly-item value="2">February</smoothly-item>
@@ -126,21 +123,22 @@ export class SmoothlyInputDemoStandard {
 					<div class="height" />
 
 					<smoothly-input-checkbox
+						name={"checkbox"}
+						color={this.options.color}
 						looks={this.options.looks}
 						readonly={this.options.readonly}
-						disabled={this.options.disabled}
-						color={this.options.color}>
+						disabled={this.options.disabled}>
 						Check
 					</smoothly-input-checkbox>
 					<div class="height" />
 
 					<smoothly-input-radio
-						name="radio"
+						name={"radio"}
 						clearable
+						color={this.options.color}
 						looks={this.options.looks}
 						readonly={this.options.readonly}
 						// TODO - disabled
-						color={this.options.color}
 						showLabel={this.options.showLabel}>
 						{this.options.showLabel && <label slot="label">Radio</label>}
 						<smoothly-input-radio-item value={"first"}>Label 1</smoothly-input-radio-item>
@@ -153,12 +151,15 @@ export class SmoothlyInputDemoStandard {
 					<div class="height" />
 
 					<smoothly-input-file
+						name={"file"}
+						color={this.options.color}
 						looks={this.options.looks}
 						readonly={this.options.readonly}
 						// TODO - disabled
-						color={this.options.color}
-						placeholder={placeholder}
-						showLabel={this.options.showLabel}>
+						// TODO - invalid
+						// TODO - errorMessage
+						showLabel={this.options.showLabel}
+						placeholder={this.options.placeholder}>
 						{this.options.showLabel && <span slot={"label"}>File</span>}
 						<smoothly-input-clear slot="end" />
 					</smoothly-input-file>
@@ -166,67 +167,81 @@ export class SmoothlyInputDemoStandard {
 
 					<smoothly-input-range
 						name={"range"}
-						label={this.options.showLabel ? "Range" : undefined}
+						color={this.options.color}
 						looks={this.options.looks}
 						readonly={this.options.readonly}
 						// TODO - disabled
-						color={this.options.color}>
+						// TODO - invalid
+						// TODO - errorMessage
+						label={this.options.showLabel ? "Range" : undefined}
+						// TODO - disabled
+						// TODO - placeholder
+					>
 						<smoothly-input-clear slot="end" />
 					</smoothly-input-range>
 					<div class="height" />
 
 					<smoothly-input-color
+						name={"color"}
+						color={this.options.color}
 						looks={this.options.looks}
 						readonly={this.options.readonly}
 						// TODO - disabled
-						color={this.options.color}
-						showLabel={this.options.showLabel}>
+						// TODO - invalid
+						// TODO - errorMessage
+						showLabel={this.options.showLabel}
+						// TODO - placeholder
+					>
 						{this.options.showLabel && <span>Color</span>}
 						<smoothly-input-clear slot="end" />
 					</smoothly-input-color>
 					<div class="height" />
 
 					<smoothly-input-date
+						color={this.options.color}
 						looks={this.options.looks}
 						readonly={this.options.readonly}
 						// TODO - disabled
 						invalid={this.options.invalid}
-						color={this.options.color}
-						showLabel={this.options.showLabel}>
+						// TODO - errorMessage
+						showLabel={this.options.showLabel}
+						// TODO - placeholder
+					>
 						{this.options.showLabel && <span>Date</span>}
 						<smoothly-input-clear slot="end" />
 					</smoothly-input-date>
 					<div class="height" />
 
 					<smoothly-input-date-time
+						color={this.options.color}
 						looks={this.options.looks}
 						readonly={this.options.readonly}
 						// TODO - disabled
 						invalid={this.options.invalid}
 						errorMessage={this.options.errorMessage}
-						color={this.options.color}
-						showLabel={this.options.showLabel}>
+						showLabel={this.options.showLabel}
+						// TODO - placeholder
+					>
 						DateTime
 						<smoothly-input-clear slot="end" />
 					</smoothly-input-date-time>
 					<div class="height" />
 
 					<smoothly-input-date-range
+						color={this.options.color}
 						looks={this.options.looks}
 						readonly={this.options.readonly}
 						// TODO - disabled
 						invalid={this.options.invalid}
-						color={this.options.color}
-						placeholder={placeholder}
-						showLabel={this.options.showLabel}>
+						// TODO - errorMessage
+						placeholder={this.options.placeholder}
+						showLabel={this.options.showLabel}
+						// TODO - placeholder
+					>
 						{this.options.showLabel && <span>Date Range</span>}
 						<smoothly-input-clear slot="end" />
 					</smoothly-input-date-range>
 					<div class="height" />
-
-					<div class={{ "guide-lines": true, "show-label": !!this.options.showLabel }}>
-						{this.options.showLabel ? "Aligned labels & values" : "Center values"}
-					</div>
 				</div>
 			</Host>
 		)

--- a/src/components/input/demo/standard/index.tsx
+++ b/src/components/input/demo/standard/index.tsx
@@ -186,7 +186,7 @@ export class SmoothlyInputDemoStandard {
 						color={this.options.color}
 						looks={this.options.looks}
 						readonly={this.options.readonly}
-						// TODO - disabled
+						disabled={this.options.disabled}
 						// TODO - invalid
 						// TODO - errorMessage
 						showLabel={this.options.showLabel}

--- a/src/components/input/demo/standard/index.tsx
+++ b/src/components/input/demo/standard/index.tsx
@@ -138,7 +138,7 @@ export class SmoothlyInputDemoStandard {
 						color={this.options.color}
 						looks={this.options.looks}
 						readonly={this.options.readonly}
-						// TODO - disabled
+						disabled={this.options.disabled}
 						showLabel={this.options.showLabel}>
 						{this.options.showLabel && <label slot="label">Radio</label>}
 						<smoothly-input-radio-item value={"first"}>Label 1</smoothly-input-radio-item>

--- a/src/components/input/demo/standard/index.tsx
+++ b/src/components/input/demo/standard/index.tsx
@@ -155,7 +155,7 @@ export class SmoothlyInputDemoStandard {
 						color={this.options.color}
 						looks={this.options.looks}
 						readonly={this.options.readonly}
-						// TODO - disabled
+						disabled={this.options.disabled}
 						// TODO - invalid
 						// TODO - errorMessage
 						showLabel={this.options.showLabel}

--- a/src/components/input/demo/standard/index.tsx
+++ b/src/components/input/demo/standard/index.tsx
@@ -170,7 +170,7 @@ export class SmoothlyInputDemoStandard {
 						color={this.options.color}
 						looks={this.options.looks}
 						readonly={this.options.readonly}
-						// TODO - disabled
+						disabled={this.options.disabled}
 						// TODO - invalid
 						// TODO - errorMessage
 						label={this.options.showLabel ? "Range" : undefined}

--- a/src/components/input/demo/standard/index.tsx
+++ b/src/components/input/demo/standard/index.tsx
@@ -234,7 +234,7 @@ export class SmoothlyInputDemoStandard {
 						color={this.options.color}
 						looks={this.options.looks}
 						readonly={this.options.readonly}
-						// TODO - disabled
+						disabled={this.options.disabled}
 						invalid={this.options.invalid}
 						// TODO - errorMessage
 						placeholder={this.options.placeholder}

--- a/src/components/input/demo/standard/style.css
+++ b/src/components/input/demo/standard/style.css
@@ -7,6 +7,9 @@
 :host p {
 	margin: .5rem 0;
 }
+:host smoothly-input-range[name=borderRadius] {
+	flex-basis: 100%;
+}
 div.input-wrapper {
 	display: grid;
 	margin-top: 1rem;
@@ -49,58 +52,4 @@ div.input-wrapper > .left-padding::before {
 }
 div.input-wrapper > .left-padding:hover::before { 
 	bottom: -100vh;
-}
-
-
-/* --- vertical --- */
-
-:host.vertical {
-	width: 100%;
-	row-gap: 0;
-	position: relative;
-}
-:host.vertical > div.input-wrapper {
-	display: grid;
-	grid-template-columns: repeat(auto-fill, 14rem);
-	gap: .5rem;
-}
-:host.vertical > div.input-wrapper > .width,
-:host.vertical > div.input-wrapper > .height,
-:host.vertical > div.input-wrapper > .left-padding {
-	display: none;
-}
-
-
-:host.vertical > div.input-wrapper > .guide-lines::before,
-:host.vertical > div.input-wrapper > .guide-lines::after {
-	content: "";
-	pointer-events: none;
-	right: 0;
-	width: 100vw;
-	position: absolute;
-	z-index: 2;
-	border-top: 1px dotted black;
-}
-
-:host:not(.vertical) .guide-lines {
-	display: none;
-}
-
-.guide-lines {
-	text-align: end;
-	justify-self: center;
-  align-content: center;
-}
-
-.guide-lines::before {
-	top: 1rem;
-}
-.guide-lines::after {
-	top: 2rem;
-}
-.guide-lines.show-label::before {
-	top: 1.05rem;
-}
-.guide-lines.show-label::after {
-	top: 2.3rem;
 }

--- a/src/components/input/file/index.tsx
+++ b/src/components/input/file/index.tsx
@@ -28,6 +28,7 @@ export class SmoothlyInputFile implements ComponentWillLoad, Input, Clearable, E
 	@Element() element: HTMLSmoothlyInputFileElement
 	@Prop({ mutable: true }) changed = false
 	@Prop({ reflect: true, mutable: true }) readonly = false
+	@Prop({ reflect: true }) disabled?: boolean
 	@Prop() accept?: string
 	@Prop({ reflect: true, mutable: true }) color?: Color
 	@Prop({ reflect: true, mutable: true }) looks?: Looks
@@ -131,7 +132,7 @@ export class SmoothlyInputFile implements ComponentWillLoad, Input, Clearable, E
 			this.value = event.dataTransfer.files[0]
 	}
 	clickHandler(event: MouseEvent): void {
-		if (!this.readonly && !event.composedPath().find(target => target == this.input)) {
+		if (!this.readonly && !this.disabled && !event.composedPath().find(target => target == this.input)) {
 			this.input?.click()
 		}
 	}
@@ -141,7 +142,7 @@ export class SmoothlyInputFile implements ComponentWillLoad, Input, Clearable, E
 	}
 	dragEnterHandler(event: DragEvent): void {
 		event.preventDefault()
-		!this.readonly && (this.dragging = true)
+		!this.readonly && !this.disabled && (this.dragging = true)
 	}
 	dragLeaveHandler(event: DragEvent): void {
 		event.stopPropagation()
@@ -170,6 +171,7 @@ export class SmoothlyInputFile implements ComponentWillLoad, Input, Clearable, E
 					<input
 						ref={element => (this.input = element)}
 						type={"file"}
+						disabled={this.disabled}
 						capture={this.camera == "back" ? "environment" : "user"}
 						accept={this.accept ?? (!this.camera ? undefined : "image/jpeg")}
 						files={this.files}

--- a/src/components/input/file/index.tsx
+++ b/src/components/input/file/index.tsx
@@ -153,7 +153,7 @@ export class SmoothlyInputFile implements ComponentWillLoad, Input, Clearable, E
 		return (
 			<Host
 				class={{ dragging: this.dragging, "has-value": !!this.value }}
-				tabindex={0}
+				tabindex={this.disabled ? undefined : 0}
 				onClick={(e: MouseEvent) => this.clickHandler(e)}
 				onDragOver={(e: DragEvent) => this.dragOverHandler(e)}
 				onDragEnter={(e: DragEvent) => this.dragEnterHandler(e)}>
@@ -161,7 +161,7 @@ export class SmoothlyInputFile implements ComponentWillLoad, Input, Clearable, E
 					<slot name={"label"} />
 				</label>
 				<div class="input">
-					<smoothly-button type={"button"} color={this.color} fill={"clear"} size="flexible">
+					<smoothly-button disabled={this.disabled} type={"button"} color={this.color} fill={"clear"} size="flexible">
 						<slot name={"button"} />
 					</smoothly-button>
 					<span>{this.value?.name ?? this.placeholder}</span>
@@ -169,6 +169,7 @@ export class SmoothlyInputFile implements ComponentWillLoad, Input, Clearable, E
 						<smoothly-icon name={"document-attach-outline"} />
 					</div>
 					<input
+						onFocus={() => console.log("focus file input!")}
 						ref={element => (this.input = element)}
 						type={"file"}
 						disabled={this.disabled}

--- a/src/components/input/file/style.css
+++ b/src/components/input/file/style.css
@@ -64,12 +64,12 @@
 	left: var(--input-padding-side);
 }
 
-:host,
-:host * {
+:host:not([readonly]),
+:host:not([readonly]) * {
 	cursor: pointer;
 }
 
-:host[readonly],
-:host[readonly] * {
+:host[disabled],
+:host[disabled] * {
 	cursor: not-allowed;
 }

--- a/src/components/input/index.tsx
+++ b/src/components/input/index.tsx
@@ -151,6 +151,7 @@ export class SmoothlyInput implements Clearable, Input, Editable {
 			this.smoothlyInput.emit({ [this.name]: this.stateHandler.getValue(this.state) })
 		}
 	}
+	@Watch("disabled")
 	@Watch("readonly")
 	readonlyChange() {
 		this.listener.changed?.(this)

--- a/src/components/input/radio/index.tsx
+++ b/src/components/input/radio/index.tsx
@@ -37,6 +37,7 @@ export class SmoothlyInputRadio implements Input, Clearable, Editable, Component
 	@Prop({ reflect: true, mutable: true }) color?: Color
 	@Prop() clearable?: boolean
 	@Prop({ mutable: true, reflect: true }) readonly = false
+	@Prop({ reflect: true }) disabled?: boolean
 	@Prop({ reflect: true }) name: string
 	@Prop({ reflect: true }) showLabel = true
 	@Event() smoothlyInputLooks: EventEmitter<(looks?: Looks, color?: Color) => void>
@@ -65,7 +66,7 @@ export class SmoothlyInputRadio implements Input, Clearable, Editable, Component
 	@Listen("smoothlySelect")
 	smoothlyRadioInputHandler(event: CustomEvent<Selectable>): void {
 		event.stopPropagation()
-		if (!this.readonly || !this.valueReceivedOnLoad) {
+		if ((!this.readonly && !this.disabled) || !this.valueReceivedOnLoad) {
 			if (this.clearable && this.active?.value === event.detail.value)
 				this.clear()
 			else if (this.active?.value !== event.detail.value) {

--- a/src/components/input/radio/index.tsx
+++ b/src/components/input/radio/index.tsx
@@ -133,6 +133,7 @@ export class SmoothlyInputRadio implements Input, Clearable, Editable, Component
 		this.smoothlyInput.emit({ [this.name]: await this.getValue() })
 		this.listener.changed?.(this)
 	}
+	@Watch("disabled")
 	@Watch("readonly")
 	watchingReadonly(): void {
 		this.listener.changed?.(this)

--- a/src/components/input/radio/item/index.tsx
+++ b/src/components/input/radio/item/index.tsx
@@ -27,13 +27,7 @@ export class SmoothlyInputRadioItem {
 		return (
 			<Host onClick={() => this.inputHandler()}>
 				<input name={this.name} type="radio" checked={this.selected} />
-				<smoothly-icon
-					name={this.selected ? "checkmark-circle" : "ellipse-outline"}
-					size="small"
-					fill="outline"
-					color={this.selected ? "success" : "medium"}
-					toolTip="Select"
-				/>
+				<smoothly-icon name={this.selected ? "checkmark-circle" : "ellipse-outline"} size="small" toolTip="Select" />
 				<label>
 					<slot />
 				</label>

--- a/src/components/input/radio/item/style.css
+++ b/src/components/input/radio/item/style.css
@@ -3,7 +3,7 @@
 	align-items: center;
 	position: relative;
 }
-smoothly-input-radio:not([disabled]) :host>* {
+smoothly-input-radio:not([disabled]):not([readonly]) :host>* {
 	cursor: pointer;
 }
 smoothly-input-radio[disabled] :host>* {
@@ -17,7 +17,7 @@ smoothly-input-radio[disabled] :host>* {
 :host>smoothly-icon {
 	--smoothly-color-contrast: var(--smoothly-input-foreground);
 }
-smoothly-input-radio:not([disabled]) :host>smoothly-icon[name=checkmark-circle] {
+smoothly-input-radio:not([disabled]):not([readonly]) :host>smoothly-icon[name=checkmark-circle] {
 	--smoothly-color-contrast: var(--smoothly-success-color);
 }
 

--- a/src/components/input/radio/item/style.css
+++ b/src/components/input/radio/item/style.css
@@ -3,14 +3,22 @@
 	align-items: center;
 	position: relative;
 }
-
-:host:hover>* {
+smoothly-input-radio:not([disabled]) :host>* {
 	cursor: pointer;
+}
+smoothly-input-radio[disabled] :host>* {
+	cursor: not-allowed;
 }
 
 :host>input:focus-visible+smoothly-icon {
 	outline: 2px solid rgb(var(--smoothly-primary-color));
 	border-radius: 1px;
+}
+:host>smoothly-icon {
+	--smoothly-color-contrast: var(--smoothly-input-foreground);
+}
+smoothly-input-radio:not([disabled]) :host>smoothly-icon[name=checkmark-circle] {
+	--smoothly-color-contrast: var(--smoothly-success-color);
 }
 
 :host>input {

--- a/src/components/input/radio/style.css
+++ b/src/components/input/radio/style.css
@@ -21,6 +21,6 @@
 	margin-left: auto;
 }
 
-:host[readonly] smoothly-input-radio-item * {
+:host[disabled] smoothly-input-radio-item * {
 	cursor: not-allowed;
 }

--- a/src/components/input/range/index.tsx
+++ b/src/components/input/range/index.tsx
@@ -37,6 +37,7 @@ export class SmoothlyInputRange implements Input, Clearable, Editable, Component
 	@Prop({ mutable: true }) changed = false
 	@Prop({ mutable: true }) defined = false
 	@Prop({ reflect: true, mutable: true }) readonly = false
+	@Prop({ reflect: true }) disabled?: boolean
 	@Prop() type: Extract<tidily.Type, "text" | "percent"> = "text"
 	@Prop() min = 0
 	@Prop() max = 100
@@ -120,6 +121,11 @@ export class SmoothlyInputRange implements Input, Clearable, Editable, Component
 		this.listener.changed?.(this)
 		this.smoothlyInput.emit({ [this.name]: this.value })
 	}
+	@Watch("disabled")
+	@Watch("readonly")
+	watchingReadonly(): void {
+		this.listener.changed?.(this)
+	}
 	setValue(value: number | undefined): void {
 		if (value == undefined)
 			this.value = undefined
@@ -160,7 +166,8 @@ export class SmoothlyInputRange implements Input, Clearable, Editable, Component
 						}}
 						value={this.type == "percent" ? this.value : this.value?.toString()}
 						placeholder={this.outputSide === "right" ? "-" : undefined}
-						readonly={this.readonly}>
+						readonly={this.readonly}
+						disabled={this.disabled}>
 						{this.label}
 					</smoothly-input>
 					<smoothly-display label={(this.type == "percent" ? this.min * 100 : this.min).toString()} />
@@ -171,7 +178,7 @@ export class SmoothlyInputRange implements Input, Clearable, Editable, Component
 						min={this.min}
 						max={this.max}
 						step={this.step ?? "any"}
-						disabled={this.readonly}
+						disabled={this.readonly || this.disabled}
 						onInput={event => {
 							event.stopPropagation()
 							this.setValue((event.target as HTMLInputElement).valueAsNumber)

--- a/src/components/input/range/style.css
+++ b/src/components/input/range/style.css
@@ -80,11 +80,13 @@
 	height: 0.8em;
 	width: 0.8em;
 	border-radius: 100%;
-	background-color: rgb(var(--smoothly-primary-color));
-	cursor: pointer;
 	margin-top: -.25em;
 	border: none;
 	/* You need to specify a margin in Chrome, but in Firefox and IE it is automatic */
+}
+:host:not([disabled]):not([readonly])>div>input[type=range]::-webkit-slider-thumb {
+	background-color: rgb(var(--smoothly-primary-color));
+	cursor: pointer;
 }
 
 /* Firefox */
@@ -92,41 +94,50 @@
 	height: 0.8em;
 	width: 0.8em;
 	border-radius: 100%;
+	border: none;
+	background-color: rgb(var(--smoothly-input-foreground));
+}
+:host:not([disabled]):not([readonly])>div>input[type=range]::-moz-range-thumb {
 	background-color: rgb(var(--smoothly-primary-color));
 	cursor: pointer;
-	border: none;
 }
 
 /*--------------------SLIDER TRACK------------------ */
 :host>div>input[type=range]::-webkit-slider-runnable-track {
-	height: .3em;
-	cursor: pointer;
-	background-color: rgb(var(--smoothly-primary-color));
+	height: .3rem;
 	border-radius: 20px;
+	background-color: rgb(var(--smoothly-input-foreground));
+}
+:host:not([disabled]):not([readonly])>div>input[type=range]::-webkit-slider-runnable-track {
+	background-color: rgb(var(--smoothly-primary-color));
+	cursor: pointer;
 }
 
 :host>div>input[type=range]::-moz-range-track {
 	width: 100%;
-	height: .3em;
-	cursor: pointer;
-	background-color: rgb(var(--smoothly-primary-color));
+	height: .3rem;
 	border-radius: 20px;
+	background-color: rgb(var(--smoothly-input-foreground));
+}
+:host:not([disabled]):not([readonly])>div>input[type=range]::-moz-range-track {
+	background-color: rgb(var(--smoothly-primary-color));
+	cursor: pointer;
 }
 
-:host(:not([value]))>div>input[type=range]::-webkit-slider-runnable-track {
+:host:not([value]):not([disabled]):not([readonly])>div>input[type=range]::-webkit-slider-runnable-track {
 	background-color: rgb(var(--smoothly-primary-tint));
 }
 
-:host(:not([value]))>dov>input[type=range]::-moz-range-track {
+:host:not([value]):not([disabled]):not([readonly])>div>input[type=range]::-moz-range-track {
 	background-color: rgb(var(--smoothly-primary-tint));
 }
 
-:host[readonly]>div>input[type=range]::-webkit-slider-thumb,
-:host[readonly]>div>input[type=range]::-moz-range-thumb,
-:host[readonly]>div>input[type=range]::-webkit-slider-runnable-track,
-:host[readonly]>div>input[type=range]::-moz-range-track,
-:host[readonly],
-:host[readonly] * {
+:host[disabled]>div>input[type=range]::-webkit-slider-thumb,
+:host[disabled]>div>input[type=range]::-moz-range-thumb,
+:host[disabled]>div>input[type=range]::-webkit-slider-runnable-track,
+:host[disabled]>div>input[type=range]::-moz-range-track,
+:host[disabled],
+:host[disabled] * {
 	cursor: not-allowed
 }
 

--- a/src/components/input/reset/index.tsx
+++ b/src/components/input/reset/index.tsx
@@ -30,7 +30,7 @@ export class SmoothlyInputReset {
 				this.readonlyAtLoad = parent.readonly
 				parent.listen("changed", async p => {
 					if (Input.is(p)) {
-						this.display = p.readonly ? false : p.changed
+						this.display = p.readonly || p.defined ? false : p.changed
 					}
 					if (p instanceof SmoothlyForm) {
 						this.display = !p.readonly

--- a/src/components/input/select/index.tsx
+++ b/src/components/input/select/index.tsx
@@ -348,7 +348,7 @@ export class SmoothlyInputSelect implements Input, Editable, Clearable, Componen
 	render(): VNode | VNode[] {
 		return (
 			<Host
-				tabIndex={0}
+				tabIndex={this.disabled ? undefined : 0}
 				class={{ "has-value": this.selected.length !== 0, open: this.open }}
 				onClick={(event: Event) => this.handleShowOptions(event)}>
 				<div class="select-display" ref={element => (this.displaySelectedElement = element)}>

--- a/src/components/input/select/index.tsx
+++ b/src/components/input/select/index.tsx
@@ -175,6 +175,7 @@ export class SmoothlyInputSelect implements Input, Editable, Clearable, Componen
 		value = value.toLowerCase()
 		await Promise.all(this.items.map(item => item.filter(value)))
 	}
+	@Watch("disabled")
 	@Watch("readonly")
 	watchingReadonly(): void {
 		this.listener.changed?.(this)

--- a/src/components/input/select/index.tsx
+++ b/src/components/input/select/index.tsx
@@ -45,6 +45,7 @@ export class SmoothlyInputSelect implements Input, Editable, Clearable, Componen
 	@Prop({ reflect: true }) showLabel = true
 	@Prop({ reflect: true, mutable: true }) showSelected?: boolean = true
 	@Prop({ reflect: true, mutable: true }) readonly = false
+	@Prop({ reflect: true }) disabled = false
 	@Prop({ reflect: true }) inCalendar = false
 	@Prop({ reflect: true }) ordered?: boolean
 	@Prop() multiple = false
@@ -229,6 +230,7 @@ export class SmoothlyInputSelect implements Input, Editable, Clearable, Componen
 			?.composedPath()
 			.find((el): el is HTMLSmoothlyItemElement => "tagName" in el && el.tagName == "SMOOTHLY-ITEM")
 		!this.readonly &&
+			!this.disabled &&
 			!(clickedItem && this.items.includes(clickedItem) && this.multiple) &&
 			!wasButtonClicked &&
 			(this.open = !this.open)

--- a/src/components/input/select/style.css
+++ b/src/components/input/select/style.css
@@ -24,7 +24,6 @@
 :host>div.select-display {
 	box-sizing: border-box;
 	display: flex;
-	cursor: pointer;
 	padding: var(--input-value-padding-top) .8rem var(--input-value-padding-bottom) 0;
 	overflow: hidden;
 	width: 100%;
@@ -32,15 +31,14 @@
 	gap: 1rem;
 	text-overflow: ellipsis;
 }
+:host:not([readonly]):not([disabled])>div.select-display {
+	cursor: pointer;
+}
 
 :host:not(:has([slot=label]))>div.select-display,
 :host:not([show-label])>div.select-display  {
 	padding: .6rem .8rem .6rem 0;
 	align-items: center;
-}
-
-:host[readonly]>div.select-display {
-	cursor: not-allowed;
 }
 
 :host>div.select-display smoothly-icon {
@@ -62,9 +60,12 @@
 :host>div.icons>smoothly-icon[name=caret-down-outline],
 :host>div.icons>smoothly-icon[name=caret-forward-outline] {
 	opacity: .7;
-	cursor: pointer;
 	height: 100%;
 	padding-inline: var(--input-padding-side);
+}
+:host:not([readonly]):not([disabled])>div.icons>smoothly-icon[name=caret-down-outline],
+:host:not([readonly]):not([disabled])>div.icons>smoothly-icon[name=caret-forward-outline] {
+	cursor: pointer;
 }
 
 :host[invalid]>div>smoothly-icon.smoothly-invalid {

--- a/src/components/input/select/style.css
+++ b/src/components/input/select/style.css
@@ -55,13 +55,6 @@
 	align-items: center;
 }
 
-:host>div.icons::slotted(smoothly-icon):not("color") {
-	color: rgb(var(--smoothly-input-foreground));
-	fill: rgb(var(--smoothly-input-foreground));
-	stroke: rgb(var(--smoothly-input-foreground));
-	filter: opacity(60%);
-}
-
 :host:hover>div.icons::slotted(smoothly-icon) {
 	filter: opacity(100%);
 }

--- a/src/components/input/shared.css
+++ b/src/components/input/shared.css
@@ -53,6 +53,12 @@
 :host[looks="transparent"]:not([readonly]):focus-within {
 	outline: 1px solid rgb(var(--smoothly-input-border));
 }
+:host([disabled]) {
+	cursor: not-allowed;
+	--smoothly-input-foreground: var(--smoothly-input-disabled-foreground);
+	--smoothly-input-background: var(--smoothly-input-disabled-background);
+	--smoothly-input-border: var(--smoothly-input-disabled-border);
+}
 
 /* --- label --- */
 

--- a/src/components/input/shared.css
+++ b/src/components/input/shared.css
@@ -55,6 +55,7 @@
 }
 :host([disabled]) {
 	cursor: not-allowed;
+	user-select: none;
 	--smoothly-input-foreground: var(--smoothly-input-disabled-foreground);
 	--smoothly-input-background: var(--smoothly-input-disabled-background);
 	--smoothly-input-border: var(--smoothly-input-disabled-border);

--- a/src/components/input/shared.css
+++ b/src/components/input/shared.css
@@ -8,7 +8,6 @@
 	border-radius: var(--smoothly-input-border-radius);
 }
 
-:host[looks="border"]::slotted(smoothly-picker-menu smoothly-input),
 :host[looks="border"] {
 	border: rgb(var(--smoothly-input-border)) solid 1px;
 }
@@ -17,7 +16,6 @@
 	border: transparent solid 1px;
 }
 
-:host[looks="line"]::slotted(smoothly-picker-menu smoothly-input),
 :host[looks="line"] {
 	border-bottom: rgb(var(--smoothly-input-border)) solid 1px;
 }

--- a/src/components/input/shared.css
+++ b/src/components/input/shared.css
@@ -54,7 +54,6 @@
 
 :host([disabled]) {
 	cursor: not-allowed;
-	user-select: none;
 	--smoothly-input-foreground: var(--smoothly-input-disabled-foreground);
 	--smoothly-input-background: var(--smoothly-input-disabled-background);
 	--smoothly-input-border: var(--smoothly-input-disabled-border);

--- a/src/components/input/shared.css
+++ b/src/components/input/shared.css
@@ -45,12 +45,13 @@
 
 :host[looks="transparent"][readonly]>input,
 :host[looks="transparent"]:not(:focus-within)>input {
-	background: transparent;
+	background-color: transparent;
 }
 
 :host[looks="transparent"]:not([readonly]):focus-within {
 	outline: 1px solid rgb(var(--smoothly-input-border));
 }
+
 :host([disabled]) {
 	cursor: not-allowed;
 	user-select: none;

--- a/src/components/input/style.css
+++ b/src/components/input/style.css
@@ -65,12 +65,17 @@
 	font-size: 1rem;
 	font-family: var(--smoothly-font-family);
 }
+:host([disabled])>.smoothly-input-container>input {
+	cursor: not-allowed;
+}
 
 :host>.smoothly-invalid {
 	display: none;
 	z-index: 2;
-	cursor: pointer;
 	padding: 0.5rem;
+}
+:host:not([disabled])>.smoothly-invalid {
+	cursor: pointer;
 }
 
 :host[invalid]>.smoothly-invalid {


### PR DESCRIPTION
## readonly vs disabled
Defining what `readonly` vs `disabled` should mean for inputs.

|                             | `readonly` | `disabled` |
|---------------------------------|:-:|:-:|
| Reflected in DOM               | ✅ | ✅ |
| Can select text                 | ✅ | ✅ |
| Can can change value     | ❌ | ❌ |
| Focusable                         | ✅ | ❌ |
| cursor   | default/text (not pointer) | not-allowed 🚫 |
| Styling | Mostly the same <br /> but no saturated colors | greyed out using css-vars |
| Suggested Use | When showing only <br />  non-editable values <br /> (e.g. instead of <br /> smoothly-display) | When a non-editable value <br />  is together with other <br />  editable values. |


### readonly example use
![image](https://github.com/user-attachments/assets/eb280d4e-ef6e-4e31-bde6-02ed31b4f114)


### disabled css-vars
- `--smoothly-input-disabled-foreground`
- `--smoothly-input-disabled-background`
- `--smoothly-input-disabled-border`

### disabled example use  
**Suggested use:** 
When a non-editable value is together with other editable values.

![image](https://github.com/user-attachments/assets/82bb8632-4ab9-43f0-9d0f-f41c9f3b2640)

## Preview 
**normal (editable)**
![Screenshot from 2025-04-22 10-29-49](https://github.com/user-attachments/assets/e08afbfc-8913-4c53-ae70-397c91c9d32e)

**readonly**
![Screenshot from 2025-04-22 10-29-55](https://github.com/user-attachments/assets/aaff6e73-ed53-4b9b-8031-9d70a151080d)

**disabled**
![Screenshot from 2025-04-22 10-30-02](https://github.com/user-attachments/assets/1f34fd95-3fdd-4ba5-87ac-de9bc9f21a0f)


## Note
inpuy-radio is actually still focusable - this will need fixing later.

