### PR TITLE
Use Preformated white space on JSON-display

### DIFF
--- a/src/components/display/json/primitive/style.css
+++ b/src/components/display/json/primitive/style.css
@@ -1,7 +1,8 @@
 :host {
 	font-family: monospace;
 	display: inline;
-	word-wrap: anywhere;
+	overflow-wrap: anywhere;
+	white-space: pre-wrap;
 }
 :host[hidden] {
 	display: none;


### PR DESCRIPTION
Also `word-wrap` is an legacy alias for `overflow-wrap`, so switched to using that one instead.

Source: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_text/Wrapping_breaking_text#breaking_long_words
![Screenshot from 2025-06-21 11-26-30](https://github.com/user-attachments/assets/83def4c5-6d8c-4625-81d7-3b68bbe26908)


## Use white-space: pre-wrap

"pre" stands for "Preformatted", fyi.

### Before
![Screenshot from 2025-06-21 11-27-15](https://github.com/user-attachments/assets/9855f127-1e3b-4c2a-825a-90ef84f86e57)


### After
![Screenshot from 2025-06-21 11-27-07](https://github.com/user-attachments/assets/4dec7337-6f77-4c30-bbfe-74195d3fc7cf)
