### PR TITLE
Fix tabs breaking when switching rooms

### DIFF
--- a/src/components/tabs/index.tsx
+++ b/src/components/tabs/index.tsx
@@ -1,4 +1,4 @@
-import { Component, Event, EventEmitter, h, Host, Listen, Method, Prop, State, Watch } from "@stencil/core"
+import { Component, Element, Event, EventEmitter, h, Host, Listen, Method, Prop, State, Watch } from "@stencil/core"
 
 @Component({
 	tag: "smoothly-tabs",
@@ -6,6 +6,7 @@ import { Component, Event, EventEmitter, h, Host, Listen, Method, Prop, State, W
 	scoped: true,
 })
 export class SmoothlyTabs {
+	@Element() element: HTMLSmoothlyTabsElement
 	@Prop({ reflect: true }) tabs: "always" | "multiple" = "always"
 	@State() tabElements: HTMLSmoothlyTabElement[] = []
 	@State() selectedElement: HTMLSmoothlyTabElement
@@ -13,10 +14,12 @@ export class SmoothlyTabs {
 
 	@Method()
 	async removeTab(tab: HTMLSmoothlyTabElement) {
-		this.tabElements = this.tabElements.filter(element => element !== tab)
-		if (tab.open) {
-			const firstOpenableTab = this.tabElements.find(element => !element.disabled)
-			firstOpenableTab && (firstOpenableTab.open = true)
+		if (this.element.isConnected) {
+			this.tabElements = this.tabElements.filter(element => element !== tab)
+			if (tab.open) {
+				const firstOpenableTab = this.tabElements.find(element => !element.disabled)
+				firstOpenableTab && (firstOpenableTab.open = true)
+			}
 		}
 	}
 


### PR DESCRIPTION



## Bug
When a tab gets disconnected from the DOM, it will remove it self, as it should but when you switch to a different room the whole smoothly-tabs component get's disconnected causing this weird bug.

The solution is to only remove a tab while smoothly-tabs is connected to the DOM.


https://github.com/user-attachments/assets/1726cd3c-ce90-4b30-b2ff-1401f7aa9a20

