### PR TITLE
Emit tab name instead of label

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -614,6 +614,7 @@ export namespace Components {
     interface SmoothlyTab {
         "disabled": boolean;
         "label": string;
+        "name": string;
         "open": boolean;
         "tooltip": string;
     }
@@ -2784,6 +2785,7 @@ declare namespace LocalJSX {
     interface SmoothlyTab {
         "disabled"?: boolean;
         "label"?: string;
+        "name"?: string;
         "onSmoothlyTabLoad"?: (event: SmoothlyTabCustomEvent<void>) => void;
         "onSmoothlyTabOpen"?: (event: SmoothlyTabCustomEvent<string>) => void;
         "open"?: boolean;

--- a/src/components/form/demo/pet/index.tsx
+++ b/src/components/form/demo/pet/index.tsx
@@ -156,8 +156,8 @@ export class SmoothlyFormDemoPet {
 							<smoothly-input-checkbox name="summary.hasPet">Has Pet</smoothly-input-checkbox>
 						</div>
 					</smoothly-summary>
-					<smoothly-tabs>
-						<smoothly-tab label="Dog">
+					<smoothly-tabs onSmoothlyTabOpen={e => console.log("Tab opened:", e.detail)}>
+						<smoothly-tab label="Dog" name="dog">
 							<smoothly-input type={"text"} name="dog.breed">
 								Breed
 							</smoothly-input>
@@ -186,7 +186,7 @@ export class SmoothlyFormDemoPet {
 							</smoothly-input-radio>
 							<smoothly-input-checkbox name="dog.hasPet">Has Pet</smoothly-input-checkbox>
 						</smoothly-tab>
-						<smoothly-tab label="Cat" open>
+						<smoothly-tab label="Cat" name="cat" open>
 							<smoothly-input name={"cat.favoriteFood"}>Favorite Food</smoothly-input>
 						</smoothly-tab>
 					</smoothly-tabs>

--- a/src/components/tabs/tab/index.tsx
+++ b/src/components/tabs/tab/index.tsx
@@ -9,6 +9,7 @@ import { Input } from "../../input/Input"
 export class SmoothlyTab {
 	private inputs: Record<string, Input.Element> = {}
 	@Prop() label: string
+	@Prop() name: string
 	@Prop() tooltip: string
 	@Prop({ mutable: true, reflect: true }) open: boolean
 	@Prop({ reflect: true }) disabled: boolean
@@ -18,7 +19,7 @@ export class SmoothlyTab {
 	@Watch("open")
 	async openHandler() {
 		if (this.open)
-			this.smoothlyTabOpen.emit(this.label)
+			this.smoothlyTabOpen.emit(this.name)
 		this.open
 			? await Promise.all(Object.values(this.inputs).map(input => input.register()))
 			: await Promise.all(Object.values(this.inputs).map(input => input.unregister()))


### PR DESCRIPTION
`smoothly-tabs` emits the Prop `name` instead of the `label`, since the `label` is the visual text that might change with depending on language and other factors.