### PR TITLE
Make open tab more obvious in styling

### DIFF
--- a/src/assets/style/mapping.css
+++ b/src/assets/style/mapping.css
@@ -49,6 +49,10 @@ smoothly-color {
   --smoothly-item-disabled-foreground: var(--smoothly-default-contrast), 50%;
 	--smoothly-item-disabled-opacity: 0.6;
 
+	/* smoothly-tab */
+	--smoothly-tab-hover-background: var(--smoothly-default-tint);
+	--smoothly-tab-active-line: var(--smoothly-primary-color);
+
 	/* smoothly-button */
 	--smoothly-button-background: var(--smoothly-color);
 	--smoothly-button-foreground: var(--smoothly-color-shade);

--- a/src/components/tabs/tab/style.css
+++ b/src/components/tabs/tab/style.css
@@ -1,12 +1,13 @@
 :host {
 	display: contents;
-	--line-width: 3px;
+	--smoothly-tab-line-width: 2px;
+	--smoothly-tab-line-width-active: 5px;
 }
 :host > div:first-child {
 	grid-column: span 1;
 	background-color: transparent;
 	border-bottom-color: rgb(var(--smoothly-default-shade));
-	border-bottom-width: var(--line-width);
+	border-bottom-width: var(--smoothly-tab-line-width);
 	border-bottom-style: solid;
 }
 :host([disabled]) > div:first-child {
@@ -18,15 +19,27 @@
 :host > div:first-child > label {
 	display: flex;
 	justify-content: center;
-	padding: .5rem;
+	padding: 0.5rem 1rem;
 	width: fit-content;
+	border-radius: 0.5rem 0.5rem 0 0;
   margin: auto;
 	cursor: pointer;
 	position: relative;
 }
+:host:not([disabled]) > div:first-child > label:hover {
+	background-color: rgb(var(--smoothly-tab-hover-background, var(--smoothly-default-shade)));
+}
 :host([open]) > div:first-child > label {
-	border-bottom: var(--line-width) solid rgb(var(--smoothly-primary-color));
-	margin-bottom: calc(-1 * var(--line-width));
+	
+	font-weight: bold;
+}
+:host([open]) > div:first-child > label::before {
+	content: '';
+	position: absolute;
+	height: var(--smoothly-tab-line-width-active);
+	background-color: rgb(var(--smoothly-tab-active-line, var(--smoothly-primary-color)));
+	inset-inline: 0;
+	bottom: calc(-1 * var(--smoothly-tab-line-width));
 }
 :host > div:first-child > label[data-smoothly-tooltip]:hover::after {
 	content: attr(data-smoothly-tooltip);


### PR DESCRIPTION
![Screenshot from 2025-05-23 14-54-03](https://github.com/user-attachments/assets/09fc20f8-889f-4d8b-851f-189665a69204)

New optional css variables (will put some default color if not used.
```
--smoothly-tab-hover-background
--smoothly-tab-active-line
```
