### PR TITLE
Fix inconsistent prop naming of tooltip (toolTip->tooltip)

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -178,7 +178,7 @@ export namespace Components {
         "icon": Icon;
         "not": boolean;
         "properties": Record<string, string>;
-        "toolTip": string;
+        "tooltip": string;
     }
     interface SmoothlyForm {
         "action"?: string;
@@ -237,7 +237,7 @@ export namespace Components {
         "name": Icon | "empty";
         "rotate"?: number;
         "size"?: "tiny" | "small" | "medium" | "large" | "xlarge";
-        "toolTip"?: string;
+        "tooltip"?: string;
     }
     interface SmoothlyIconDemo {
     }
@@ -407,7 +407,7 @@ export namespace Components {
         "fill"?: Fill;
         "shape"?: "rounded";
         "size": "flexible" | "small" | "large" | "icon";
-        "toolTip": string;
+        "tooltip": string;
         "type": "form" | "input";
     }
     interface SmoothlyInputFile {
@@ -558,7 +558,7 @@ export namespace Components {
         "icon": Icon | false;
         "shape"?: "rounded";
         "size": "flexible" | "small" | "large" | "icon";
-        "toolTip": string;
+        "tooltip": string;
     }
     interface SmoothlyItem {
         "deselectable": boolean;
@@ -2386,7 +2386,7 @@ declare namespace LocalJSX {
         "onSmoothlyFilterManipulate"?: (event: SmoothlyFilterToggleCustomEvent<Filter.Manipulate>) => void;
         "onSmoothlyFilterUpdate"?: (event: SmoothlyFilterToggleCustomEvent<Filter.Update>) => void;
         "properties"?: Record<string, string>;
-        "toolTip"?: string;
+        "tooltip"?: string;
     }
     interface SmoothlyForm {
         "action"?: string;
@@ -2448,7 +2448,7 @@ declare namespace LocalJSX {
         "name"?: Icon | "empty";
         "rotate"?: number;
         "size"?: "tiny" | "small" | "medium" | "large" | "xlarge";
-        "toolTip"?: string;
+        "tooltip"?: string;
     }
     interface SmoothlyIconDemo {
         "onNotice"?: (event: SmoothlyIconDemoCustomEvent<Notice>) => void;
@@ -2598,7 +2598,7 @@ declare namespace LocalJSX {
         "onSmoothlyInputLoad"?: (event: SmoothlyInputEditCustomEvent<(parent: Editable) => void>) => void;
         "shape"?: "rounded";
         "size"?: "flexible" | "small" | "large" | "icon";
-        "toolTip"?: string;
+        "tooltip"?: string;
         "type"?: "form" | "input";
     }
     interface SmoothlyInputFile {
@@ -2732,7 +2732,7 @@ declare namespace LocalJSX {
         "onSmoothlyInputLoad"?: (event: SmoothlyInputSubmitCustomEvent<(parent: Editable) => void>) => void;
         "shape"?: "rounded";
         "size"?: "flexible" | "small" | "large" | "icon";
-        "toolTip"?: string;
+        "tooltip"?: string;
     }
     interface SmoothlyItem {
         "deselectable"?: boolean;

--- a/src/components/button/demo/standard/index.tsx
+++ b/src/components/button/demo/standard/index.tsx
@@ -82,7 +82,7 @@ export class SmoothlyButtonDemoStandard {
 						<span slot="label">Icon</span>
 						{Icon.Name.values.map(icon => (
 							<smoothly-item value={icon} key={icon}>
-								<smoothly-icon name={icon} size="small" toolTip={icon} />
+								<smoothly-icon name={icon} size="small" tooltip={icon} />
 							</smoothly-item>
 						))}
 						<smoothly-input-clear slot="end" />

--- a/src/components/checkbox/index.tsx
+++ b/src/components/checkbox/index.tsx
@@ -50,7 +50,7 @@ export class SmoothlyCheckbox implements Clearable {
 		return (
 			<Host>
 				<smoothly-icon
-					toolTip={this.t(!this.checked ? "Select" : "De-select")}
+					tooltip={this.t(!this.checked ? "Select" : "De-select")}
 					onClick={() => this.toggle()}
 					size={this.size}
 					name={

--- a/src/components/filter/index.tsx
+++ b/src/components/filter/index.tsx
@@ -53,7 +53,7 @@ export class SmoothlyFilter {
 				{this.criteria.toString() != "" && (
 					<smoothly-icon
 						name={"close"}
-						toolTip={"Clear all filters"}
+						tooltip={"Clear all filters"}
 						size="small"
 						onClick={() => {
 							this.clear()
@@ -65,7 +65,7 @@ export class SmoothlyFilter {
 				</div>
 				<smoothly-icon
 					name={this.expanded ? "options" : "options-outline"}
-					toolTip={(this.expanded ? "Hide" : "Show") + " additional filters"}
+					tooltip={(this.expanded ? "Hide" : "Show") + " additional filters"}
 					size="small"
 					onClick={() => {
 						this.expanded = !this.expanded

--- a/src/components/filter/toggle/index.tsx
+++ b/src/components/filter/toggle/index.tsx
@@ -11,7 +11,7 @@ import { Filter } from "../Filter"
 export class SmoothlyFilterToggle {
 	@Prop() icon: Icon
 	@Prop() properties: Record<string, string>
-	@Prop() toolTip: string
+	@Prop() tooltip: string
 	@Prop() not: boolean
 	@Prop({ reflect: true }) flip = false
 	@Prop({ mutable: true }) active = false
@@ -95,7 +95,7 @@ export class SmoothlyFilterToggle {
 				fill="clear"
 				color={this.active ? "success" : "medium"}
 				name={(this.active ? `${this.icon}` : `${this.icon}-outline`) as Icon}
-				toolTip={this.toolTip}
+				tooltip={this.tooltip}
 				onClick={() => this.activeHandler(true)}
 			/>
 		)

--- a/src/components/icon/demo/index.tsx
+++ b/src/components/icon/demo/index.tsx
@@ -79,7 +79,7 @@ export class SmoothlyIconDemo {
 					].map(name => (
 						<smoothly-icon
 							name={name}
-							toolTip={name}
+							tooltip={name}
 							data-name={name}
 							color={this.props.color}
 							fill={this.props.fill}

--- a/src/components/icon/index.tsx
+++ b/src/components/icon/index.tsx
@@ -15,13 +15,13 @@ export class SmoothlyIcon {
 	@Prop({ reflect: true }) size?: "tiny" | "small" | "medium" | "large" | "xlarge"
 	@Prop({ reflect: true }) rotate?: number
 	@Prop({ reflect: true }) flip?: "x" | "y"
-	@Prop() toolTip?: string
+	@Prop() tooltip?: string
 	@State() latestPromise: Promise<string | undefined>
 
 	async componentWillLoad() {
 		await this.nameChanged()
 	}
-	@Watch("toolTip")
+	@Watch("tooltip")
 	@Watch("name")
 	async nameChanged() {
 		if (this.name == "empty") {
@@ -51,14 +51,14 @@ export class SmoothlyIcon {
 			svgElement.removeAttribute("height")
 
 			const titleElement = svgElement.querySelector("title")
-			if (!this.toolTip) {
+			if (!this.tooltip) {
 				titleElement?.remove()
 			} else {
 				if (titleElement) {
-					titleElement.textContent = this.toolTip
+					titleElement.textContent = this.tooltip
 				} else {
 					const newTitleElement = document.createElement("title")
-					newTitleElement.textContent = this.toolTip
+					newTitleElement.textContent = this.tooltip
 					svgElement.appendChild(newTitleElement)
 				}
 			}

--- a/src/components/input/date/time/index.tsx
+++ b/src/components/input/date/time/index.tsx
@@ -221,7 +221,7 @@ export class SmoothlyInputDateTime implements ComponentWillLoad, Clearable, Inpu
 						color="danger"
 						fill="clear"
 						size="small"
-						toolTip={this.errorMessage}
+						tooltip={this.errorMessage}
 					/>
 					<slot name={"end"} />
 				</span>

--- a/src/components/input/edit/index.tsx
+++ b/src/components/input/edit/index.tsx
@@ -17,7 +17,7 @@ export class SmoothlyInputEdit implements ComponentWillLoad {
 	@Prop({ reflect: true }) shape?: "rounded"
 	@Prop({ reflect: true }) type: "form" | "input" = "input"
 	@Prop({ reflect: true }) size: "flexible" | "small" | "large" | "icon"
-	@Prop() toolTip = "Edit"
+	@Prop() tooltip = "Edit"
 	@Event() smoothlyInputLoad: EventEmitter<(parent: Editable) => void>
 	componentWillLoad(): void {
 		this.smoothlyInputLoad.emit(parent => {
@@ -36,7 +36,7 @@ export class SmoothlyInputEdit implements ComponentWillLoad {
 
 	render(): VNode | VNode[] {
 		return (
-			<Host title={this.toolTip}>
+			<Host title={this.tooltip}>
 				<smoothly-button
 					disabled={this.disabled}
 					size={this.size}

--- a/src/components/input/index.tsx
+++ b/src/components/input/index.tsx
@@ -229,7 +229,7 @@ export class SmoothlyInput implements Clearable, Input, Editable {
 					color="danger"
 					fill="clear"
 					size="small"
-					toolTip={this.errorMessage}
+					tooltip={this.errorMessage}
 				/>
 				<slot name="end" />
 			</Host>

--- a/src/components/input/radio/item/index.tsx
+++ b/src/components/input/radio/item/index.tsx
@@ -36,7 +36,7 @@ export class SmoothlyInputRadioItem {
 		return (
 			<Host onClick={() => this.inputHandler()}>
 				<input name={this.name} type="radio" checked={this.selected} disabled={this.disabled} />
-				<smoothly-icon name={this.selected ? "checkmark-circle" : "ellipse-outline"} size="small" toolTip="Select" />
+				<smoothly-icon name={this.selected ? "checkmark-circle" : "ellipse-outline"} size="small" tooltip="Select" />
 				<label>
 					<slot />
 				</label>

--- a/src/components/input/select/index.tsx
+++ b/src/components/input/select/index.tsx
@@ -367,7 +367,7 @@ export class SmoothlyInputSelect implements Input, Editable, Clearable, Componen
 						color="danger"
 						fill="clear"
 						size="small"
-						toolTip={this.errorMessage}
+						tooltip={this.errorMessage}
 					/>
 					<slot name="end" />
 					{this.looks == "border" && !this.readonly && (

--- a/src/components/input/submit/index.tsx
+++ b/src/components/input/submit/index.tsx
@@ -20,7 +20,7 @@ export class SmoothlyInputSubmit implements ComponentWillLoad {
 	@Prop({ reflect: true, mutable: true }) display = false
 	@Prop({ reflect: true }) shape?: "rounded"
 	@Prop({ reflect: true }) size: "flexible" | "small" | "large" | "icon" = "icon"
-	@Prop() toolTip = this.delete ? "Remove" : "Submit"
+	@Prop() tooltip = this.delete ? "Remove" : "Submit"
 	@Event() smoothlyInputLoad: EventEmitter<(parent: Editable) => void>
 	componentWillLoad(): void {
 		this.smoothlyInputLoad.emit(parent => {
@@ -43,7 +43,7 @@ export class SmoothlyInputSubmit implements ComponentWillLoad {
 
 	render(): VNode | VNode[] {
 		return (
-			<Host title={this.toolTip}>
+			<Host title={this.tooltip}>
 				{this.delete == true ? (
 					<smoothly-button-confirm
 						size={this.size}

--- a/src/components/table/demo/filtered/index.tsx
+++ b/src/components/table/demo/filtered/index.tsx
@@ -45,19 +45,19 @@ export class TableDemoFiltered implements ComponentWillLoad {
 					<smoothly-filter-toggle
 						properties={{ ["nested.pattern"]: "Ticked", breed: "" }}
 						icon="add"
-						toolTip="Nested Ticked"
+						tooltip="Nested Ticked"
 						slot="bar"
 					/>
 					<smoothly-filter-toggle
 						properties={{ pattern: "Ticked", breed: "" }}
 						icon="paw"
-						toolTip="Ticked cats"
+						tooltip="Ticked cats"
 						slot="bar"
 					/>
 					<smoothly-filter-toggle
 						properties={{ breed: "Bombay", pattern: "Solid" }}
 						icon="radio-button-on"
-						toolTip="Solid bombay cats"
+						tooltip="Solid bombay cats"
 						slot="bar"
 					/>
 					<smoothly-filter-toggle
@@ -65,7 +65,7 @@ export class TableDemoFiltered implements ComponentWillLoad {
 						not
 						active
 						icon="alert"
-						toolTip="Colored cats"
+						tooltip="Colored cats"
 						slot="bar"
 					/>
 					<smoothly-filter-select menuHeight="5items" label="coat" property="nested.coat" slot="bar" multiple={false}>


### PR DESCRIPTION
Inconsistent prop naming for `toolTip`/`tooltip` changing all to be the same (`tooltip`) to avoid unnecessary capitalization.

⚠️ Note: This is a breaking change. (but easy to fix for anyone using smoothly)