### PR TITLE
Don't allow focus on disabled radio items

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -18,6 +18,7 @@ import { isly } from "isly";
 import { Key } from "./components/input/Key";
 import { RGB } from "./model/Color/RGB";
 import { Selectable } from "./components/input/radio/Selected";
+import { SmoothlyInputRadio } from "./components/input/radio/index";
 export { Color, Data, Fill, Icon, Message, Notice, Submit, Trigger } from "./model";
 export { FunctionalComponent, VNode } from "@stencil/core";
 export { Button } from "./components/button/Button";
@@ -31,6 +32,7 @@ export { isly } from "isly";
 export { Key } from "./components/input/Key";
 export { RGB } from "./model/Color/RGB";
 export { Selectable } from "./components/input/radio/Selected";
+export { SmoothlyInputRadio } from "./components/input/radio/index";
 export namespace Components {
     interface SmoothlyApp {
         "color": Color;
@@ -1595,7 +1597,7 @@ declare global {
     };
     interface HTMLSmoothlyInputRadioItemElementEventMap {
         "smoothlySelect": Selectable;
-        "smoothlyRadioItemRegister": (name: string) => void;
+        "smoothlyRadioItemRegister": (parent: SmoothlyInputRadio) => void;
     }
     interface HTMLSmoothlyInputRadioItemElement extends Components.SmoothlyInputRadioItem, HTMLStencilElement {
         addEventListener<K extends keyof HTMLSmoothlyInputRadioItemElementEventMap>(type: K, listener: (this: HTMLSmoothlyInputRadioItemElement, ev: SmoothlyInputRadioItemCustomEvent<HTMLSmoothlyInputRadioItemElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -2637,7 +2639,7 @@ declare namespace LocalJSX {
     interface SmoothlyInputRadioItem {
         "looks"?: Looks;
         "name"?: string;
-        "onSmoothlyRadioItemRegister"?: (event: SmoothlyInputRadioItemCustomEvent<(name: string) => void>) => void;
+        "onSmoothlyRadioItemRegister"?: (event: SmoothlyInputRadioItemCustomEvent<(parent: SmoothlyInputRadio) => void>) => void;
         "onSmoothlySelect"?: (event: SmoothlyInputRadioItemCustomEvent<Selectable>) => void;
         "selected"?: boolean;
         "value"?: any;

--- a/src/components/input/radio/index.tsx
+++ b/src/components/input/radio/index.tsx
@@ -55,9 +55,9 @@ export class SmoothlyInputRadio implements Input, Clearable, Editable, Component
 		this.initialValue = this.active
 	}
 	@Listen("smoothlyRadioItemRegister")
-	handleRegister(event: CustomEvent<(name: string) => void>) {
+	handleRegister(event: CustomEvent<(parent: SmoothlyInputRadio) => void>) {
 		event.stopPropagation()
-		event.detail(this.name)
+		event.detail(this)
 	}
 	@Listen("smoothlyInputLoad")
 	smoothlyInputLoadHandler(event: CustomEvent<(parent: SmoothlyInputRadio) => void>): void {

--- a/src/components/input/radio/item/index.tsx
+++ b/src/components/input/radio/item/index.tsx
@@ -1,5 +1,7 @@
-import { Component, Element, Event, EventEmitter, h, Host, Prop, VNode } from "@stencil/core"
+import { Component, Element, Event, EventEmitter, h, Host, Prop, State, VNode } from "@stencil/core"
+import { Input } from "../../Input"
 import { Looks } from "../../Looks"
+import { SmoothlyInputRadio } from "../index"
 import { Selectable } from "../Selected"
 
 @Component({
@@ -13,10 +15,17 @@ export class SmoothlyInputRadioItem {
 	@Prop({ mutable: true, reflect: true }) selected = false
 	@Prop({ mutable: true, reflect: true }) looks?: Looks
 	@Prop({ mutable: true }) name: string
+	@State() disabled?: boolean
 	@Event() smoothlySelect: EventEmitter<Selectable>
-	@Event() smoothlyRadioItemRegister: EventEmitter<(name: string) => void>
+	@Event() smoothlyRadioItemRegister: EventEmitter<(parent: SmoothlyInputRadio) => void>
 	componentWillLoad(): void | Promise<void> {
-		this.smoothlyRadioItemRegister.emit(name => (this.name = name))
+		this.smoothlyRadioItemRegister.emit(parent => {
+			this.name = parent.name
+			parent.listen(async p => {
+				if (Input.is(p))
+					this.disabled = p.disabled
+			})
+		})
 		this.selected && this.inputHandler()
 	}
 	inputHandler(): void {
@@ -26,7 +35,7 @@ export class SmoothlyInputRadioItem {
 	render(): VNode | VNode[] {
 		return (
 			<Host onClick={() => this.inputHandler()}>
-				<input name={this.name} type="radio" checked={this.selected} />
+				<input name={this.name} type="radio" checked={this.selected} disabled={this.disabled} />
 				<smoothly-icon name={this.selected ? "checkmark-circle" : "ellipse-outline"} size="small" toolTip="Select" />
 				<label>
 					<slot />


### PR DESCRIPTION
Make input-radio-item un-focusable when disabled.

## Before
[Screencast from 2025-05-05 10:14:04.webm](https://github.com/user-attachments/assets/d724080a-3ef0-4a50-b3fb-8f76f71a7ca7)
