### PR TITLE
Add standard button demo

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -88,6 +88,8 @@ export namespace Components {
     }
     interface SmoothlyButtonDemo {
     }
+    interface SmoothlyButtonDemoStandard {
+    }
     interface SmoothlyCalendar {
         "doubleInput": boolean;
         "end"?: isoly.Date;
@@ -987,6 +989,12 @@ declare global {
     var HTMLSmoothlyButtonDemoElement: {
         prototype: HTMLSmoothlyButtonDemoElement;
         new (): HTMLSmoothlyButtonDemoElement;
+    };
+    interface HTMLSmoothlyButtonDemoStandardElement extends Components.SmoothlyButtonDemoStandard, HTMLStencilElement {
+    }
+    var HTMLSmoothlyButtonDemoStandardElement: {
+        prototype: HTMLSmoothlyButtonDemoStandardElement;
+        new (): HTMLSmoothlyButtonDemoStandardElement;
     };
     interface HTMLSmoothlyCalendarElementEventMap {
         "smoothlyValueChange": isoly.Date;
@@ -2118,6 +2126,7 @@ declare global {
         "smoothly-button": HTMLSmoothlyButtonElement;
         "smoothly-button-confirm": HTMLSmoothlyButtonConfirmElement;
         "smoothly-button-demo": HTMLSmoothlyButtonDemoElement;
+        "smoothly-button-demo-standard": HTMLSmoothlyButtonDemoStandardElement;
         "smoothly-calendar": HTMLSmoothlyCalendarElement;
         "smoothly-checkbox": HTMLSmoothlyCheckboxElement;
         "smoothly-color": HTMLSmoothlyColorElement;
@@ -2273,6 +2282,8 @@ declare namespace LocalJSX {
         "size"?: "small" | "large" | "icon" | "flexible";
     }
     interface SmoothlyButtonDemo {
+    }
+    interface SmoothlyButtonDemoStandard {
     }
     interface SmoothlyCalendar {
         "doubleInput"?: boolean;
@@ -2908,6 +2919,7 @@ declare namespace LocalJSX {
         "smoothly-button": SmoothlyButton;
         "smoothly-button-confirm": SmoothlyButtonConfirm;
         "smoothly-button-demo": SmoothlyButtonDemo;
+        "smoothly-button-demo-standard": SmoothlyButtonDemoStandard;
         "smoothly-calendar": SmoothlyCalendar;
         "smoothly-checkbox": SmoothlyCheckbox;
         "smoothly-color": SmoothlyColor;
@@ -3020,6 +3032,7 @@ declare module "@stencil/core" {
             "smoothly-button": LocalJSX.SmoothlyButton & JSXBase.HTMLAttributes<HTMLSmoothlyButtonElement>;
             "smoothly-button-confirm": LocalJSX.SmoothlyButtonConfirm & JSXBase.HTMLAttributes<HTMLSmoothlyButtonConfirmElement>;
             "smoothly-button-demo": LocalJSX.SmoothlyButtonDemo & JSXBase.HTMLAttributes<HTMLSmoothlyButtonDemoElement>;
+            "smoothly-button-demo-standard": LocalJSX.SmoothlyButtonDemoStandard & JSXBase.HTMLAttributes<HTMLSmoothlyButtonDemoStandardElement>;
             "smoothly-calendar": LocalJSX.SmoothlyCalendar & JSXBase.HTMLAttributes<HTMLSmoothlyCalendarElement>;
             "smoothly-checkbox": LocalJSX.SmoothlyCheckbox & JSXBase.HTMLAttributes<HTMLSmoothlyCheckboxElement>;
             "smoothly-color": LocalJSX.SmoothlyColor & JSXBase.HTMLAttributes<HTMLSmoothlyColorElement>;

--- a/src/components/button/demo/index.tsx
+++ b/src/components/button/demo/index.tsx
@@ -7,7 +7,6 @@ export class SmoothlyButtonDemo {
 	render() {
 		return (
 			<Host>
-				<h2>Buttons</h2>
 				<section>
 					<smoothly-button-demo-standard />
 				</section>

--- a/src/components/button/demo/index.tsx
+++ b/src/components/button/demo/index.tsx
@@ -1,151 +1,156 @@
-import { Component, h } from "@stencil/core"
+import { Component, h, Host } from "@stencil/core"
 @Component({
 	tag: "smoothly-button-demo",
 	styleUrl: "style.css",
 })
 export class SmoothlyButtonDemo {
 	render() {
-		return [
-			<h2>Buttons</h2>,
-			<section>
-				<h4>Confirm button (two clicks)</h4>
-				<div>
-					<smoothly-button-confirm name="confirm" shape="rounded" color="danger" size="large">
-						Delete
-					</smoothly-button-confirm>
-					<smoothly-button-confirm name="confirm-icon" shape="rounded" color="success" size="icon">
-						<smoothly-icon name="checkmark-outline" size="tiny" />
-					</smoothly-button-confirm>
-					<smoothly-button-confirm name="confirm-icon" shape="rounded" color="danger" size="icon" fill="outline">
-						<smoothly-icon name="trash-outline" size="tiny" fill="outline" />
-					</smoothly-button-confirm>
-				</div>
-				<smoothly-toggle-switch-demo />
-				<h4>Links with icons</h4>
-				<smoothly-button type="link">
-					<smoothly-icon name="checkmark-circle" slot="start" />
-					type link
-				</smoothly-button>
-				<smoothly-button type="button" color="warning" fill="default">
-					<smoothly-icon name="call" slot="start" />
-					<a href="https://google.com">link</a>
-				</smoothly-button>
-				<smoothly-button link="https://google.com" type="link">
-					<smoothly-icon name="arrow-forward" slot="end" />
-					link + type link
-				</smoothly-button>
-				<h4>Size and Color test</h4>
-				<smoothly-button color="primary" fill="solid" size="small" shape="rounded">
-					Color Primary + Small
-				</smoothly-button>
-				<smoothly-button color="secondary" fill="solid" shape="rounded">
-					Color Secondary + Default
-				</smoothly-button>
-				<smoothly-button color="warning" fill="solid" size="large">
-					Color Warning + Large
-				</smoothly-button>
-				<smoothly-button color="danger" fill="solid" size="small" shape="rounded">
-					Color Danger + Small
-				</smoothly-button>
-				<smoothly-button color="success" fill="solid" size="small" shape="rounded">
-					Color Success + Small
-				</smoothly-button>
-				<smoothly-button color="tertiary" fill="solid" size="small" shape="rounded">
-					Color Tertiary + Small
-				</smoothly-button>
-				<smoothly-button color="dark" fill="solid" size="small" shape="rounded">
-					Color Dark + Small
-				</smoothly-button>
-				<smoothly-button color="medium" fill="solid" size="small" shape="rounded">
-					Color Medium + Small
-				</smoothly-button>
-				<smoothly-button color="light" fill="solid" size="small" shape="rounded">
-					Color Light + Small
-				</smoothly-button>
-				<h4>Expand examples</h4>
-				<smoothly-button color="secondary" fill="solid" expand="full">
-					Color Secondary + Default
-				</smoothly-button>
-				<smoothly-button color="warning" fill="solid" expand="block">
-					Color Warning + Large
-				</smoothly-button>
-				<h4>Fill examples</h4>
-				<div>
-					<smoothly-button shape="rounded" color="primary" fill="solid">
+		return (
+			<Host>
+				<h2>Buttons</h2>
+				<section>
+					<smoothly-button-demo-standard />
+				</section>
+				<section>
+					<h4>Confirm button (two clicks)</h4>
+					<div>
+						<smoothly-button-confirm name="confirm" shape="rounded" color="danger" size="large">
+							Delete
+						</smoothly-button-confirm>
+						<smoothly-button-confirm name="confirm-icon" shape="rounded" color="success" size="icon">
+							<smoothly-icon name="checkmark-outline" size="tiny" />
+						</smoothly-button-confirm>
+						<smoothly-button-confirm name="confirm-icon" shape="rounded" color="danger" size="icon" fill="outline">
+							<smoothly-icon name="trash-outline" size="tiny" fill="outline" />
+						</smoothly-button-confirm>
+					</div>
+					<smoothly-toggle-switch-demo />
+					<h4>Links with icons</h4>
+					<smoothly-button type="link">
 						<smoothly-icon name="checkmark-circle" slot="start" />
-						Fill Solid
+						type link
 					</smoothly-button>
-					<smoothly-button shape="rounded" color="secondary" fill="outline">
-						<smoothly-icon name="checkmark-circle" slot="start" />
-						Fill Outline
-					</smoothly-button>
-					<smoothly-button shape="rounded" color="tertiary" fill="clear">
-						<smoothly-icon name="checkmark-circle" slot="start" />
-						Fill Clear
-					</smoothly-button>
-					<smoothly-button size="icon" shape="rounded" color="success" fill="solid">
-						<smoothly-icon name="basketball" />
-					</smoothly-button>
-				</div>
-				<h4>Buttons with Icon in "start"</h4>
-				<div>
-					<smoothly-button shape="rounded" fill="solid" color="warning">
-						<smoothly-icon name="checkmark-circle" slot="start" />
-						Check
-					</smoothly-button>
-					<smoothly-button shape="rounded" fill="solid" color="secondary">
-						<smoothly-icon name="basketball" slot="start" />
-						Check
-					</smoothly-button>
-					<smoothly-button shape="rounded" fill="solid" color="success">
+					<smoothly-button type="button" color="warning" fill="default">
 						<smoothly-icon name="call" slot="start" />
-						Check
-					</smoothly-button>
-					<smoothly-button size="icon" fill="solid" shape="rounded" color="success">
-						<smoothly-icon name="call" />
-					</smoothly-button>
-					<smoothly-button size="flexible" fill="solid" color="success">
-						<smoothly-icon name="airplane" />
-					</smoothly-button>
-				</div>
-				<h4>Buttons with Icon in "end"</h4>
-				<smoothly-button fill="solid" color="light">
-					Go Forward
-					<smoothly-icon name="arrow-forward" slot="end" />
-				</smoothly-button>
-				<h4>Test for icon button</h4>
-				<div>
-					<smoothly-button size="icon" fill="solid" shape="rounded" color="success">
-						<smoothly-icon name="call" />
-					</smoothly-button>
-					<smoothly-button size="icon" shape="rounded" color="warning" fill="solid">
-						<smoothly-icon name="search-outline" />
-					</smoothly-button>
-					<smoothly-button size="icon" shape="rounded" color="secondary">
-						<smoothly-icon name="checkmark-circle" />
-					</smoothly-button>
-				</div>
-				<h4>Link examples</h4>
-				<div>
-					<smoothly-button type="link">type link</smoothly-button>
-					<smoothly-button type="button" fill="clear">
 						<a href="https://google.com">link</a>
 					</smoothly-button>
 					<smoothly-button link="https://google.com" type="link">
+						<smoothly-icon name="arrow-forward" slot="end" />
 						link + type link
 					</smoothly-button>
-				</div>
-				<h4>Disabled buttons</h4>
-				<div>
-					<smoothly-button disabled fill="solid" color="secondary">
-						Disabled
+					<h4>Size and Color test</h4>
+					<smoothly-button color="primary" fill="solid" size="small" shape="rounded">
+						Color Primary + Small
 					</smoothly-button>
-					<smoothly-button type="link" link="https://google.com" disabled>
-						Disabled link
+					<smoothly-button color="secondary" fill="solid" shape="rounded">
+						Color Secondary + Default
 					</smoothly-button>
-				</div>
-			</section>,
-			<smoothly-back-to-top />,
-		]
+					<smoothly-button color="warning" fill="solid" size="large">
+						Color Warning + Large
+					</smoothly-button>
+					<smoothly-button color="danger" fill="solid" size="small" shape="rounded">
+						Color Danger + Small
+					</smoothly-button>
+					<smoothly-button color="success" fill="solid" size="small" shape="rounded">
+						Color Success + Small
+					</smoothly-button>
+					<smoothly-button color="tertiary" fill="solid" size="small" shape="rounded">
+						Color Tertiary + Small
+					</smoothly-button>
+					<smoothly-button color="dark" fill="solid" size="small" shape="rounded">
+						Color Dark + Small
+					</smoothly-button>
+					<smoothly-button color="medium" fill="solid" size="small" shape="rounded">
+						Color Medium + Small
+					</smoothly-button>
+					<smoothly-button color="light" fill="solid" size="small" shape="rounded">
+						Color Light + Small
+					</smoothly-button>
+					<h4>Expand examples</h4>
+					<smoothly-button color="secondary" fill="solid" expand="full">
+						Color Secondary + Default
+					</smoothly-button>
+					<smoothly-button color="warning" fill="solid" expand="block">
+						Color Warning + Large
+					</smoothly-button>
+					<h4>Fill examples</h4>
+					<div>
+						<smoothly-button shape="rounded" color="primary" fill="solid">
+							<smoothly-icon name="checkmark-circle" slot="start" />
+							Fill Solid
+						</smoothly-button>
+						<smoothly-button shape="rounded" color="secondary" fill="outline">
+							<smoothly-icon name="checkmark-circle" slot="start" />
+							Fill Outline
+						</smoothly-button>
+						<smoothly-button shape="rounded" color="tertiary" fill="clear">
+							<smoothly-icon name="checkmark-circle" slot="start" />
+							Fill Clear
+						</smoothly-button>
+						<smoothly-button size="icon" shape="rounded" color="success" fill="solid">
+							<smoothly-icon name="basketball" />
+						</smoothly-button>
+					</div>
+					<h4>Buttons with Icon in "start"</h4>
+					<div>
+						<smoothly-button shape="rounded" fill="solid" color="warning">
+							<smoothly-icon name="checkmark-circle" slot="start" />
+							Check
+						</smoothly-button>
+						<smoothly-button shape="rounded" fill="solid" color="secondary">
+							<smoothly-icon name="basketball" slot="start" />
+							Check
+						</smoothly-button>
+						<smoothly-button shape="rounded" fill="solid" color="success">
+							<smoothly-icon name="call" slot="start" />
+							Check
+						</smoothly-button>
+						<smoothly-button size="icon" fill="solid" shape="rounded" color="success">
+							<smoothly-icon name="call" />
+						</smoothly-button>
+						<smoothly-button size="flexible" fill="solid" color="success">
+							<smoothly-icon name="airplane" />
+						</smoothly-button>
+					</div>
+					<h4>Buttons with Icon in "end"</h4>
+					<smoothly-button fill="solid" color="light">
+						Go Forward
+						<smoothly-icon name="arrow-forward" slot="end" />
+					</smoothly-button>
+					<h4>Test for icon button</h4>
+					<div>
+						<smoothly-button size="icon" fill="solid" shape="rounded" color="success">
+							<smoothly-icon name="call" />
+						</smoothly-button>
+						<smoothly-button size="icon" shape="rounded" color="warning" fill="solid">
+							<smoothly-icon name="search-outline" />
+						</smoothly-button>
+						<smoothly-button size="icon" shape="rounded" color="secondary">
+							<smoothly-icon name="checkmark-circle" />
+						</smoothly-button>
+					</div>
+					<h4>Link examples</h4>
+					<div>
+						<smoothly-button type="link">type link</smoothly-button>
+						<smoothly-button type="button" fill="clear">
+							<a href="https://google.com">link</a>
+						</smoothly-button>
+						<smoothly-button link="https://google.com" type="link">
+							link + type link
+						</smoothly-button>
+					</div>
+					<h4>Disabled buttons</h4>
+					<div>
+						<smoothly-button disabled fill="solid" color="secondary">
+							Disabled
+						</smoothly-button>
+						<smoothly-button type="link" link="https://google.com" disabled>
+							Disabled link
+						</smoothly-button>
+					</div>
+				</section>
+				<smoothly-back-to-top />
+			</Host>
+		)
 	}
 }

--- a/src/components/button/demo/standard/index.tsx
+++ b/src/components/button/demo/standard/index.tsx
@@ -1,0 +1,112 @@
+import { Component, h, Host, State, Watch } from "@stencil/core"
+import { Color, Fill, Icon } from "../../../../model"
+import { Button } from "../../Button"
+
+type Options = {
+	fill?: Fill
+	disabled?: boolean
+	expand?: "block" | "full"
+	type?: Button.Properties["type"]
+	size?: "small" | "large" | "icon" | "flexible"
+	rounded?: boolean
+	icon?: Icon
+	text?: { value: string; useColor?: boolean }
+}
+
+@Component({
+	tag: "smoothly-button-demo-standard",
+	styleUrl: "style.css",
+	scoped: true,
+})
+export class SmoothlyButtonDemoStandard {
+	@State() props: Options = {}
+	@State() heightText: string = ""
+	@State() lastButton?: HTMLElement
+
+	@Watch("props")
+	updateInputHeightText() {
+		setTimeout(() => {
+			const rootFontSize = Number(getComputedStyle(document.documentElement).fontSize.replace("px", ""))
+			if (this.lastButton) {
+				const heightPx = this.lastButton.clientHeight
+				this.heightText = `${heightPx / rootFontSize}rem (${heightPx}px)`
+			}
+		}, 100)
+	}
+
+	render() {
+		return (
+			<Host>
+				<smoothly-form onSmoothlyFormInput={e => (this.props = e.detail)} looks="grid">
+					<smoothly-input-checkbox name="text.useColor" checked>
+						Use Color as Text
+					</smoothly-input-checkbox>
+					<smoothly-input-select name="size">
+						<span slot="label">Size</span>
+						{["small", "large", "icon", "flexible"].map(size => (
+							<smoothly-item value={size} key={size}>
+								{size}
+							</smoothly-item>
+						))}
+					</smoothly-input-select>
+					<smoothly-input name="text.value" value="Button">
+						Text
+						<smoothly-input-clear slot="end" />
+					</smoothly-input>
+					<smoothly-input-radio name="expand" clearable>
+						<span slot="label">Expand</span>
+						<smoothly-input-radio-item value="block">block</smoothly-input-radio-item>
+						<smoothly-input-radio-item value="full">full</smoothly-input-radio-item>
+						<smoothly-input-clear slot="end" />
+					</smoothly-input-radio>
+					<smoothly-input-select name="fill">
+						<span slot="label">Fill</span>
+						{Fill.values.map(fill => (
+							<smoothly-item value={fill} key={fill}>
+								{fill}
+							</smoothly-item>
+						))}
+					</smoothly-input-select>
+					<smoothly-input-checkbox name="disabled">Disabled</smoothly-input-checkbox>
+					<smoothly-input-select name="type">
+						<span slot="label">Type</span>
+						{["button", "submit", "reset", "link"].map(type => (
+							<smoothly-item value={type} key={type}>
+								{type}
+							</smoothly-item>
+						))}
+					</smoothly-input-select>
+					<smoothly-input-checkbox name="rounded">Rounded</smoothly-input-checkbox>
+					<smoothly-input-select name="icon" menuHeight="8items">
+						<span slot="label">Icon</span>
+						{Icon.Name.values.map(icon => (
+							<smoothly-item value={icon} key={icon}>
+								<smoothly-icon name={icon} size="small" toolTip={icon} />
+							</smoothly-item>
+						))}
+						<smoothly-input-clear slot="end" />
+					</smoothly-input-select>
+				</smoothly-form>
+				<h3>Standard Buttons</h3>
+				<div class="buttons">
+					{Color.values.map((color, index, colors) => (
+						<smoothly-button
+							ref={el => colors.length - 1 == index && (this.lastButton = el)}
+							color={color}
+							expand={this.props.expand}
+							fill={this.props.fill}
+							disabled={this.props.disabled}
+							shape={this.props.rounded ? "rounded" : undefined}
+							size={this.props.size}
+							type={this.props.type}
+							key={color}>
+							{this.props.icon ? <smoothly-icon name={this.props.icon} /> : undefined}
+							{this.props.text?.useColor ? color : this.props.text?.value}
+						</smoothly-button>
+					))}
+					<div class="height-text">{this.heightText}</div>
+				</div>
+			</Host>
+		)
+	}
+}

--- a/src/components/button/demo/standard/index.tsx
+++ b/src/components/button/demo/standard/index.tsx
@@ -37,6 +37,7 @@ export class SmoothlyButtonDemoStandard {
 	render() {
 		return (
 			<Host>
+				<h2>Button Standard</h2>
 				<smoothly-form onSmoothlyFormInput={e => (this.props = e.detail)} looks="grid">
 					<smoothly-input-checkbox name="text.useColor" checked>
 						Use Color as Text
@@ -87,7 +88,6 @@ export class SmoothlyButtonDemoStandard {
 						<smoothly-input-clear slot="end" />
 					</smoothly-input-select>
 				</smoothly-form>
-				<h3>Standard Buttons</h3>
 				<div class="buttons">
 					{Color.values.map((color, index, colors) => (
 						<smoothly-button

--- a/src/components/button/demo/standard/style.css
+++ b/src/components/button/demo/standard/style.css
@@ -1,0 +1,18 @@
+:host smoothly-input-select smoothly-item {
+	display: flex;
+}
+
+:host .buttons {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.5rem;
+}
+:host .buttons > smoothly-button {
+	margin-block: 0;
+}
+
+:host .height-text {
+	border-left: 3px dotted rgb(var(--smoothly-default-contrast));
+	padding-inline: 1rem;
+	align-content: center;
+}


### PR DESCRIPTION
Add similar to input standard demo.

This is very useful to sort, what heights buttons should be at different sizes. 
Now the heights are all over the place depending on if the content is icon or text and whatnot.

![image](https://github.com/user-attachments/assets/77682a51-30f9-4c0a-bd8a-537f0080504e)