### PR TITLE
Only expand row/cell/group if no selection

### DIFF
--- a/src/components/table/expandable/cell/index.tsx
+++ b/src/components/table/expandable/cell/index.tsx
@@ -18,7 +18,12 @@ export class SmoothlyTableExpandableCell {
 		this.open = false
 	}
 	clickHandler(event: MouseEvent): void {
-		this.detailElement && !event.composedPath().includes(this.detailElement) && (this.open = !this.open)
+		const clickedOnDetail = this.detailElement && event.composedPath().includes(this.detailElement)
+		if (!clickedOnDetail) {
+			const selection = window.getSelection()?.toString().trim()
+			if ((selection?.length ?? 0) == 0)
+				this.open = !this.open
+		}
 	}
 	@Watch("open")
 	openChange() {

--- a/src/components/table/expandable/row/index.tsx
+++ b/src/components/table/expandable/row/index.tsx
@@ -11,7 +11,12 @@ export class SmoothlyTableExpandableRow {
 	@Event() smoothlyTableExpandableRowChange: EventEmitter<boolean>
 
 	clickHandler(event: MouseEvent): void {
-		;(this.div && event.composedPath().includes(this.div)) || (this.open = !this.open)
+		const clickedOnDetail = this.div && event.composedPath().includes(this.div)
+		if (!clickedOnDetail) {
+			const selection = window.getSelection()?.toString().trim()
+			if ((selection?.length ?? 0) == 0)
+				this.open = !this.open
+		}
 	}
 	@Watch("open")
 	openChange() {

--- a/src/components/table/group/index.tsx
+++ b/src/components/table/group/index.tsx
@@ -11,8 +11,11 @@ export class SmoothlyTableRowGroup {
 	@Event() smoothlyTableRowGroupChange: EventEmitter<boolean>
 
 	clickHandler(): void {
-		this.open = !this.open
-		this.smoothlyTableRowGroupChange.emit(this.open)
+		const selection = window.getSelection()?.toString().trim()
+		if ((selection?.length ?? 0) == 0) {
+			this.open = !this.open
+			this.smoothlyTableRowGroupChange.emit(this.open)
+		}
 	}
 
 	render(): VNode | VNode[] {


### PR DESCRIPTION
When highlighting text in an expandable-row (or cell or group) the expandable bit would open. This PR fixes that so you can highlight stuff in the row.

## Preview

https://github.com/user-attachments/assets/95f86c03-1023-4d9c-8901-369f8d633ff1


https://github.com/user-attachments/assets/97710497-47b5-4abb-a10c-6b70c9d04e2c


