### PR TITLE
Smoothly-input-select: add method to refresh the display of the innerText of selected item

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -540,6 +540,7 @@ export namespace Components {
         "setInitialValue": () => Promise<void>;
         "showLabel": boolean;
         "showSelected"?: boolean;
+        "syncSelectedDisplay": () => Promise<void>;
         "unregister": () => Promise<void>;
     }
     interface SmoothlyInputSubmit {

--- a/src/components/input/select/index.tsx
+++ b/src/components/input/select/index.tsx
@@ -138,7 +138,12 @@ export class SmoothlyInputSelect implements Input, Editable, Clearable, Componen
 		this.changed = false
 		this.open && this.handleShowOptions()
 	}
-
+	@Method()
+	async syncSelectedDisplay(): Promise<void> {
+		await new Promise(requestAnimationFrame) // wait for children to be fully rendered in DOM
+		this.selected = this.items.filter(item => item.selected)
+		this.displaySelected()
+	}
 	@Method()
 	async clear(): Promise<void> {
 		if (this.clearable) {


### PR DESCRIPTION
### Issue:
if you already selected one item and then you update the innerText of that item, it updates in the dropdown but it doesn' t get updated in the box
### Fix: 
[Screencast from 2025-05-09 13-56-30.webm](https://github.com/user-attachments/assets/efa776db-5cb0-4ba7-895a-01a0426236d2)


