### PR TITLE
Make button tooltip work even for disabled button

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -76,6 +76,7 @@ export namespace Components {
         "link"?: string;
         "shape"?: "rounded";
         "size": "small" | "large" | "icon" | "flexible";
+        "tooltip"?: string;
         "type": Button.Properties["type"];
     }
     interface SmoothlyButtonConfirm {
@@ -2324,6 +2325,7 @@ declare namespace LocalJSX {
         "link"?: string;
         "shape"?: "rounded";
         "size"?: "small" | "large" | "icon" | "flexible";
+        "tooltip"?: string;
         "type"?: Button.Properties["type"];
     }
     interface SmoothlyButtonConfirm {

--- a/src/components/button/demo/standard/index.tsx
+++ b/src/components/button/demo/standard/index.tsx
@@ -11,6 +11,7 @@ type Options = {
 	rounded?: boolean
 	icon?: Icon
 	text?: { value: string; useColor?: boolean }
+	tooltip?: string
 }
 
 @Component({
@@ -87,10 +88,16 @@ export class SmoothlyButtonDemoStandard {
 						))}
 						<smoothly-input-clear slot="end" />
 					</smoothly-input-select>
+					<smoothly-input name="tooltip" value="Tooltip">
+						Tooltip
+						<smoothly-input-clear slot="end" />
+					</smoothly-input>
 				</smoothly-form>
 				<div class="buttons">
 					{Color.values.map((color, index, colors) => (
 						<smoothly-button
+							onClick={e => console.log(`Clicked button with color: ${color}`, e)}
+							tooltip={this.props.tooltip}
 							ref={el => colors.length - 1 == index && (this.lastButton = el)}
 							color={color}
 							expand={this.props.expand}

--- a/src/components/button/index.tsx
+++ b/src/components/button/index.tsx
@@ -1,4 +1,4 @@
-import { Component, h, Prop } from "@stencil/core"
+import { Component, h, Host, Prop } from "@stencil/core"
 import { Color, Fill } from "../../model"
 import { Button } from "./Button"
 
@@ -11,6 +11,7 @@ export class SmoothlyButton {
 	@Prop({ reflect: true }) color?: Color
 	@Prop({ reflect: true }) expand?: "block" | "full"
 	@Prop({ reflect: true }) fill?: Fill
+	@Prop({ reflect: true }) tooltip?: string
 	@Prop({ reflect: true }) disabled = false
 	@Prop({ reflect: true }) type: Button.Properties["type"]
 	@Prop({ reflect: true }) size: "small" | "large" | "icon" | "flexible"
@@ -19,9 +20,11 @@ export class SmoothlyButton {
 
 	render() {
 		return (
-			<Button disabled={this.disabled} type={this.type} link={this.link}>
-				<slot />
-			</Button>
+			<Host title={this.tooltip}>
+				<Button disabled={this.disabled} type={this.type} link={this.link}>
+					<slot />
+				</Button>
+			</Host>
 		)
 	}
 }

--- a/src/components/button/style.css
+++ b/src/components/button/style.css
@@ -20,7 +20,6 @@
 
 :host([disabled]) {
 	opacity: 0.5;
-	pointer-events: none;
 }
 
 :host>a,
@@ -113,15 +112,15 @@
 	border-color: rgb(var(--smoothly-button-foreground));
 }
 
-:host(:not([fill=clear]))>button:hover,
-:host()>button:focus-visible,
-:host([fill=outline]):active>button::before {
+:host(:not([fill=clear]):not([disabled]))>button:hover,
+:host(:not([disabled]))>button:focus-visible,
+:host([fill=outline]:not([disabled])):active>button::before {
 	border-color: rgb(var(--smoothly-button-focus-color));
 }
 
-:host([fill=outline])>button:hover::before,
-:host([fill=outline])>button:focus-within::before,
-:host([fill=outline])>button:active::before {
+:host([fill=outline]:not([disabled]))>button:hover::before,
+:host([fill=outline]:not([disabled]))>button:focus-within::before,
+:host([fill=outline]:not([disabled]))>button:active::before {
 	content: "";
 	position: absolute;
 	border: 2px solid rgb(var(--smoothly-button-focus-border));
@@ -129,9 +128,9 @@
 	border-radius: var(--smoothly-button-border-radius);
 }
 
-:host(:not([fill=clear]):not([fill=outline]))>button:hover,
-:host(:not([fill=clear]):not([fill=outline]))>button:focus-visible,
-:host(:not([fill=clear]):not([fill=outline]))>button:active {
+:host(:not([fill=clear]):not([fill=outline]):not([disabled]))>button:hover,
+:host(:not([fill=clear]):not([fill=outline]):not([disabled]))>button:focus-visible,
+:host(:not([fill=clear]):not([fill=outline]):not([disabled]))>button:active {
 	background: rgb(var(--smoothly-button-hover-background));
 }
 


### PR DESCRIPTION
Turns out the disabled button never needed to be `pointer-events: none`, since disabled buttons don't emit click events.


> A form control that is [disabled](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#concept-fe-disabled) must prevent any [click](https://w3c.github.io/uievents/#event-type-click) events that are [queued](https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task) on the [user interaction task source](https://html.spec.whatwg.org/multipage/webappapis.html#user-interaction-task-source) from being dispatched on the element.
>
> — [whatwg spec for disabled form controls (e.g. button)](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#enabling-and-disabling-form-controls:-the-disabled-attribute)
