### PR TITLE
Fix table expandable row selector to not target details - only cells

### DIFF
--- a/src/components/table/expandable/row/style.scss
+++ b/src/components/table/expandable/row/style.scss
@@ -8,7 +8,7 @@
 	box-shadow: 0px 1px 1px -1px rgb(var(--smoothly-table-border));
 }
 
-:host::slotted(*) {
+:host::slotted(:not(.detail)) {
 	cursor: pointer;
 	grid-column: span var(--smoothly-table-cell-span, 1);
 	display: flex;
@@ -31,7 +31,7 @@
 	grid-template-rows: 0fr 1fr;
 }
 
-:host(:not([open]))>div.detail  {
+:host(:not([open]))>div.detail {
 	display: none;
 }
 


### PR DESCRIPTION
## Before
![Screenshot from 2025-04-22 13-40-51](https://github.com/user-attachments/assets/958a2719-176b-4c0f-8232-040c1154f846)


## After
![Screenshot from 2025-04-22 13-40-27](https://github.com/user-attachments/assets/8f3c9749-abc3-4dc6-9ff5-de50cbd1b81c)
