### PR TITLE
Refactor smoothly-icon

### DIFF
--- a/src/components/icon/index.tsx
+++ b/src/components/icon/index.tsx
@@ -66,17 +66,11 @@ export class SmoothlyIcon {
 		return svgElement ?? undefined
 	}
 	updateDocument(svg?: SVGElement) {
-		if (svg) {
-			this.element.replaceChildren(svg)
-		} else {
-			const emptySvg = document.createElementNS("http://www.w3.org/2000/svg", "svg")
-			emptySvg.setAttribute("viewBox", "0 0 512 512")
-			const titleElement = document.createElementNS("http://www.w3.org/2000/svg", "title")
-			titleElement.textContent = "Empty"
-			emptySvg.appendChild(titleElement)
-			this.element.replaceChildren(emptySvg)
-			return
-		}
+		svg
+			? this.element.replaceChildren(svg)
+			: (this.element.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+					<title>Empty</title>
+				</svg>`)
 	}
 
 	render() {

--- a/src/components/icon/index.tsx
+++ b/src/components/icon/index.tsx
@@ -25,7 +25,7 @@ export class SmoothlyIcon {
 	@Watch("name")
 	async nameChanged() {
 		if (this.name == "empty") {
-			this.updateDocument()
+			this.updateSvg()
 			return
 		}
 
@@ -36,7 +36,7 @@ export class SmoothlyIcon {
 
 		if (result) {
 			const svgElement = this.cleanSvg(result)
-			this.updateDocument(svgElement)
+			this.updateSvg(svgElement)
 		}
 	}
 
@@ -65,7 +65,7 @@ export class SmoothlyIcon {
 		}
 		return svgElement ?? undefined
 	}
-	updateDocument(svg?: SVGElement) {
+	updateSvg(svg?: SVGElement) {
 		svg
 			? this.element.replaceChildren(svg)
 			: (this.element.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">

--- a/src/components/icon/index.tsx
+++ b/src/components/icon/index.tsx
@@ -41,17 +41,34 @@ export class SmoothlyIcon {
 	}
 
 	private cleanSvg(svg: string): string {
-		svg = svg
-			?.replace(/(?<=^<svg\s?)/, `$& role="img"`)
-			.replace(` width="512" height="512"`, "")
-			.replace(/stroke:#000;/gi, "")
-		if (!this.toolTip)
-			svg = svg?.replace(/<title>.*<\/title>/, "")
-		else if (svg?.includes("<title>"))
-			svg = svg.replace(/(<title>).*(<\/title>)/, `<title>${this.toolTip}</title>`)
-		else
-			svg = svg?.replace(/(.*>)(<\/svg>$)/, `$1<title>${this.toolTip}</title>$2`)
-		return svg
+		console.log("Cleaning SVG", this.name, svg)
+		const parser = new DOMParser()
+		const document = parser.parseFromString(svg, "image/svg+xml")
+		const svgElement = document.querySelector("svg")
+
+		if (svgElement) {
+			svgElement.setAttribute("role", "img")
+			svgElement.removeAttribute("width")
+			svgElement.removeAttribute("height")
+			svgElement.querySelectorAll("[stroke]").forEach(el => {
+				if (el.getAttribute("stroke")?.toLowerCase() === "#000")
+					el.removeAttribute("stroke")
+			})
+
+			const titleElement = svgElement.querySelector("title")
+			if (!this.toolTip) {
+				titleElement?.remove()
+			} else {
+				if (titleElement) {
+					titleElement.textContent = this.toolTip
+				} else {
+					const newTitleElement = document.createElement("title")
+					newTitleElement.textContent = this.toolTip
+					svgElement.appendChild(newTitleElement)
+				}
+			}
+		}
+		return svgElement?.outerHTML ?? ""
 	}
 	updateDocument(svg?: string) {
 		this.document =

--- a/src/components/icon/index.tsx
+++ b/src/components/icon/index.tsx
@@ -26,18 +26,20 @@ export class SmoothlyIcon {
 	async nameChanged() {
 		if (this.name == "empty") {
 			this.updateDocument()
-		} else {
-			const promise = (this.latestPromise = Icon.load(this.name))
-			let result = await promise
+			return
+		}
 
-			if (promise == this.latestPromise) {
-				if (result) {
-					result = this.cleanSvg(result)
-					this.updateDocument(result)
-				}
-			}
+		const promise = (this.latestPromise = Icon.load(this.name))
+		let result = await promise
+		if (promise != this.latestPromise)
+			return
+
+		if (result) {
+			result = this.cleanSvg(result)
+			this.updateDocument(result)
 		}
 	}
+
 	private cleanSvg(svg: string): string {
 		svg = svg
 			?.replace(/(?<=^<svg\s?)/, `$& role="img"`)

--- a/src/components/icon/index.tsx
+++ b/src/components/icon/index.tsx
@@ -24,28 +24,36 @@ export class SmoothlyIcon {
 	@Watch("toolTip")
 	@Watch("name")
 	async nameChanged() {
-		if (this.name != "empty") {
+		if (this.name == "empty") {
+			this.updateDocument()
+		} else {
 			const promise = (this.latestPromise = Icon.load(this.name))
 			let result = await promise
+
 			if (promise == this.latestPromise) {
-				result = result
-					?.replace(/(?<=^<svg\s?)/, `$& role="img"`)
-					.replace(` width="512" height="512"`, "")
-					.replace(/stroke:#000;/gi, "")
-				if (!this.toolTip)
-					result = result?.replace(/<title>.*<\/title>/, "")
-				else if (result?.includes("<title>"))
-					result = result.replace(/(<title>).*(<\/title>)/, `<title>${this.toolTip}</title>`)
-				else
-					result = result?.replace(/(.*>)(<\/svg>$)/, `$1<title>${this.toolTip}</title>$2`)
-				this.updateDocument(result)
+				if (result) {
+					result = this.cleanSvg(result)
+					this.updateDocument(result)
+				}
 			}
-		} else
-			this.updateDocument()
+		}
 	}
-	updateDocument(document?: string) {
+	private cleanSvg(svg: string): string {
+		svg = svg
+			?.replace(/(?<=^<svg\s?)/, `$& role="img"`)
+			.replace(` width="512" height="512"`, "")
+			.replace(/stroke:#000;/gi, "")
+		if (!this.toolTip)
+			svg = svg?.replace(/<title>.*<\/title>/, "")
+		else if (svg?.includes("<title>"))
+			svg = svg.replace(/(<title>).*(<\/title>)/, `<title>${this.toolTip}</title>`)
+		else
+			svg = svg?.replace(/(.*>)(<\/svg>$)/, `$1<title>${this.toolTip}</title>$2`)
+		return svg
+	}
+	updateDocument(svg?: string) {
 		this.document =
-			document ??
+			svg ??
 			`<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
 		<title>Empty</title>
 		</svg>`

--- a/src/components/icon/index.tsx
+++ b/src/components/icon/index.tsx
@@ -35,12 +35,12 @@ export class SmoothlyIcon {
 			return
 
 		if (result) {
-			const svgElement = this.cleanSvg(result)
+			const svgElement = this.sanitizeSvg(result)
 			this.updateSvg(svgElement)
 		}
 	}
 
-	private cleanSvg(svg: string): SVGElement | undefined {
+	private sanitizeSvg(svg: string): SVGElement | undefined {
 		const parser = new DOMParser()
 		const document = parser.parseFromString(svg, "image/svg+xml")
 		const svgElement = document.querySelector("svg")

--- a/src/components/icon/index.tsx
+++ b/src/components/icon/index.tsx
@@ -41,7 +41,6 @@ export class SmoothlyIcon {
 	}
 
 	private cleanSvg(svg: string): string {
-		console.log("Cleaning SVG", this.name, svg)
 		const parser = new DOMParser()
 		const document = parser.parseFromString(svg, "image/svg+xml")
 		const svgElement = document.querySelector("svg")
@@ -50,10 +49,6 @@ export class SmoothlyIcon {
 			svgElement.setAttribute("role", "img")
 			svgElement.removeAttribute("width")
 			svgElement.removeAttribute("height")
-			svgElement.querySelectorAll("[stroke]").forEach(el => {
-				if (el.getAttribute("stroke")?.toLowerCase() === "#000")
-					el.removeAttribute("stroke")
-			})
 
 			const titleElement = svgElement.querySelector("title")
 			if (!this.toolTip) {


### PR DESCRIPTION
- Use early return to make code more readable.
- Split up `sanitizeSvg` to own function
- Use DOMParser instead of being cleaver with regex
- Removed replacing `stroke:#000` since I can't find any icon using that.
- Set element with `replaceChildren(svgElement)` instead of `innerHTML = svgString`
