### PR TITLE
Fix smoothly-date-time-input: to make the watcher run on initial value

### DIFF
--- a/src/components/input/date/time/index.tsx
+++ b/src/components/input/date/time/index.tsx
@@ -59,6 +59,7 @@ export class SmoothlyInputDateTime implements ComponentWillLoad, Clearable, Inpu
 		this.smoothlyInputLoad.emit(parent => (this.parent = parent))
 		!this.readonly && this.smoothlyFormDisable.emit(readonly => (this.readonly = readonly))
 		this.observer.publish()
+		this.valueChange(this.value)
 	}
 	async disconnectedCallback() {
 		if (!this.element.isConnected)


### PR DESCRIPTION
In Stencil, the @Watch('value') decorator is designed to observe changes to a property, but it only fires when the property changes after the component has been initialized (i.e., after componentWillLoad or componentDidLoad). If you're setting the property initially via an attribute or directly in JSX.