### PR TITLE
Added possibility for cell-items to be wraped in a-tag in expandable row.

### DIFF
--- a/src/components/table/demo/simple/simple.tsx
+++ b/src/components/table/demo/simple/simple.tsx
@@ -35,6 +35,10 @@ export class SmoothlyTableDemoSimple {
 							</smoothly-table-row>
 						))}
 						<smoothly-table-expandable-row>
+							<a href="#" onClick={e => !e.button && e.preventDefault()} target="_blank">
+								<smoothly-table-cell>Cell1 in expandable row</smoothly-table-cell>
+								<smoothly-table-cell>Cell2 in expandable row</smoothly-table-cell>
+							</a>
 							<div slot={"detail"}>
 								Content
 								<br />
@@ -46,8 +50,6 @@ export class SmoothlyTableDemoSimple {
 								<br />
 								row
 							</div>
-							<smoothly-table-cell>Cell1 in expandable row</smoothly-table-cell>
-							<smoothly-table-cell>Cell2 in expandable row</smoothly-table-cell>
 						</smoothly-table-expandable-row>
 						<smoothly-table-row>
 							<smoothly-table-cell>Cell5</smoothly-table-cell>

--- a/src/components/table/demo/simple/simple.tsx
+++ b/src/components/table/demo/simple/simple.tsx
@@ -35,7 +35,7 @@ export class SmoothlyTableDemoSimple {
 							</smoothly-table-row>
 						))}
 						<smoothly-table-expandable-row>
-							<a href="#" onClick={e => !e.button && e.preventDefault()} target="_blank">
+							<a class="smoothly-row" href="#" onClick={e => !e.button && e.preventDefault()} target="_blank">
 								<smoothly-table-cell>Cell1 in expandable row</smoothly-table-cell>
 								<smoothly-table-cell>Cell2 in expandable row</smoothly-table-cell>
 							</a>

--- a/src/components/table/expandable/row/style.scss
+++ b/src/components/table/expandable/row/style.scss
@@ -8,7 +8,12 @@
 	box-shadow: 0px 1px 1px -1px rgb(var(--smoothly-table-border));
 }
 
-:host::slotted(:not(.detail)) {
+:host a { 
+	display: contents;
+}
+
+:host::slotted(:not(.detail)):not(a),
+:host::slotted(a>*) {
 	cursor: pointer;
 	grid-column: span var(--smoothly-table-cell-span, 1);
 	display: flex;
@@ -17,7 +22,8 @@
 	white-space: nowrap;
 }
 
-:host:has(>:not(:last-child):hover)> :not(:last-child) {
+:host:has(>:not(:last-child):hover),
+:host a:has(>:not(:last-child):hover) {
 	background-color: rgb(var(--smoothly-table-hover-background));
 	color: rgb(var(--smoothly-table-hover-foreground));
 }
@@ -44,16 +50,18 @@
 	color: rgb(var(--smoothly-table-expanded-foreground));
 }
 
-:host> :first-child:not(:last-child) {
+:host> :first-child,
+:host a> :first-child {
 	@include arrow;
 }
 
-:host:has(>:not(:last-child):hover)> :first-child:not(:last-child) {
+:host:has(>:hover)> :first-child,
+:host>a:has(>:hover)> :first-child {
 	@include arrow-hover;
-
 }
 
-:host[open]> :first-child:not(:last-child) {
+:host[open]> :first-child,
+:host[open] a > :first-child {
 	@include arrow-open;
 }
 

--- a/src/components/table/expandable/row/style.scss
+++ b/src/components/table/expandable/row/style.scss
@@ -8,12 +8,12 @@
 	box-shadow: 0px 1px 1px -1px rgb(var(--smoothly-table-border));
 }
 
-:host a { 
+:host>a { 
 	display: contents;
 }
 
 :host::slotted(:not(.detail)):not(a),
-:host::slotted(a>*) {
+:host>::slotted(a>*) {
 	cursor: pointer;
 	grid-column: span var(--smoothly-table-cell-span, 1);
 	display: flex;
@@ -23,7 +23,7 @@
 }
 
 :host:has(>:not(:last-child):hover),
-:host a:has(>:not(:last-child):hover) {
+:host>a:has(>:not(:last-child):hover) {
 	background-color: rgb(var(--smoothly-table-hover-background));
 	color: rgb(var(--smoothly-table-hover-foreground));
 }
@@ -51,7 +51,7 @@
 }
 
 :host> :first-child,
-:host a> :first-child {
+:host>a> :first-child {
 	@include arrow;
 }
 
@@ -61,7 +61,7 @@
 }
 
 :host[open]> :first-child,
-:host[open] a > :first-child {
+:host[open]>a>:first-child {
 	@include arrow-open;
 }
 

--- a/src/components/table/expandable/row/style.scss
+++ b/src/components/table/expandable/row/style.scss
@@ -8,12 +8,15 @@
 	box-shadow: 0px 1px 1px -1px rgb(var(--smoothly-table-border));
 }
 
-:host>a { 
-	display: contents;
+:host>.smoothly-row { 
+	display: grid;
+	grid-template-columns: subgrid;
+	grid-column: 1 / -1;
 }
 
-:host::slotted(:not(.detail)):not(a),
-:host>::slotted(a>*) {
+:host::slotted(:not(.detail)):not(.smoothly-row),
+:host>::slotted(.smoothly-row>*) {
+	grid: subgrid;
 	cursor: pointer;
 	grid-column: span var(--smoothly-table-cell-span, 1);
 	display: flex;
@@ -23,7 +26,7 @@
 }
 
 :host:has(>:not(:last-child):hover),
-:host>a:has(>:not(:last-child):hover) {
+:host>.smoothly-row:has(>:not(:last-child):hover) {
 	background-color: rgb(var(--smoothly-table-hover-background));
 	color: rgb(var(--smoothly-table-hover-foreground));
 }
@@ -51,17 +54,17 @@
 }
 
 :host> :first-child,
-:host>a> :first-child {
+:host>.smoothly-row> :first-child {
 	@include arrow;
 }
 
 :host:has(>:hover)> :first-child,
-:host>a:has(>:hover)> :first-child {
+:host>.smoothly-row:has(>:hover)> :first-child {
 	@include arrow-hover;
 }
 
 :host[open]> :first-child,
-:host[open]>a>:first-child {
+:host[open]>.smoothly-row>:first-child {
 	@include arrow-open;
 }
 


### PR DESCRIPTION
Everything looks and works the same, i've only adapted the styling for children of an expandable row. An expandable row can now have its cell-items wrapped in an a-tag. This is useful if you want to open a row (or whatever data is displayed in it) in a different window. with this you could scroll-click och right-click and follow a link, super handy!

Demo: i've added an a-tag to the expandable row in the "simple"-table in the table-room. 