### PR TITLE
Highlight input-border on focus

### DIFF
--- a/src/assets/style/mapping.css
+++ b/src/assets/style/mapping.css
@@ -25,6 +25,7 @@ smoothly-color {
 	--smoothly-input-foreground: var(--smoothly-default-contrast);
 	--smoothly-input-background: var(--smoothly-default-tint);
 	--smoothly-input-border: var(--smoothly-default-shade);
+	--smoothly-input-border-active: var(--smoothly-primary-color);
 	--smoothly-input-disabled-foreground: var(--smoothly-default-contrast);
 	--smoothly-input-disabled-background: var(--smoothly-default-shade);
 	--smoothly-input-disabled-border: var(--smoothly-default-shade);

--- a/src/assets/style/mapping.css
+++ b/src/assets/style/mapping.css
@@ -25,7 +25,7 @@ smoothly-color {
 	--smoothly-input-foreground: var(--smoothly-default-contrast);
 	--smoothly-input-background: var(--smoothly-default-tint);
 	--smoothly-input-border: var(--smoothly-default-shade);
-	--smoothly-input-border-active: var(--smoothly-primary-color);
+	--smoothly-input-border-focus: var(--smoothly-primary-color);
 	--smoothly-input-disabled-foreground: var(--smoothly-default-contrast);
 	--smoothly-input-disabled-background: var(--smoothly-default-shade);
 	--smoothly-input-disabled-border: var(--smoothly-default-shade);

--- a/src/components/input/color/style.css
+++ b/src/components/input/color/style.css
@@ -10,7 +10,7 @@
 :host>smoothly-input {
 	width: 100%;
 	--input-min-height: calc(var(--input-min-height) - 2px);
-	--smoothly-input-border-active: none;
+	--smoothly-input-border-focus: none;
 }
 :host div.color-sample {
 	height: 2em;

--- a/src/components/input/color/style.css
+++ b/src/components/input/color/style.css
@@ -10,6 +10,7 @@
 :host>smoothly-input {
 	width: 100%;
 	--input-min-height: calc(var(--input-min-height) - 2px);
+	--smoothly-input-border-active: none;
 }
 :host div.color-sample {
 	height: 2em;

--- a/src/components/input/date/time/style.css
+++ b/src/components/input/date/time/style.css
@@ -11,6 +11,7 @@
 
 :host>smoothly-input {
 	--input-min-height: calc(var(--input-min-height) - 2px);
+	--smoothly-input-border-active: none;
 }
 
 :host:not([readonly])>smoothly-input>div>input {

--- a/src/components/input/date/time/style.css
+++ b/src/components/input/date/time/style.css
@@ -11,7 +11,7 @@
 
 :host>smoothly-input {
 	--input-min-height: calc(var(--input-min-height) - 2px);
-	--smoothly-input-border-active: none;
+	--smoothly-input-border-focus: none;
 }
 
 :host:not([readonly])>smoothly-input>div>input {

--- a/src/components/input/range/style.css
+++ b/src/components/input/range/style.css
@@ -23,10 +23,7 @@
 :host>div>smoothly-input {
 	width: 12em;
 	--input-min-height: calc(3rem - 2px);
-}
-:host>div>smoothly-input:focus {
-	outline: none;
-	border: none
+	--smoothly-input-border-active: none;
 }
 :host>div>smoothly-input label {
 	white-space: nowrap;

--- a/src/components/input/range/style.css
+++ b/src/components/input/range/style.css
@@ -23,7 +23,7 @@
 :host>div>smoothly-input {
 	width: 12em;
 	--input-min-height: calc(3rem - 2px);
-	--smoothly-input-border-active: none;
+	--smoothly-input-border-focus: none;
 }
 :host>div>smoothly-input label {
 	white-space: nowrap;

--- a/src/components/input/shared.css
+++ b/src/components/input/shared.css
@@ -14,25 +14,22 @@
 :host([looks="border"]:not([readonly]):not([disabled]):focus-within) {
 	outline: 2px solid rgb(var(--smoothly-input-border-focus));
 }
-
 :host[looks="border"][readonly] {
 	border: transparent solid 1px;
 }
 
 :host[looks="line"] {
 	border-bottom: rgb(var(--smoothly-input-border)) solid 1px;
+	position: relative;
 }
-
 :host[looks="line"][readonly] {
 	border-bottom: transparent solid 1px;
-}
-:host([looks="line"]:not([readonly]):not([disabled]):focus-within) {
-	position: relative;
 }
 :host([looks="line"]:not([readonly]):not([disabled]):focus-within)::before {
 	content: "";
 	position: absolute;
 	inset: 0;
+	pointer-events: none;
 	border-bottom: 2px solid rgb(var(--smoothly-input-border-focus));
 	z-index: 10;
 }

--- a/src/components/input/shared.css
+++ b/src/components/input/shared.css
@@ -32,8 +32,7 @@
 :host([looks="line"]:not([readonly]):not([disabled]):focus-within)::before {
 	content: "";
 	position: absolute;
-	inset-inline: 0;
-	bottom: 0;
+	inset: 0;
 	border-bottom: 2px solid rgb(var(--smoothly-input-border-focus));
 	z-index: 10;
 }

--- a/src/components/input/shared.css
+++ b/src/components/input/shared.css
@@ -12,7 +12,7 @@
 	border: rgb(var(--smoothly-input-border)) solid 1px;
 }
 :host([looks="border"]:not([readonly]):not([disabled]):focus-within) {
-	outline: 2px solid rgb(var(--smoothly-input-border-active));
+	outline: 2px solid rgb(var(--smoothly-input-border-focus));
 }
 
 :host[looks="border"][readonly] {
@@ -34,7 +34,7 @@
 	position: absolute;
 	inset-inline: 0;
 	bottom: 0;
-	border-bottom: 2px solid rgb(var(--smoothly-input-border-active));
+	border-bottom: 2px solid rgb(var(--smoothly-input-border-focus));
 	z-index: 10;
 }
 
@@ -49,7 +49,7 @@
 }
 :host[looks="grid"]:not([readonly]):not([disabled]):focus-within {
 	position: relative;
-	box-shadow: 0px 0px 0px 2px rgb(var(--smoothly-input-border-active));
+	box-shadow: 0px 0px 0px 2px rgb(var(--smoothly-input-border-focus));
 	outline: none;
 	z-index: 10;
 }

--- a/src/components/input/shared.css
+++ b/src/components/input/shared.css
@@ -11,6 +11,9 @@
 :host[looks="border"] {
 	border: rgb(var(--smoothly-input-border)) solid 1px;
 }
+:host([looks="border"]:not([readonly]):not([disabled]):focus-within) {
+	outline: 2px solid rgb(var(--smoothly-input-border-active));
+}
 
 :host[looks="border"][readonly] {
 	border: transparent solid 1px;
@@ -23,6 +26,17 @@
 :host[looks="line"][readonly] {
 	border-bottom: transparent solid 1px;
 }
+:host([looks="line"]:not([readonly]):not([disabled]):focus-within) {
+	position: relative;
+}
+:host([looks="line"]:not([readonly]):not([disabled]):focus-within)::before {
+	content: "";
+	position: absolute;
+	inset-inline: 0;
+	bottom: 0;
+	border-bottom: 2px solid rgb(var(--smoothly-input-border-active));
+	z-index: 10;
+}
 
 :host[looks="grid"] {
   flex-grow: 1;
@@ -32,6 +46,12 @@
 }
 :host[looks="grid"][readonly] {
 	box-shadow: 0px 0px 0px 1px rgba(var(--smoothly-input-border-readonly));
+}
+:host[looks="grid"]:not([readonly]):not([disabled]):focus-within {
+	position: relative;
+	box-shadow: 0px 0px 0px 2px rgb(var(--smoothly-input-border-active));
+	outline: none;
+	z-index: 10;
 }
 
 :host[looks="transparent"] {


### PR DESCRIPTION
Highlight border focus on `looks=grid`, `looks=border` and `looks=line`.
Set with css variable
`--smoothly-input-border-focus`

### grid
![image](https://github.com/user-attachments/assets/d6f351c2-c060-41ef-9bd7-51cc67328527)


### border
![image](https://github.com/user-attachments/assets/a1eae9f0-3e94-445c-9be5-e5ff044b6776)

### line
![image](https://github.com/user-attachments/assets/0367df0f-f6cd-482f-8189-872eeb9aaeac)

