### PR TITLE
Improve smoothly-input-checkbox behavior

### DIFF
--- a/src/components/input/checkbox/index.tsx
+++ b/src/components/input/checkbox/index.tsx
@@ -15,7 +15,7 @@ export class SmoothlyInputCheckbox implements Input, Clearable, Editable, Compon
 	parent: Editable | undefined
 	private initialValue?: any
 	private observer = Editable.Observer.create(this)
-	private mouseDownPosition?: { x: number; y: number }
+	private id: string
 	@Prop({ reflect: true }) name: string
 	@Prop({ mutable: true }) changed = false
 	@Prop({ reflect: true, mutable: true }) readonly = false
@@ -36,6 +36,7 @@ export class SmoothlyInputCheckbox implements Input, Clearable, Editable, Compon
 		)
 		this.smoothlyInputLoad.emit(parent => (this.parent = parent))
 		this.observer.publish()
+		this.id = "id-" + Math.random().toString(36).substr(2, 9)
 	}
 	async disconnectedCallback() {
 		if (!this.element.isConnected)
@@ -88,19 +89,18 @@ export class SmoothlyInputCheckbox implements Input, Clearable, Editable, Compon
 			this.observer.publish()
 		}
 	}
-	click() {
-		!this.disabled && !this.readonly && (this.checked = !this.checked)
-	}
 	render() {
 		return (
-			<Host
-				onMouseDown={(e: MouseEvent) => (this.mouseDownPosition = { x: e.clientX, y: e.clientY })}
-				onMouseUp={(e: MouseEvent) =>
-					this.mouseDownPosition?.x == e.clientX && this.mouseDownPosition.y == e.clientY && this.click()
-				}>
-				<input type="checkbox" checked={this.checked} disabled={this.disabled} />
+			<Host>
+				<input
+					type="checkbox"
+					id={this.id}
+					checked={this.checked}
+					disabled={this.disabled || this.readonly}
+					onChange={e => (this.checked = (e.target as HTMLInputElement).checked)}
+				/>
 				{this.checked && <smoothly-icon name="checkmark-outline" size="tiny" />}
-				<label>
+				<label htmlFor={this.id}>
 					<slot />
 				</label>
 			</Host>

--- a/src/components/input/checkbox/style.css
+++ b/src/components/input/checkbox/style.css
@@ -16,6 +16,7 @@
 :host>smoothly-icon {
 	position: absolute;
 	z-index: 1;
+	pointer-events: none;
 }
 
 :host>input {

--- a/src/components/input/checkbox/style.css
+++ b/src/components/input/checkbox/style.css
@@ -30,8 +30,8 @@
 	display: block;
 }
 
-:host:not([readonly]):not([disabled]),
-:host:not([readonly]):not([disabled])>* {
+:host:not([readonly]):not([disabled])>input,
+:host:not([readonly]):not([disabled])>label {
 	cursor: pointer;
 }
 


### PR DESCRIPTION
Improvements:
- Pressing space while checkbox focused will toggle the checkbox now. 
- If you move by a pixel while clicking - it will still check (this was so annoying before, thought I was being cleaver). 
- The label actually uses the for element so the click target is just the label and not the whole input-checkbox component.