### PR TITLE
Fix tabs within tabs bug

### DIFF
--- a/src/components/tabs/index.tsx
+++ b/src/components/tabs/index.tsx
@@ -1,4 +1,5 @@
-import { Component, Element, Event, EventEmitter, h, Host, Listen, Prop, State, Watch } from "@stencil/core"
+import { Component, Event, EventEmitter, h, Host, Listen, Prop, State, Watch } from "@stencil/core"
+import { isSmoothlyTabElement } from "./isSmoothlyTabElement"
 
 @Component({
 	tag: "smoothly-tabs",
@@ -6,7 +7,6 @@ import { Component, Element, Event, EventEmitter, h, Host, Listen, Prop, State, 
 	scoped: true,
 })
 export class SmoothlyTabs {
-	@Element() element: HTMLSmoothlyTabsElement
 	@Prop({ reflect: true }) tabs: "always" | "multiple" = "always"
 	@State() tabElements: HTMLElement[] = []
 	@State() selectedElement: HTMLSmoothlyTabElement
@@ -14,6 +14,7 @@ export class SmoothlyTabs {
 
 	@Listen("smoothlyTabLoad")
 	onInputLoad(event: CustomEvent) {
+		event.stopPropagation()
 		if (event.target instanceof HTMLElement && !this.tabElements.includes(event.target)) {
 			this.tabElements = [...this.tabElements, event.target]
 		}
@@ -21,9 +22,10 @@ export class SmoothlyTabs {
 
 	@Listen("smoothlyTabOpen")
 	openChanged(event: CustomEvent) {
-		if (event.target != this.element) {
+		const target = event.target
+		if (isSmoothlyTabElement(target)) {
 			event.stopPropagation()
-			this.selectedElement = event.target as HTMLSmoothlyTabElement
+			this.selectedElement = target
 			this.smoothlyTabOpen.emit(event.detail)
 		}
 	}

--- a/src/components/tabs/index.tsx
+++ b/src/components/tabs/index.tsx
@@ -1,5 +1,4 @@
 import { Component, Event, EventEmitter, h, Host, Listen, Prop, State, Watch } from "@stencil/core"
-import { isSmoothlyTabElement } from "./isSmoothlyTabElement"
 
 @Component({
 	tag: "smoothly-tabs",
@@ -20,10 +19,14 @@ export class SmoothlyTabs {
 		}
 	}
 
+	private isSmoothlyTabElement(element: any): element is HTMLSmoothlyTabElement {
+		return element?.tagName == "SMOOTHLY-TAB"
+	}
+
 	@Listen("smoothlyTabOpen")
 	openChanged(event: CustomEvent) {
 		const target = event.target
-		if (isSmoothlyTabElement(target)) {
+		if (this.isSmoothlyTabElement(target)) {
 			event.stopPropagation()
 			this.selectedElement = target
 			this.smoothlyTabOpen.emit(event.detail)

--- a/src/components/tabs/isSmoothlyTabElement.ts
+++ b/src/components/tabs/isSmoothlyTabElement.ts
@@ -1,3 +1,0 @@
-export function isSmoothlyTabElement(element: any): element is HTMLSmoothlyTabElement {
-	return element?.tagName == "SMOOTHLY-TAB"
-}

--- a/src/components/tabs/isSmoothlyTabElement.ts
+++ b/src/components/tabs/isSmoothlyTabElement.ts
@@ -1,0 +1,3 @@
+export function isSmoothlyTabElement(element: any): element is HTMLSmoothlyTabElement {
+	return element?.tagName == "SMOOTHLY-TAB"
+}


### PR DESCRIPTION
Having tabs within tabs causes issues since the `smoothlyTabLoad` and `smoothlyTabOpen` events aren't stopped.