### PR TITLE
Replace title element in svg root with host title attribute

### DIFF
--- a/src/components/icon/index.tsx
+++ b/src/components/icon/index.tsx
@@ -49,19 +49,6 @@ export class SmoothlyIcon {
 			svgElement.setAttribute("role", "img")
 			svgElement.removeAttribute("width")
 			svgElement.removeAttribute("height")
-
-			const titleElement = svgElement.querySelector("title")
-			if (!this.tooltip) {
-				titleElement?.remove()
-			} else {
-				if (titleElement) {
-					titleElement.textContent = this.tooltip
-				} else {
-					const newTitleElement = document.createElement("title")
-					newTitleElement.textContent = this.tooltip
-					svgElement.appendChild(newTitleElement)
-				}
-			}
 		}
 		return svgElement ?? undefined
 	}
@@ -74,6 +61,6 @@ export class SmoothlyIcon {
 	}
 
 	render() {
-		return <Host style={{ ["--rotation"]: `${this.rotate ?? 0}deg` }} />
+		return <Host title={this.tooltip} style={{ ["--rotation"]: `${this.rotate ?? 0}deg` }} />
 	}
 }


### PR DESCRIPTION
Showing `<title>` on hover has always been a bit unreliable in icon for some reason, and now it stopped working completely after, I switched from `innerHTML` to `replaceChildren`.

According to the [SVG-spec](https://www.w3.org/TR/SVG2/struct.html#TitleElement) title directly inside the root-svg element should not show up on hover.

> "For reasons of accessibility, user agents should always make the content of the ‘title’ child element to the root svg element available to users. However, this is typically done through other means than the tooltips used for nested SVG and graphics elements, e.g., by displaying in a browser tab."
>
> — [SVG title Specification](https://www.w3.org/TR/SVG2/struct.html#TitleElement) (last paragraph)


So title has always been misplaced, but because of inconsistent parsing behaviour with innerHTML it sometimes worked.

`<title>` could be used inside other svg-elements, like `path`, `rect`, `circle` etc. and that would show on hover, but that would just show when hovering on the path/rect/circle etc.
