### PR TITLE
No smoothlyInput event when value change between undefined and false

### DIFF
--- a/src/components/input/checkbox/index.tsx
+++ b/src/components/input/checkbox/index.tsx
@@ -80,10 +80,13 @@ export class SmoothlyInputCheckbox implements Input, Clearable, Editable, Compon
 		this.changed = false
 	}
 	@Watch("checked")
-	async elementCheck() {
-		this.changed = this.initialValue !== this.checked
-		this.smoothlyInput.emit({ [this.name]: await this.getValue() })
-		this.observer.publish()
+	async elementCheck(checked: boolean | undefined, before: boolean | undefined) {
+		this.changed = !!this.initialValue != !!this.checked
+		const changed = !!checked != !!before
+		if (changed) {
+			this.smoothlyInput.emit({ [this.name]: await this.getValue() })
+			this.observer.publish()
+		}
 	}
 	click() {
 		!this.disabled && !this.readonly && (this.checked = !this.checked)


### PR DESCRIPTION
Don't emit event smoothlyInput on checked changing between `undefined` and `false`.
This PR makes it so `undefined` is interpreted as `false`.