### PR TITLE
Add smoothlyUserInput to inputs

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -1604,6 +1604,7 @@ declare global {
     };
     interface HTMLSmoothlyInputMonthElementEventMap {
         "smoothlyInput": Data;
+        "smoothlyUserInput": Input.UserInput;
         "smoothlyInputLoad": (parent: Editable) => void;
         "smoothlyFormDisable": (disabled: boolean) => void;
         "smoothlyInputLooks": (looks?: Looks, color?: Color) => void;
@@ -2685,6 +2686,7 @@ declare namespace LocalJSX {
         "onSmoothlyInput"?: (event: SmoothlyInputMonthCustomEvent<Data>) => void;
         "onSmoothlyInputLoad"?: (event: SmoothlyInputMonthCustomEvent<(parent: Editable) => void>) => void;
         "onSmoothlyInputLooks"?: (event: SmoothlyInputMonthCustomEvent<(looks?: Looks, color?: Color) => void>) => void;
+        "onSmoothlyUserInput"?: (event: SmoothlyInputMonthCustomEvent<Input.UserInput>) => void;
         "previous"?: boolean;
         "readonly"?: boolean;
         "showLabel"?: boolean;

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -1580,6 +1580,7 @@ declare global {
     interface HTMLSmoothlyInputFileElementEventMap {
         "smoothlyInputLooks": (looks?: Looks, color?: Color) => void;
         "smoothlyInput": Record<string, any>;
+        "smoothlyUserInput": Input.UserInput;
         "smoothlyInputLoad": (parent: Editable) => void;
         "smoothlyFormDisable": (disabled: boolean) => void;
     }
@@ -2657,6 +2658,7 @@ declare namespace LocalJSX {
         "onSmoothlyInput"?: (event: SmoothlyInputFileCustomEvent<Record<string, any>>) => void;
         "onSmoothlyInputLoad"?: (event: SmoothlyInputFileCustomEvent<(parent: Editable) => void>) => void;
         "onSmoothlyInputLooks"?: (event: SmoothlyInputFileCustomEvent<(looks?: Looks, color?: Color) => void>) => void;
+        "onSmoothlyUserInput"?: (event: SmoothlyInputFileCustomEvent<Input.UserInput>) => void;
         "placeholder"?: string | undefined;
         "readonly"?: boolean;
         "showLabel"?: boolean;

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -1452,6 +1452,7 @@ declare global {
     interface HTMLSmoothlyInputColorElementEventMap {
         "smoothlyInputLooks": (looks?: Looks, color?: Color) => void;
         "smoothlyInput": Record<string, any>;
+        "smoothlyUserInput": Input.UserInput;
         "smoothlyInputLoad": (parent: Editable) => void;
         "smoothlyFormDisable": (disabled: boolean) => void;
     }
@@ -2564,6 +2565,7 @@ declare namespace LocalJSX {
         "onSmoothlyInput"?: (event: SmoothlyInputColorCustomEvent<Record<string, any>>) => void;
         "onSmoothlyInputLoad"?: (event: SmoothlyInputColorCustomEvent<(parent: Editable) => void>) => void;
         "onSmoothlyInputLooks"?: (event: SmoothlyInputColorCustomEvent<(looks?: Looks, color?: Color) => void>) => void;
+        "onSmoothlyUserInput"?: (event: SmoothlyInputColorCustomEvent<Input.UserInput>) => void;
         "output"?: "rgb" | "hex";
         "readonly"?: boolean;
         "showLabel"?: boolean;

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -16,6 +16,7 @@ import { Filter } from "./components/filter/Filter";
 import { Looks } from "./components/input/Looks";
 import { isly } from "isly";
 import { Key } from "./components/input/Key";
+import { Input } from "./components/input/Input";
 import { RGB } from "./model/Color/RGB";
 import { Selectable } from "./components/input/radio/Selected";
 import { SmoothlyInputRadio } from "./components/input/radio/index";
@@ -31,6 +32,7 @@ export { Filter } from "./components/filter/Filter";
 export { Looks } from "./components/input/Looks";
 export { isly } from "isly";
 export { Key } from "./components/input/Key";
+export { Input } from "./components/input/Input";
 export { RGB } from "./model/Color/RGB";
 export { Selectable } from "./components/input/radio/Selected";
 export { SmoothlyInputRadio } from "./components/input/radio/index";
@@ -291,7 +293,7 @@ export namespace Components {
         "reset": () => Promise<void>;
         "setInitialValue": () => Promise<void>;
         "unregister": () => Promise<void>;
-        "value": boolean;
+        "value"?: Record<"true" | "false", any>;
     }
     interface SmoothlyInputCheckboxDemo {
     }
@@ -1387,6 +1389,7 @@ declare global {
         "smoothlyBlur": void;
         "smoothlyChange": Record<string, any>;
         "smoothlyInput": Record<string, any>;
+        "smoothlyUserInput": Input.UserInput;
     }
     interface HTMLSmoothlyInputElement extends Components.SmoothlyInput, HTMLStencilElement {
         addEventListener<K extends keyof HTMLSmoothlyInputElementEventMap>(type: K, listener: (this: HTMLSmoothlyInputElement, ev: SmoothlyInputCustomEvent<HTMLSmoothlyInputElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -1405,6 +1408,7 @@ declare global {
     interface HTMLSmoothlyInputCheckboxElementEventMap {
         "smoothlyInputLooks": (looks?: Looks, color?: Color) => void;
         "smoothlyInput": Data;
+        "smoothlyUserInput": Input.UserInput;
         "smoothlyInputLoad": (parent: Editable) => void;
         "smoothlyFormDisable": (disabled: boolean) => void;
     }
@@ -1622,6 +1626,7 @@ declare global {
     interface HTMLSmoothlyInputRadioElementEventMap {
         "smoothlyInputLooks": (looks?: Looks, color?: Color) => void;
         "smoothlyInput": Data;
+        "smoothlyUserInput": Input.UserInput;
         "smoothlyInputLoad": (parent: Editable) => void;
         "smoothlyFormDisable": (disabled: boolean) => void;
     }
@@ -1702,6 +1707,7 @@ declare global {
     };
     interface HTMLSmoothlyInputSelectElementEventMap {
         "smoothlyInput": Data;
+        "smoothlyUserInput": Input.UserInput;
         "smoothlyInputLooks": (looks?: Looks, color?: Color) => void;
         "smoothlyInputLoad": (parent: Editable) => void;
         "smoothlyFormDisable": (disabled: boolean) => void;
@@ -1739,7 +1745,7 @@ declare global {
         new (): HTMLSmoothlyInputSubmitElement;
     };
     interface HTMLSmoothlyItemElementEventMap {
-        "smoothlyItemSelect": HTMLSmoothlyItemElement;
+        "smoothlyItemSelect": { userInitiated: boolean; item: HTMLSmoothlyItemElement };
         "smoothlyInputLoad": (parent: Editable) => void;
         "smoothlyItemDOMChange": void;
     }
@@ -2507,6 +2513,7 @@ declare namespace LocalJSX {
         "onSmoothlyInputLoad"?: (event: SmoothlyInputCustomEvent<(parent: Editable) => void>) => void;
         "onSmoothlyInputLooks"?: (event: SmoothlyInputCustomEvent<(looks?: Looks, color?: Color) => void>) => void;
         "onSmoothlyKeydown"?: (event: SmoothlyInputCustomEvent<Key>) => void;
+        "onSmoothlyUserInput"?: (event: SmoothlyInputCustomEvent<Input.UserInput>) => void;
         "pad"?: number;
         "placeholder"?: string | undefined;
         "readonly"?: boolean;
@@ -2527,8 +2534,9 @@ declare namespace LocalJSX {
         "onSmoothlyInput"?: (event: SmoothlyInputCheckboxCustomEvent<Data>) => void;
         "onSmoothlyInputLoad"?: (event: SmoothlyInputCheckboxCustomEvent<(parent: Editable) => void>) => void;
         "onSmoothlyInputLooks"?: (event: SmoothlyInputCheckboxCustomEvent<(looks?: Looks, color?: Color) => void>) => void;
+        "onSmoothlyUserInput"?: (event: SmoothlyInputCheckboxCustomEvent<Input.UserInput>) => void;
         "readonly"?: boolean;
-        "value"?: boolean;
+        "value"?: Record<"true" | "false", any>;
     }
     interface SmoothlyInputCheckboxDemo {
     }
@@ -2684,6 +2692,7 @@ declare namespace LocalJSX {
         "onSmoothlyInput"?: (event: SmoothlyInputRadioCustomEvent<Data>) => void;
         "onSmoothlyInputLoad"?: (event: SmoothlyInputRadioCustomEvent<(parent: Editable) => void>) => void;
         "onSmoothlyInputLooks"?: (event: SmoothlyInputRadioCustomEvent<(looks?: Looks, color?: Color) => void>) => void;
+        "onSmoothlyUserInput"?: (event: SmoothlyInputRadioCustomEvent<Input.UserInput>) => void;
         "readonly"?: boolean;
         "showLabel"?: boolean;
         "value"?: any;
@@ -2749,6 +2758,7 @@ declare namespace LocalJSX {
         "onSmoothlyInputLoad"?: (event: SmoothlyInputSelectCustomEvent<(parent: Editable) => void>) => void;
         "onSmoothlyInputLooks"?: (event: SmoothlyInputSelectCustomEvent<(looks?: Looks, color?: Color) => void>) => void;
         "onSmoothlyItemSelect"?: (event: SmoothlyInputSelectCustomEvent<HTMLSmoothlyItemElement>) => void;
+        "onSmoothlyUserInput"?: (event: SmoothlyInputSelectCustomEvent<Input.UserInput>) => void;
         "ordered"?: boolean;
         "placeholder"?: string | any;
         "readonly"?: boolean;
@@ -2776,7 +2786,7 @@ declare namespace LocalJSX {
         "marked"?: boolean;
         "onSmoothlyInputLoad"?: (event: SmoothlyItemCustomEvent<(parent: Editable) => void>) => void;
         "onSmoothlyItemDOMChange"?: (event: SmoothlyItemCustomEvent<void>) => void;
-        "onSmoothlyItemSelect"?: (event: SmoothlyItemCustomEvent<HTMLSmoothlyItemElement>) => void;
+        "onSmoothlyItemSelect"?: (event: SmoothlyItemCustomEvent<{ userInitiated: boolean; item: HTMLSmoothlyItemElement }>) => void;
         "selected"?: boolean;
         "value"?: any;
     }

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -1480,6 +1480,7 @@ declare global {
         "smoothlyInputLoad": (parent: Editable) => void;
         "smoothlyValueChange": isoly.Date;
         "smoothlyInput": Record<string, any>;
+        "smoothlyUserInput": Input.UserInput;
         "smoothlyInputLooks": (looks?: Looks, color?: Color) => void;
         "smoothlyFormDisable": (disabled: boolean) => void;
     }
@@ -2587,6 +2588,7 @@ declare namespace LocalJSX {
         "onSmoothlyInput"?: (event: SmoothlyInputDateCustomEvent<Record<string, any>>) => void;
         "onSmoothlyInputLoad"?: (event: SmoothlyInputDateCustomEvent<(parent: Editable) => void>) => void;
         "onSmoothlyInputLooks"?: (event: SmoothlyInputDateCustomEvent<(looks?: Looks, color?: Color) => void>) => void;
+        "onSmoothlyUserInput"?: (event: SmoothlyInputDateCustomEvent<Input.UserInput>) => void;
         "onSmoothlyValueChange"?: (event: SmoothlyInputDateCustomEvent<isoly.Date>) => void;
         "open"?: boolean;
         "readonly"?: boolean;

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -1666,6 +1666,7 @@ declare global {
     interface HTMLSmoothlyInputRangeElementEventMap {
         "smoothlyInputLooks": (looks?: Looks, color?: Color) => void;
         "smoothlyInput": Record<string, any>;
+        "smoothlyUserInput": Input.UserInput;
         "smoothlyInputLoad": (parent: Editable) => void;
         "smoothlyFormDisable": (disabled: boolean) => void;
     }
@@ -2721,6 +2722,7 @@ declare namespace LocalJSX {
         "onSmoothlyInput"?: (event: SmoothlyInputRangeCustomEvent<Record<string, any>>) => void;
         "onSmoothlyInputLoad"?: (event: SmoothlyInputRangeCustomEvent<(parent: Editable) => void>) => void;
         "onSmoothlyInputLooks"?: (event: SmoothlyInputRangeCustomEvent<(looks?: Looks, color?: Color) => void>) => void;
+        "onSmoothlyUserInput"?: (event: SmoothlyInputRangeCustomEvent<Input.UserInput>) => void;
         "outputSide"?: "right" | "left";
         "readonly"?: boolean;
         "step"?: number;

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -402,6 +402,8 @@ export namespace Components {
     }
     interface SmoothlyInputDemoStandard {
     }
+    interface SmoothlyInputDemoUserInput {
+    }
     interface SmoothlyInputEdit {
         "color"?: Color;
         "disabled": boolean;
@@ -1564,6 +1566,12 @@ declare global {
         prototype: HTMLSmoothlyInputDemoStandardElement;
         new (): HTMLSmoothlyInputDemoStandardElement;
     };
+    interface HTMLSmoothlyInputDemoUserInputElement extends Components.SmoothlyInputDemoUserInput, HTMLStencilElement {
+    }
+    var HTMLSmoothlyInputDemoUserInputElement: {
+        prototype: HTMLSmoothlyInputDemoUserInputElement;
+        new (): HTMLSmoothlyInputDemoUserInputElement;
+    };
     interface HTMLSmoothlyInputEditElementEventMap {
         "smoothlyInputLoad": (parent: Editable) => void;
     }
@@ -2217,6 +2225,7 @@ declare global {
         "smoothly-input-date-time": HTMLSmoothlyInputDateTimeElement;
         "smoothly-input-demo": HTMLSmoothlyInputDemoElement;
         "smoothly-input-demo-standard": HTMLSmoothlyInputDemoStandardElement;
+        "smoothly-input-demo-user-input": HTMLSmoothlyInputDemoUserInputElement;
         "smoothly-input-edit": HTMLSmoothlyInputEditElement;
         "smoothly-input-file": HTMLSmoothlyInputFileElement;
         "smoothly-input-month": HTMLSmoothlyInputMonthElement;
@@ -2644,6 +2653,8 @@ declare namespace LocalJSX {
     }
     interface SmoothlyInputDemoStandard {
     }
+    interface SmoothlyInputDemoUserInput {
+    }
     interface SmoothlyInputEdit {
         "color"?: Color;
         "disabled"?: boolean;
@@ -3025,6 +3036,7 @@ declare namespace LocalJSX {
         "smoothly-input-date-time": SmoothlyInputDateTime;
         "smoothly-input-demo": SmoothlyInputDemo;
         "smoothly-input-demo-standard": SmoothlyInputDemoStandard;
+        "smoothly-input-demo-user-input": SmoothlyInputDemoUserInput;
         "smoothly-input-edit": SmoothlyInputEdit;
         "smoothly-input-file": SmoothlyInputFile;
         "smoothly-input-month": SmoothlyInputMonth;
@@ -3138,6 +3150,7 @@ declare module "@stencil/core" {
             "smoothly-input-date-time": LocalJSX.SmoothlyInputDateTime & JSXBase.HTMLAttributes<HTMLSmoothlyInputDateTimeElement>;
             "smoothly-input-demo": LocalJSX.SmoothlyInputDemo & JSXBase.HTMLAttributes<HTMLSmoothlyInputDemoElement>;
             "smoothly-input-demo-standard": LocalJSX.SmoothlyInputDemoStandard & JSXBase.HTMLAttributes<HTMLSmoothlyInputDemoStandardElement>;
+            "smoothly-input-demo-user-input": LocalJSX.SmoothlyInputDemoUserInput & JSXBase.HTMLAttributes<HTMLSmoothlyInputDemoUserInputElement>;
             "smoothly-input-edit": LocalJSX.SmoothlyInputEdit & JSXBase.HTMLAttributes<HTMLSmoothlyInputEditElement>;
             "smoothly-input-file": LocalJSX.SmoothlyInputFile & JSXBase.HTMLAttributes<HTMLSmoothlyInputFileElement>;
             "smoothly-input-month": LocalJSX.SmoothlyInputMonth & JSXBase.HTMLAttributes<HTMLSmoothlyInputMonthElement>;

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -1500,6 +1500,7 @@ declare global {
     };
     interface HTMLSmoothlyInputDateRangeElementEventMap {
         "smoothlyInput": { [name: string]: isoly.DateRange | undefined };
+        "smoothlyUserInput": Input.UserInput;
         "smoothlyInputLoad": (parent: Editable) => void;
         "smoothlyInputLooks": (looks?: Looks, color?: Color) => void;
         "smoothlyFormDisable": (disabled: boolean) => void;
@@ -2609,6 +2610,7 @@ declare namespace LocalJSX {
         "onSmoothlyInput"?: (event: SmoothlyInputDateRangeCustomEvent<{ [name: string]: isoly.DateRange | undefined }>) => void;
         "onSmoothlyInputLoad"?: (event: SmoothlyInputDateRangeCustomEvent<(parent: Editable) => void>) => void;
         "onSmoothlyInputLooks"?: (event: SmoothlyInputDateRangeCustomEvent<(looks?: Looks, color?: Color) => void>) => void;
+        "onSmoothlyUserInput"?: (event: SmoothlyInputDateRangeCustomEvent<Input.UserInput>) => void;
         "placeholder"?: string;
         "readonly"?: boolean;
         "showLabel"?: boolean;

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -18,7 +18,7 @@ import { isly } from "isly";
 import { Key } from "./components/input/Key";
 import { Input } from "./components/input/Input";
 import { RGB } from "./model/Color/RGB";
-import { Selectable } from "./components/input/radio/Selected";
+import { RadioItemSelect } from "./components/input/radio/RadioItemSelect";
 import { SmoothlyInputRadio } from "./components/input/radio/index";
 import { SmoothlyTabs } from "./components/tabs";
 export { Color, Data, Fill, Icon, Message, Notice, Submit, Trigger } from "./model";
@@ -34,7 +34,7 @@ export { isly } from "isly";
 export { Key } from "./components/input/Key";
 export { Input } from "./components/input/Input";
 export { RGB } from "./model/Color/RGB";
-export { Selectable } from "./components/input/radio/Selected";
+export { RadioItemSelect } from "./components/input/radio/RadioItemSelect";
 export { SmoothlyInputRadio } from "./components/input/radio/index";
 export { SmoothlyTabs } from "./components/tabs";
 export namespace Components {
@@ -1645,7 +1645,7 @@ declare global {
         new (): HTMLSmoothlyInputRadioElement;
     };
     interface HTMLSmoothlyInputRadioItemElementEventMap {
-        "smoothlySelect": Selectable;
+        "smoothlyRadioItemSelect": RadioItemSelect;
         "smoothlyRadioItemRegister": (parent: SmoothlyInputRadio) => void;
     }
     interface HTMLSmoothlyInputRadioItemElement extends Components.SmoothlyInputRadioItem, HTMLStencilElement {
@@ -2701,7 +2701,7 @@ declare namespace LocalJSX {
         "looks"?: Looks;
         "name"?: string;
         "onSmoothlyRadioItemRegister"?: (event: SmoothlyInputRadioItemCustomEvent<(parent: SmoothlyInputRadio) => void>) => void;
-        "onSmoothlySelect"?: (event: SmoothlyInputRadioItemCustomEvent<Selectable>) => void;
+        "onSmoothlyRadioItemSelect"?: (event: SmoothlyInputRadioItemCustomEvent<RadioItemSelect>) => void;
         "selected"?: boolean;
         "value"?: any;
     }

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -1523,6 +1523,7 @@ declare global {
         "smoothlyInputLoad": (parent: Editable) => void;
         "smoothlyValueChange": isoly.DateTime;
         "smoothlyInput": Record<string, any>;
+        "smoothlyUserInput": Input.UserInput;
         "smoothlyInputLooks": (looks?: Looks, color?: Color) => void;
         "smoothlyFormDisable": (disabled: boolean) => void;
     }
@@ -2630,6 +2631,7 @@ declare namespace LocalJSX {
         "onSmoothlyInput"?: (event: SmoothlyInputDateTimeCustomEvent<Record<string, any>>) => void;
         "onSmoothlyInputLoad"?: (event: SmoothlyInputDateTimeCustomEvent<(parent: Editable) => void>) => void;
         "onSmoothlyInputLooks"?: (event: SmoothlyInputDateTimeCustomEvent<(looks?: Looks, color?: Color) => void>) => void;
+        "onSmoothlyUserInput"?: (event: SmoothlyInputDateTimeCustomEvent<Input.UserInput>) => void;
         "onSmoothlyValueChange"?: (event: SmoothlyInputDateTimeCustomEvent<isoly.DateTime>) => void;
         "open"?: boolean;
         "readonly"?: boolean;

--- a/src/components/calendar/index.tsx
+++ b/src/components/calendar/index.tsx
@@ -81,7 +81,8 @@ export class Calendar {
 					onSmoothlyInput={e => {
 						e.stopPropagation()
 						"month" in e.detail && typeof e.detail.month == "string" && (this.month = e.detail.month)
-					}}>
+					}}
+					onSmoothlyUserInput={e => e.stopPropagation()}>
 					<div slot={"year-label"}>
 						<slot name={"year-label"} />
 					</div>

--- a/src/components/input/Input.ts
+++ b/src/components/input/Input.ts
@@ -9,7 +9,7 @@ import { Looks } from "./Looks"
 export interface Input extends Input.Element {
 	smoothlyInputLoad: EventEmitter<(parent: Editable) => void>
 	smoothlyInput: EventEmitter<Data> // Used for smoothly-form
-	smoothlyUserInput?: EventEmitter<Input.UserInput> // Make required
+	smoothlyUserInput: EventEmitter<Input.UserInput>
 	smoothlyKeydown?: EventEmitter<Key>
 	smoothlyInputForm?: EventEmitter<Record<string, Data>>
 	parent: Editable | undefined

--- a/src/components/input/Input.ts
+++ b/src/components/input/Input.ts
@@ -8,7 +8,7 @@ import { Looks } from "./Looks"
 
 export interface Input extends Input.Element {
 	smoothlyInputLoad: EventEmitter<(parent: Editable) => void>
-	smoothlyInput: EventEmitter<Data>
+	smoothlyInput: EventEmitter<Data> // Used for smoothly-form
 	smoothlyUserInput?: EventEmitter<Input.UserInput> // Make required
 	smoothlyKeydown?: EventEmitter<Key>
 	smoothlyInputForm?: EventEmitter<Record<string, Data>>

--- a/src/components/input/Input.ts
+++ b/src/components/input/Input.ts
@@ -9,11 +9,13 @@ import { Looks } from "./Looks"
 export interface Input extends Input.Element {
 	smoothlyInputLoad: EventEmitter<(parent: Editable) => void>
 	smoothlyInput: EventEmitter<Data>
+	smoothlyUserInput?: EventEmitter<Input.UserInput> // Make required
 	smoothlyKeydown?: EventEmitter<Key>
 	smoothlyInputForm?: EventEmitter<Record<string, Data>>
 	parent: Editable | undefined
 }
 export namespace Input {
+	export type UserInput = { name: string; value: any }
 	export interface Element {
 		register: () => Promise<void>
 		unregister: () => Promise<void>
@@ -47,6 +49,7 @@ export namespace Input {
 	export const type = Element.type.extend<Input>({
 		smoothlyInputLoad: EventEmitter,
 		smoothlyInput: EventEmitter,
+		smoothlyUserInput: EventEmitter,
 		smoothlyKeydown: EventEmitter.optional(),
 		smoothlyInputForm: EventEmitter.optional(),
 		parent: Editable.type.optional(),

--- a/src/components/input/checkbox/index.tsx
+++ b/src/components/input/checkbox/index.tsx
@@ -21,11 +21,12 @@ export class SmoothlyInputCheckbox implements Input, Clearable, Editable, Compon
 	@Prop({ reflect: true, mutable: true }) readonly = false
 	@Prop({ reflect: true }) disabled: boolean
 	@Prop({ mutable: true }) checked = false
-	@Prop() value = this.checked
+	@Prop() value?: Record<"true" | "false", any>
 	@Prop({ reflect: true, mutable: true }) looks?: Looks
 	@Prop({ reflect: true, mutable: true }) color?: Color
 	@Event() smoothlyInputLooks: EventEmitter<(looks?: Looks, color?: Color) => void>
 	@Event() smoothlyInput: EventEmitter<Data>
+	@Event() smoothlyUserInput: EventEmitter<Input.UserInput>
 	@Event() smoothlyInputLoad: EventEmitter<(parent: Editable) => void>
 	@Event() smoothlyFormDisable: EventEmitter<(disabled: boolean) => void>
 	componentWillLoad(): void | Promise<void> {
@@ -56,7 +57,7 @@ export class SmoothlyInputCheckbox implements Input, Clearable, Editable, Compon
 	}
 	@Method()
 	async getValue(): Promise<boolean> {
-		return this.checked
+		return this.value ? this.value[`${!!this.checked}`] : this.checked
 	}
 	@Method()
 	async clear(): Promise<void> {
@@ -97,7 +98,10 @@ export class SmoothlyInputCheckbox implements Input, Clearable, Editable, Compon
 					id={this.id}
 					checked={this.checked}
 					disabled={this.disabled || this.readonly}
-					onChange={e => (this.checked = (e.target as HTMLInputElement).checked)}
+					onChange={async e => {
+						this.checked = (e.target as HTMLInputElement).checked
+						this.smoothlyUserInput.emit({ name: this.name, value: await this.getValue() })
+					}}
 				/>
 				{this.checked && <smoothly-icon name="checkmark-outline" size="tiny" />}
 				<label htmlFor={this.id}>

--- a/src/components/input/color/index.tsx
+++ b/src/components/input/color/index.tsx
@@ -143,7 +143,7 @@ export class SmoothlyInputColor implements Input, Clearable, Editable, Component
 			this.value && (this.hsl = Color.RGB.toHSL(Color.Hex.toRGB(this.value)))
 		}
 	}
-	hexInputHandler(value: string): void {
+	async hexInputHandler(value: string): Promise<void> {
 		if (value !== this.value) {
 			if (value && Color.Hex.type.is(value)) {
 				if (this.sliderMode === "hsl" || this.rgb.r === undefined) {
@@ -157,7 +157,7 @@ export class SmoothlyInputColor implements Input, Clearable, Editable, Component
 				this.hsl = { h: undefined, s: undefined, l: undefined }
 			}
 			this.value = value
-			this.smoothlyUserInput.emit({ name: this.name, value: this.value })
+			this.smoothlyUserInput.emit({ name: this.name, value: await this.getValue() })
 		}
 	}
 	sliderInputHandler(event: CustomEvent<Data>): void {
@@ -246,6 +246,7 @@ export class SmoothlyInputColor implements Input, Clearable, Editable, Component
 								step={1}
 								outputSide="right"
 								onSmoothlyInput={event => this.sliderInputHandler(event)}
+								onSmoothlyUserInput={event => event.stopPropagation()}
 								label={key.toUpperCase()}
 							/>
 						))}
@@ -261,6 +262,7 @@ export class SmoothlyInputColor implements Input, Clearable, Editable, Component
 								step={key === "s" || key === "l" ? 0.01 : 1}
 								outputSide="right"
 								onSmoothlyInput={event => this.sliderInputHandler(event)}
+								onSmoothlyUserInput={event => event.stopPropagation()}
 								label={key.toUpperCase()}
 							/>
 						))}

--- a/src/components/input/color/index.tsx
+++ b/src/components/input/color/index.tsx
@@ -46,6 +46,7 @@ export class SmoothlyInputColor implements Input, Clearable, Editable, Component
 	@State() sliderMode: "rgb" | "hsl" = "rgb"
 	@Event() smoothlyInputLooks: EventEmitter<(looks?: Looks, color?: Color) => void>
 	@Event() smoothlyInput: EventEmitter<Record<string, any>>
+	@Event() smoothlyUserInput: EventEmitter<Input.UserInput>
 	@Event() smoothlyInputLoad: EventEmitter<(parent: Editable) => void>
 	@Event() smoothlyFormDisable: EventEmitter<(disabled: boolean) => void>
 	async componentWillLoad(): Promise<void> {
@@ -156,6 +157,7 @@ export class SmoothlyInputColor implements Input, Clearable, Editable, Component
 				this.hsl = { h: undefined, s: undefined, l: undefined }
 			}
 			this.value = value
+			this.smoothlyUserInput.emit({ name: this.name, value: this.value })
 		}
 	}
 	sliderInputHandler(event: CustomEvent<Data>): void {

--- a/src/components/input/date/index.tsx
+++ b/src/components/input/date/index.tsx
@@ -152,7 +152,10 @@ export class SmoothlyInputDate implements ComponentWillLoad, Clearable, Input, E
 					onSmoothlyInput={e => {
 						e.stopPropagation()
 						this.value = e.detail[this.name]
-						this.smoothlyUserInput.emit({ name: this.name, value: this.value })
+					}}
+					onSmoothlyUserInput={e => {
+						e.stopPropagation()
+						this.smoothlyUserInput.emit({ name: this.name, value: this.getValue() })
 					}}>
 					<slot />
 				</smoothly-input>

--- a/src/components/input/date/index.tsx
+++ b/src/components/input/date/index.tsx
@@ -44,6 +44,7 @@ export class SmoothlyInputDate implements ComponentWillLoad, Clearable, Input, E
 	@Event() smoothlyInputLoad: EventEmitter<(parent: Editable) => void>
 	@Event() smoothlyValueChange: EventEmitter<isoly.Date>
 	@Event() smoothlyInput: EventEmitter<Record<string, any>>
+	@Event() smoothlyUserInput: EventEmitter<Input.UserInput>
 	@Event() smoothlyInputLooks: EventEmitter<(looks?: Looks, color?: Color) => void>
 	@Event() smoothlyFormDisable: EventEmitter<(disabled: boolean) => void>
 
@@ -151,6 +152,7 @@ export class SmoothlyInputDate implements ComponentWillLoad, Clearable, Input, E
 					onSmoothlyInput={e => {
 						e.stopPropagation()
 						this.value = e.detail[this.name]
+						this.smoothlyUserInput.emit({ name: this.name, value: this.value })
 					}}>
 					<slot />
 				</smoothly-input>
@@ -164,6 +166,7 @@ export class SmoothlyInputDate implements ComponentWillLoad, Clearable, Input, E
 							value={this.value}
 							onSmoothlyValueChange={event => {
 								this.value = event.detail
+								this.smoothlyUserInput.emit({ name: this.name, value: this.value })
 								event.stopPropagation()
 							}}
 							max={this.max}

--- a/src/components/input/date/range/index.tsx
+++ b/src/components/input/date/range/index.tsx
@@ -34,6 +34,7 @@ export class SmoothlyInputDateRange implements Clearable, Input, Editable {
 	@State() value?: isoly.DateRange
 	@State() open: boolean
 	@Event() smoothlyInput: EventEmitter<{ [name: string]: isoly.DateRange | undefined }>
+	@Event() smoothlyUserInput: EventEmitter<Input.UserInput>
 	@Event() smoothlyInputLoad: EventEmitter<(parent: Editable) => void>
 	@Event() smoothlyInputLooks: EventEmitter<(looks?: Looks, color?: Color) => void>
 	@Event() smoothlyFormDisable: EventEmitter<(disabled: boolean) => void>
@@ -176,6 +177,7 @@ export class SmoothlyInputDateRange implements Clearable, Input, Editable {
 								e.stopPropagation()
 								this.open = false
 								this.smoothlyInput.emit({ [this.name]: e.detail })
+								this.smoothlyUserInput.emit({ name: this.name, value: e.detail })
 							}}
 							value={this.start}
 							start={this.start}

--- a/src/components/input/date/time/index.tsx
+++ b/src/components/input/date/time/index.tsx
@@ -176,7 +176,6 @@ export class SmoothlyInputDateTime implements ComponentWillLoad, Clearable, Inpu
 					onSmoothlyInput={async e => {
 						e.stopPropagation()
 						this.date = e.detail.date
-						// this.smoothlyUserInput.emit({ name: this.name, value: await this.getValue() })
 					}}
 					onSmoothlyUserInput={async e => {
 						e.stopPropagation()
@@ -197,7 +196,6 @@ export class SmoothlyInputDateTime implements ComponentWillLoad, Clearable, Inpu
 					onSmoothlyInput={async e => {
 						e.stopPropagation()
 						this.hour = e.detail.hour
-						// this.smoothlyUserInput.emit({ name: this.name, value: await this.getValue() })
 					}}
 					onSmoothlyUserInput={async e => {
 						e.stopPropagation()
@@ -218,7 +216,6 @@ export class SmoothlyInputDateTime implements ComponentWillLoad, Clearable, Inpu
 					onSmoothlyInput={async e => {
 						e.stopPropagation()
 						this.minute = e.detail.minute
-						// this.smoothlyUserInput.emit({ name: this.name, value: await this.getValue() })
 					}}
 					onSmoothlyUserInput={async e => {
 						e.stopPropagation()

--- a/src/components/input/date/time/index.tsx
+++ b/src/components/input/date/time/index.tsx
@@ -48,6 +48,7 @@ export class SmoothlyInputDateTime implements ComponentWillLoad, Clearable, Inpu
 	@Event() smoothlyInputLoad: EventEmitter<(parent: Editable) => void>
 	@Event() smoothlyValueChange: EventEmitter<isoly.DateTime>
 	@Event() smoothlyInput: EventEmitter<Record<string, any>>
+	@Event() smoothlyUserInput: EventEmitter<Input.UserInput>
 	@Event() smoothlyInputLooks: EventEmitter<(looks?: Looks, color?: Color) => void>
 	@Event() smoothlyFormDisable: EventEmitter<(disabled: boolean) => void>
 
@@ -177,9 +178,10 @@ export class SmoothlyInputDateTime implements ComponentWillLoad, Clearable, Inpu
 					value={this.date}
 					showLabel={this.showLabel}
 					onSmoothlyInputLoad={e => e.stopPropagation()}
-					onSmoothlyInput={e => {
+					onSmoothlyInput={async e => {
 						e.stopPropagation()
 						this.date = e.detail.date
+						this.smoothlyUserInput.emit({ name: this.name, value: await this.getValue() })
 					}}>
 					<slot />
 				</smoothly-input>
@@ -193,9 +195,10 @@ export class SmoothlyInputDateTime implements ComponentWillLoad, Clearable, Inpu
 					disabled={this.disabled}
 					placeholder="hh"
 					onSmoothlyInputLoad={e => e.stopPropagation()}
-					onSmoothlyInput={e => {
+					onSmoothlyInput={async e => {
 						e.stopPropagation()
 						this.hour = e.detail.hour
+						this.smoothlyUserInput.emit({ name: this.name, value: await this.getValue() })
 					}}
 				/>
 				<span class="colon">:</span>
@@ -209,9 +212,10 @@ export class SmoothlyInputDateTime implements ComponentWillLoad, Clearable, Inpu
 					disabled={this.disabled}
 					placeholder="mm"
 					onSmoothlyInputLoad={e => e.stopPropagation()}
-					onSmoothlyInput={e => {
+					onSmoothlyInput={async e => {
 						e.stopPropagation()
 						this.minute = e.detail.minute
+						this.smoothlyUserInput.emit({ name: this.name, value: await this.getValue() })
 					}}
 				/>
 				<span class="icons">
@@ -232,13 +236,14 @@ export class SmoothlyInputDateTime implements ComponentWillLoad, Clearable, Inpu
 							value={this.value ? isoly.DateTime.getDate(this.value) : undefined}
 							min={this.min ? isoly.DateTime.getDate(this.min) : undefined}
 							max={this.max ? isoly.DateTime.getDate(this.max) : undefined}
-							onSmoothlyValueChange={e => {
-								this.date = e.detail
+							onSmoothlyValueChange={async e => {
 								e.stopPropagation()
+								this.date = e.detail
+								this.smoothlyUserInput.emit({ name: this.name, value: await this.getValue() })
 							}}
 							onSmoothlyDateSet={e => {
-								this.open = false
 								e.stopPropagation()
+								this.open = false
 							}}>
 							<div slot={"year-label"}>
 								<slot name={"year-label"} />

--- a/src/components/input/date/time/index.tsx
+++ b/src/components/input/date/time/index.tsx
@@ -124,11 +124,6 @@ export class SmoothlyInputDateTime implements ComponentWillLoad, Clearable, Inpu
 	watchingReadonly(): void {
 		this.observer.publish()
 	}
-	@Listen("smoothlyInput")
-	smoothlyInputHandler(event: CustomEvent<Record<string, any>>) {
-		if (event.target != this.element)
-			event.stopPropagation()
-	}
 	@Listen("smoothlyInputLooks")
 	smoothlyInputLooksHandler(event: CustomEvent<(looks: Looks) => void>) {
 		if (event.target != this.element)
@@ -181,6 +176,10 @@ export class SmoothlyInputDateTime implements ComponentWillLoad, Clearable, Inpu
 					onSmoothlyInput={async e => {
 						e.stopPropagation()
 						this.date = e.detail.date
+						// this.smoothlyUserInput.emit({ name: this.name, value: await this.getValue() })
+					}}
+					onSmoothlyUserInput={async e => {
+						e.stopPropagation()
 						this.smoothlyUserInput.emit({ name: this.name, value: await this.getValue() })
 					}}>
 					<slot />
@@ -198,6 +197,10 @@ export class SmoothlyInputDateTime implements ComponentWillLoad, Clearable, Inpu
 					onSmoothlyInput={async e => {
 						e.stopPropagation()
 						this.hour = e.detail.hour
+						// this.smoothlyUserInput.emit({ name: this.name, value: await this.getValue() })
+					}}
+					onSmoothlyUserInput={async e => {
+						e.stopPropagation()
 						this.smoothlyUserInput.emit({ name: this.name, value: await this.getValue() })
 					}}
 				/>
@@ -215,6 +218,10 @@ export class SmoothlyInputDateTime implements ComponentWillLoad, Clearable, Inpu
 					onSmoothlyInput={async e => {
 						e.stopPropagation()
 						this.minute = e.detail.minute
+						// this.smoothlyUserInput.emit({ name: this.name, value: await this.getValue() })
+					}}
+					onSmoothlyUserInput={async e => {
+						e.stopPropagation()
 						this.smoothlyUserInput.emit({ name: this.name, value: await this.getValue() })
 					}}
 				/>

--- a/src/components/input/demo/index.tsx
+++ b/src/components/input/demo/index.tsx
@@ -16,6 +16,7 @@ export class SmoothlyInputDemo {
 		return (
 			<Host>
 				<smoothly-input-demo-standard />
+				<smoothly-input-demo-user-input />
 				<div class="inputs">
 					<h2>Calendar</h2>
 					<smoothly-input-date name="some-date">Calendar</smoothly-input-date>

--- a/src/components/input/demo/user-input/index.tsx
+++ b/src/components/input/demo/user-input/index.tsx
@@ -3,6 +3,7 @@ import { isoly } from "isoly"
 
 @Component({
 	tag: "smoothly-input-demo-user-input",
+	styleUrl: "style.css",
 	scoped: true,
 })
 export class SmoothlyInputDemoUserInput {
@@ -25,18 +26,21 @@ export class SmoothlyInputDemoUserInput {
 	render() {
 		return (
 			<Host>
-				<h2>User Input</h2>
-				<p>
-					These inputs demonstrate how user input is handled. The <code>smoothlyUserInput</code> event fires only when
-					the user interacts with an input, not when its value is changed programmatically (such as by clicking the
-					buttons above).
-					<br />
-					Check the console to see the details of each <code>smoothlyUserInput</code> event.
-				</p>
+				<div>
+					<h2>User Input</h2>
+					<p>
+						These inputs demonstrate how user input is handled. The <code>smoothlyUserInput</code> event fires only when
+						the user interacts with an input, not when its value is changed programmatically (such as by clicking the
+						buttons above).
+						<br />
+						Check the console to see the details of each <code>smoothlyUserInput</code> event.
+					</p>
+				</div>
 				<smoothly-button color="primary" onClick={() => (this.textIndex = this.increment(this.textIndex))}>
 					Change text
 				</smoothly-button>
 				<smoothly-input
+					looks="border"
 					name="demo-user-input-text"
 					value={this.textIndex === undefined ? "" : this.values[this.textIndex]}
 					onSmoothlyUserInput={e => console.debug("smoothlyUserInput", e.detail.name, e.detail.value)}>
@@ -47,6 +51,7 @@ export class SmoothlyInputDemoUserInput {
 					Next select item
 				</smoothly-button>
 				<smoothly-input-select
+					looks="border"
 					name="demo-user-input-select"
 					onSmoothlyUserInput={e => console.debug("smoothlyUserInput", e.detail.name, e.detail.value)}>
 					<span slot="label">Select input</span>
@@ -61,6 +66,7 @@ export class SmoothlyInputDemoUserInput {
 					Toggle checkbox
 				</smoothly-button>
 				<smoothly-input-checkbox
+					looks="border"
 					name="demo-user-input-checkbox"
 					checked={this.checkboxChecked}
 					onSmoothlyUserInput={e => console.debug("smoothlyUserInput", e.detail.name, e.detail.value)}>
@@ -72,6 +78,7 @@ export class SmoothlyInputDemoUserInput {
 				</smoothly-button>
 				{/* Bug: radio has bugs when changing programmatically - TODO: consider changing to using a regular radio input as underlying controls */}
 				<smoothly-input-radio
+					looks="border"
 					name="demo-user-input-radio"
 					onSmoothlyUserInput={e => console.debug("smoothlyUserInput", e.detail.name, e.detail.value)}>
 					<span slot="label">Radio input</span>
@@ -88,6 +95,7 @@ export class SmoothlyInputDemoUserInput {
 					Next range value
 				</smoothly-button>
 				<smoothly-input-range
+					looks="border"
 					name="demo-user-input-range"
 					step={1}
 					min={0}
@@ -101,6 +109,7 @@ export class SmoothlyInputDemoUserInput {
 					Next color
 				</smoothly-button>
 				<smoothly-input-color
+					looks="border"
 					name="demo-user-input-color"
 					value={typeof this.colorIndex == "number" ? this.colors[this.colorIndex] : undefined}
 					onSmoothlyUserInput={e => console.debug("smoothlyUserInput", e.detail.name, e.detail.value)}>
@@ -113,6 +122,7 @@ export class SmoothlyInputDemoUserInput {
 					Next day
 				</smoothly-button>
 				<smoothly-input-date
+					looks="border"
 					name="demo-user-input-date"
 					value={this.dateValue}
 					onSmoothlyUserInput={e => console.debug("smoothlyUserInput", e.detail.name, e.detail.value)}>
@@ -129,6 +139,7 @@ export class SmoothlyInputDemoUserInput {
 					Next date time
 				</smoothly-button>
 				<smoothly-input-date-time
+					looks="border"
 					name="demo-user-input-datetime"
 					value={this.datetimeValue}
 					onSmoothlyUserInput={e => console.debug("smoothlyUserInput", e.detail.name, e.detail.value)}>
@@ -145,6 +156,7 @@ export class SmoothlyInputDemoUserInput {
 					Next date range
 				</smoothly-button>
 				<smoothly-input-date-range
+					looks="border"
 					name="demo-user-input-daterange"
 					start={this.dateRangeValue?.start}
 					end={this.dateRangeValue?.end}

--- a/src/components/input/demo/user-input/index.tsx
+++ b/src/components/input/demo/user-input/index.tsx
@@ -43,7 +43,7 @@ export class SmoothlyInputDemoUserInput {
 					looks="border"
 					name="demo-user-input-text"
 					value={this.textIndex === undefined ? "" : this.values[this.textIndex]}
-					onSmoothlyUserInput={e => console.debug("smoothlyUserInput", e.detail.name, e.detail.value)}>
+					onSmoothlyUserInput={e => console.debug(e.type, e.detail.name, e.detail.value)}>
 					Text input
 				</smoothly-input>
 
@@ -53,7 +53,7 @@ export class SmoothlyInputDemoUserInput {
 				<smoothly-input-select
 					looks="border"
 					name="demo-user-input-select"
-					onSmoothlyUserInput={e => console.debug("smoothlyUserInput", e.detail.name, e.detail.value)}>
+					onSmoothlyUserInput={e => console.debug(e.type, e.detail.name, e.detail.value)}>
 					<span slot="label">Select input</span>
 					{this.values.map((value, index) => (
 						<smoothly-item value={index} selected={index == this.selectIndex}>
@@ -69,7 +69,7 @@ export class SmoothlyInputDemoUserInput {
 					looks="border"
 					name="demo-user-input-checkbox"
 					checked={this.checkboxChecked}
-					onSmoothlyUserInput={e => console.debug("smoothlyUserInput", e.detail.name, e.detail.value)}>
+					onSmoothlyUserInput={e => console.debug(e.type, e.detail.name, e.detail.value)}>
 					Checkbox input
 				</smoothly-input-checkbox>
 
@@ -80,7 +80,7 @@ export class SmoothlyInputDemoUserInput {
 				<smoothly-input-radio
 					looks="border"
 					name="demo-user-input-radio"
-					onSmoothlyUserInput={e => console.debug("smoothlyUserInput", e.detail.name, e.detail.value)}>
+					onSmoothlyUserInput={e => console.debug(e.type, e.detail.name, e.detail.value)}>
 					<span slot="label">Radio input</span>
 					{this.values.map((value, index) => (
 						<smoothly-input-radio-item value={value} selected={index == this.radioIndex}>
@@ -102,7 +102,7 @@ export class SmoothlyInputDemoUserInput {
 					max={this.values.length}
 					value={this.rangeValue}
 					label={"Range Input"}
-					onSmoothlyUserInput={e => console.debug("smoothlyInputUserInput", e.detail.name, e.detail.value)}
+					onSmoothlyUserInput={e => console.debug(e.type, e.detail.name, e.detail.value)}
 				/>
 
 				<smoothly-button color="tertiary" onClick={() => (this.colorIndex = this.increment(this.colorIndex))}>
@@ -112,7 +112,7 @@ export class SmoothlyInputDemoUserInput {
 					looks="border"
 					name="demo-user-input-color"
 					value={typeof this.colorIndex == "number" ? this.colors[this.colorIndex] : undefined}
-					onSmoothlyUserInput={e => console.debug("smoothlyUserInput", e.detail.name, e.detail.value)}>
+					onSmoothlyUserInput={e => console.debug(e.type, e.detail.name, e.detail.value)}>
 					Color input
 				</smoothly-input-color>
 
@@ -125,7 +125,7 @@ export class SmoothlyInputDemoUserInput {
 					looks="border"
 					name="demo-user-input-date"
 					value={this.dateValue}
-					onSmoothlyUserInput={e => console.debug("smoothlyUserInput", e.detail.name, e.detail.value)}>
+					onSmoothlyUserInput={e => console.debug(e.type, e.detail.name, e.detail.value)}>
 					Date input
 				</smoothly-input-date>
 
@@ -142,7 +142,7 @@ export class SmoothlyInputDemoUserInput {
 					looks="border"
 					name="demo-user-input-datetime"
 					value={this.datetimeValue}
-					onSmoothlyUserInput={e => console.debug("smoothlyUserInput", e.detail.name, e.detail.value)}>
+					onSmoothlyUserInput={e => console.debug(e.type, e.detail.name, e.detail.value)}>
 					Date time input
 				</smoothly-input-date-time>
 
@@ -160,7 +160,7 @@ export class SmoothlyInputDemoUserInput {
 					name="demo-user-input-daterange"
 					start={this.dateRangeValue?.start}
 					end={this.dateRangeValue?.end}
-					onSmoothlyUserInput={e => console.debug("smoothlyUserInput", e.detail.name, e.detail.value)}>
+					onSmoothlyUserInput={e => console.debug(e.type, e.detail.name, e.detail.value)}>
 					Date range input
 				</smoothly-input-date-range>
 			</Host>

--- a/src/components/input/demo/user-input/index.tsx
+++ b/src/components/input/demo/user-input/index.tsx
@@ -1,4 +1,5 @@
 import { Component, h, Host, State } from "@stencil/core"
+import { isoly } from "isoly"
 
 @Component({
 	tag: "smoothly-input-demo-user-input",
@@ -13,6 +14,9 @@ export class SmoothlyInputDemoUserInput {
 	@State() rangeValue?: number
 	private readonly colors = ["#ff0000", "#00ff00", "#0000ff", "#ffff00", "#00ffff", "#ff00ff"]
 	@State() colorIndex?: number
+	@State() dateValue?: isoly.Date
+	@State() datetimeValue?: isoly.DateTime
+	@State() dateRangeValue?: isoly.DateRange
 
 	increment(index?: number): number {
 		return index === undefined ? 0 : (index + 1) % this.values.length
@@ -102,6 +106,18 @@ export class SmoothlyInputDemoUserInput {
 					onSmoothlyUserInput={e => console.debug("smoothlyUserInput", e.detail.name, e.detail.value)}>
 					Color input
 				</smoothly-input-color>
+
+				<smoothly-button
+					color="primary"
+					onClick={() => (this.dateValue = this.dateValue ? isoly.Date.next(this.dateValue) : isoly.Date.now())}>
+					Next day
+				</smoothly-button>
+				<smoothly-input-date
+					name="demo-user-input-date"
+					value={this.dateValue}
+					onSmoothlyUserInput={e => console.debug("smoothlyUserInput", e.detail.name, e.detail.value)}>
+					Date input
+				</smoothly-input-date>
 			</Host>
 		)
 	}

--- a/src/components/input/demo/user-input/index.tsx
+++ b/src/components/input/demo/user-input/index.tsx
@@ -1,0 +1,80 @@
+import { Component, h, Host, State } from "@stencil/core"
+
+@Component({
+	tag: "smoothly-input-demo-user-input",
+	scoped: true,
+})
+export class SmoothlyInputDemoUserInput {
+	private readonly values = ["zero", "one", "two", "three", "four", "five"]
+	@State() textIndex?: number
+	@State() selectIndex?: number
+	@State() checkboxChecked: boolean
+	@State() radioIndex?: number
+
+	nextIndex(index?: number): number {
+		return index === undefined ? 0 : (index + 1) % this.values.length
+	}
+
+	render() {
+		return (
+			<Host>
+				<h2>User Input</h2>
+				<p>
+					These inputs demonstrate how user input is handled. The <code>smoothlyUserInput</code> event fires only when
+					the user interacts with an input, not when its value is changed programmatically (such as by clicking the
+					buttons above).
+					<br />
+					Check the console to see the details of each <code>smoothlyUserInput</code> event.
+				</p>
+				<smoothly-button color="primary" onClick={() => (this.textIndex = this.nextIndex(this.textIndex))}>
+					Change text
+				</smoothly-button>
+				<smoothly-input
+					name="demo-user-input-text"
+					value={this.textIndex === undefined ? "" : this.values[this.textIndex]}
+					onSmoothlyUserInput={e => console.debug("smoothlyUserInput", e.detail.name, e.detail.value)}>
+					Text input
+				</smoothly-input>
+
+				<smoothly-button onClick={() => (this.selectIndex = this.nextIndex(this.selectIndex))} color="primary">
+					Next select item
+				</smoothly-button>
+				<smoothly-input-select
+					name="demo-user-input-select"
+					onSmoothlyUserInput={e => console.debug("smoothlyUserInput", e.detail.name, e.detail.value)}>
+					<span slot="label">Select input</span>
+					{this.values.map((value, index) => (
+						<smoothly-item value={index} selected={index == this.selectIndex}>
+							{value}
+						</smoothly-item>
+					))}
+				</smoothly-input-select>
+
+				<smoothly-button color="primary" onClick={() => (this.checkboxChecked = !this.checkboxChecked)}>
+					Toggle checkbox
+				</smoothly-button>
+				<smoothly-input-checkbox
+					name="demo-user-input-checkbox"
+					checked={this.checkboxChecked}
+					onSmoothlyUserInput={e => console.debug("smoothlyUserInput", e.detail.name, e.detail.value)}>
+					Checkbox input
+				</smoothly-input-checkbox>
+
+				<smoothly-button color="primary" onClick={() => (this.radioIndex = this.nextIndex(this.radioIndex))}>
+					Next radio item
+				</smoothly-button>
+				{/* Bug: radio has bugs when changing programmatically - TODO: change to using a regular radio input as underlying controls */}
+				<smoothly-input-radio
+					name="demo-user-input-radio"
+					onSmoothlyUserInput={e => console.debug("smoothlyUserInput", e.detail.name, e.detail.value)}>
+					<span slot="label">Radio input</span>
+					{this.values.map((value, index) => (
+						<smoothly-input-radio-item value={value} selected={index == this.radioIndex}>
+							{value}
+						</smoothly-input-radio-item>
+					))}
+				</smoothly-input-radio>
+			</Host>
+		)
+	}
+}

--- a/src/components/input/demo/user-input/index.tsx
+++ b/src/components/input/demo/user-input/index.tsx
@@ -134,6 +134,23 @@ export class SmoothlyInputDemoUserInput {
 					onSmoothlyUserInput={e => console.debug("smoothlyUserInput", e.detail.name, e.detail.value)}>
 					Date time input
 				</smoothly-input-date-time>
+
+				<smoothly-button
+					color="primary"
+					onClick={() =>
+						(this.dateRangeValue = this.dateRangeValue
+							? { start: isoly.Date.next(this.dateRangeValue.start), end: isoly.Date.next(this.dateRangeValue.end) }
+							: { start: isoly.Date.now(), end: isoly.Date.next(isoly.Date.now(), 10) })
+					}>
+					Next date range
+				</smoothly-button>
+				<smoothly-input-date-range
+					name="demo-user-input-daterange"
+					start={this.dateRangeValue?.start}
+					end={this.dateRangeValue?.end}
+					onSmoothlyUserInput={e => console.debug("smoothlyUserInput", e.detail.name, e.detail.value)}>
+					Date range input
+				</smoothly-input-date-range>
 			</Host>
 		)
 	}

--- a/src/components/input/demo/user-input/index.tsx
+++ b/src/components/input/demo/user-input/index.tsx
@@ -118,6 +118,22 @@ export class SmoothlyInputDemoUserInput {
 					onSmoothlyUserInput={e => console.debug("smoothlyUserInput", e.detail.name, e.detail.value)}>
 					Date input
 				</smoothly-input-date>
+
+				<smoothly-button
+					color="primary"
+					onClick={() =>
+						(this.datetimeValue = this.datetimeValue
+							? isoly.DateTime.nextDay(this.datetimeValue)
+							: isoly.DateTime.now())
+					}>
+					Next date time
+				</smoothly-button>
+				<smoothly-input-date-time
+					name="demo-user-input-datetime"
+					value={this.datetimeValue}
+					onSmoothlyUserInput={e => console.debug("smoothlyUserInput", e.detail.name, e.detail.value)}>
+					Date time input
+				</smoothly-input-date-time>
 			</Host>
 		)
 	}

--- a/src/components/input/demo/user-input/index.tsx
+++ b/src/components/input/demo/user-input/index.tsx
@@ -10,8 +10,9 @@ export class SmoothlyInputDemoUserInput {
 	@State() selectIndex?: number
 	@State() checkboxChecked: boolean
 	@State() radioIndex?: number
+	@State() rangeValue?: number
 
-	nextIndex(index?: number): number {
+	increment(index?: number): number {
 		return index === undefined ? 0 : (index + 1) % this.values.length
 	}
 
@@ -26,7 +27,7 @@ export class SmoothlyInputDemoUserInput {
 					<br />
 					Check the console to see the details of each <code>smoothlyUserInput</code> event.
 				</p>
-				<smoothly-button color="primary" onClick={() => (this.textIndex = this.nextIndex(this.textIndex))}>
+				<smoothly-button color="primary" onClick={() => (this.textIndex = this.increment(this.textIndex))}>
 					Change text
 				</smoothly-button>
 				<smoothly-input
@@ -36,7 +37,7 @@ export class SmoothlyInputDemoUserInput {
 					Text input
 				</smoothly-input>
 
-				<smoothly-button onClick={() => (this.selectIndex = this.nextIndex(this.selectIndex))} color="primary">
+				<smoothly-button onClick={() => (this.selectIndex = this.increment(this.selectIndex))} color="primary">
 					Next select item
 				</smoothly-button>
 				<smoothly-input-select
@@ -60,10 +61,10 @@ export class SmoothlyInputDemoUserInput {
 					Checkbox input
 				</smoothly-input-checkbox>
 
-				<smoothly-button color="primary" onClick={() => (this.radioIndex = this.nextIndex(this.radioIndex))}>
+				<smoothly-button color="primary" onClick={() => (this.radioIndex = this.increment(this.radioIndex))}>
 					Next radio item
 				</smoothly-button>
-				{/* Bug: radio has bugs when changing programmatically - TODO: change to using a regular radio input as underlying controls */}
+				{/* Bug: radio has bugs when changing programmatically - TODO: consider changing to using a regular radio input as underlying controls */}
 				<smoothly-input-radio
 					name="demo-user-input-radio"
 					onSmoothlyUserInput={e => console.debug("smoothlyUserInput", e.detail.name, e.detail.value)}>
@@ -74,6 +75,21 @@ export class SmoothlyInputDemoUserInput {
 						</smoothly-input-radio-item>
 					))}
 				</smoothly-input-radio>
+
+				{/* Not sure how to test smoothly-input-file */}
+
+				<smoothly-button color="primary" onClick={() => (this.rangeValue = this.increment(this.rangeValue))}>
+					Next range value
+				</smoothly-button>
+				<smoothly-input-range
+					name="demo-user-input-range"
+					step={1}
+					min={0}
+					max={this.values.length}
+					value={this.rangeValue}
+					onSmoothlyUserInput={e => console.debug("smoothlyInputUserInput", e.detail.name, e.detail.value)}>
+					<span slot="label">Range input</span>
+				</smoothly-input-range>
 			</Host>
 		)
 	}

--- a/src/components/input/demo/user-input/index.tsx
+++ b/src/components/input/demo/user-input/index.tsx
@@ -36,7 +36,7 @@ export class SmoothlyInputDemoUserInput {
 						Check the console to see the details of each <code>smoothlyUserInput</code> event.
 					</p>
 				</div>
-				<smoothly-button color="primary" onClick={() => (this.textIndex = this.increment(this.textIndex))}>
+				<smoothly-button color="tertiary" onClick={() => (this.textIndex = this.increment(this.textIndex))}>
 					Change text
 				</smoothly-button>
 				<smoothly-input
@@ -47,7 +47,7 @@ export class SmoothlyInputDemoUserInput {
 					Text input
 				</smoothly-input>
 
-				<smoothly-button onClick={() => (this.selectIndex = this.increment(this.selectIndex))} color="primary">
+				<smoothly-button onClick={() => (this.selectIndex = this.increment(this.selectIndex))} color="tertiary">
 					Next select item
 				</smoothly-button>
 				<smoothly-input-select
@@ -62,7 +62,7 @@ export class SmoothlyInputDemoUserInput {
 					))}
 				</smoothly-input-select>
 
-				<smoothly-button color="primary" onClick={() => (this.checkboxChecked = !this.checkboxChecked)}>
+				<smoothly-button color="tertiary" onClick={() => (this.checkboxChecked = !this.checkboxChecked)}>
 					Toggle checkbox
 				</smoothly-button>
 				<smoothly-input-checkbox
@@ -73,7 +73,7 @@ export class SmoothlyInputDemoUserInput {
 					Checkbox input
 				</smoothly-input-checkbox>
 
-				<smoothly-button color="primary" onClick={() => (this.radioIndex = this.increment(this.radioIndex))}>
+				<smoothly-button color="tertiary" onClick={() => (this.radioIndex = this.increment(this.radioIndex))}>
 					Next radio item
 				</smoothly-button>
 				{/* Bug: radio has bugs when changing programmatically - TODO: consider changing to using a regular radio input as underlying controls */}
@@ -91,7 +91,7 @@ export class SmoothlyInputDemoUserInput {
 
 				{/* Not sure how to test smoothly-input-file */}
 
-				<smoothly-button color="primary" onClick={() => (this.rangeValue = this.increment(this.rangeValue))}>
+				<smoothly-button color="tertiary" onClick={() => (this.rangeValue = this.increment(this.rangeValue))}>
 					Next range value
 				</smoothly-button>
 				<smoothly-input-range
@@ -105,7 +105,7 @@ export class SmoothlyInputDemoUserInput {
 					onSmoothlyUserInput={e => console.debug("smoothlyInputUserInput", e.detail.name, e.detail.value)}
 				/>
 
-				<smoothly-button color="primary" onClick={() => (this.colorIndex = this.increment(this.colorIndex))}>
+				<smoothly-button color="tertiary" onClick={() => (this.colorIndex = this.increment(this.colorIndex))}>
 					Next color
 				</smoothly-button>
 				<smoothly-input-color
@@ -117,7 +117,7 @@ export class SmoothlyInputDemoUserInput {
 				</smoothly-input-color>
 
 				<smoothly-button
-					color="primary"
+					color="tertiary"
 					onClick={() => (this.dateValue = this.dateValue ? isoly.Date.next(this.dateValue) : isoly.Date.now())}>
 					Next day
 				</smoothly-button>
@@ -130,7 +130,7 @@ export class SmoothlyInputDemoUserInput {
 				</smoothly-input-date>
 
 				<smoothly-button
-					color="primary"
+					color="tertiary"
 					onClick={() =>
 						(this.datetimeValue = this.datetimeValue
 							? isoly.DateTime.nextDay(this.datetimeValue)
@@ -147,7 +147,7 @@ export class SmoothlyInputDemoUserInput {
 				</smoothly-input-date-time>
 
 				<smoothly-button
-					color="primary"
+					color="tertiary"
 					onClick={() =>
 						(this.dateRangeValue = this.dateRangeValue
 							? { start: isoly.Date.next(this.dateRangeValue.start), end: isoly.Date.next(this.dateRangeValue.end) }

--- a/src/components/input/demo/user-input/index.tsx
+++ b/src/components/input/demo/user-input/index.tsx
@@ -27,7 +27,7 @@ export class SmoothlyInputDemoUserInput {
 		return (
 			<Host>
 				<div>
-					<h2>User Input</h2>
+					<h2>User Input Event</h2>
 					<p>
 						These inputs demonstrate how user input is handled. The <code>smoothlyUserInput</code> event fires only when
 						the user interacts with an input, not when its value is changed programmatically (such as by clicking the

--- a/src/components/input/demo/user-input/index.tsx
+++ b/src/components/input/demo/user-input/index.tsx
@@ -11,6 +11,8 @@ export class SmoothlyInputDemoUserInput {
 	@State() checkboxChecked: boolean
 	@State() radioIndex?: number
 	@State() rangeValue?: number
+	private readonly colors = ["#ff0000", "#00ff00", "#0000ff", "#ffff00", "#00ffff", "#ff00ff"]
+	@State() colorIndex?: number
 
 	increment(index?: number): number {
 		return index === undefined ? 0 : (index + 1) % this.values.length
@@ -87,9 +89,19 @@ export class SmoothlyInputDemoUserInput {
 					min={0}
 					max={this.values.length}
 					value={this.rangeValue}
-					onSmoothlyUserInput={e => console.debug("smoothlyInputUserInput", e.detail.name, e.detail.value)}>
-					<span slot="label">Range input</span>
-				</smoothly-input-range>
+					label={"Range Input"}
+					onSmoothlyUserInput={e => console.debug("smoothlyInputUserInput", e.detail.name, e.detail.value)}
+				/>
+
+				<smoothly-button color="primary" onClick={() => (this.colorIndex = this.increment(this.colorIndex))}>
+					Next color
+				</smoothly-button>
+				<smoothly-input-color
+					name="demo-user-input-color"
+					value={typeof this.colorIndex == "number" ? this.colors[this.colorIndex] : undefined}
+					onSmoothlyUserInput={e => console.debug("smoothlyUserInput", e.detail.name, e.detail.value)}>
+					Color input
+				</smoothly-input-color>
 			</Host>
 		)
 	}

--- a/src/components/input/demo/user-input/style.css
+++ b/src/components/input/demo/user-input/style.css
@@ -1,5 +1,5 @@
 :host {
-	max-width: min(100%, 48rem);
+	max-width: min(100%, 56rem);
 	margin-inline: auto;
 	display: grid;
 	grid-template-columns: 12rem 1fr;

--- a/src/components/input/demo/user-input/style.css
+++ b/src/components/input/demo/user-input/style.css
@@ -1,0 +1,10 @@
+:host {
+	max-width: min(100%, 48rem);
+	margin-inline: auto;
+	display: grid;
+	grid-template-columns: 12rem 1fr;
+	gap: 1rem;
+}
+:host > div {
+	grid-column: 1 / -1;
+}

--- a/src/components/input/file/index.tsx
+++ b/src/components/input/file/index.tsx
@@ -40,6 +40,7 @@ export class SmoothlyInputFile implements ComponentWillLoad, Input, Clearable, E
 	@State() dragging = false
 	@Event() smoothlyInputLooks: EventEmitter<(looks?: Looks, color?: Color) => void>
 	@Event() smoothlyInput: EventEmitter<Record<string, any>>
+	@Event() smoothlyUserInput: EventEmitter<Input.UserInput>
 	@Event() smoothlyInputLoad: EventEmitter<(parent: Editable) => void>
 	@Event() smoothlyFormDisable: EventEmitter<(disabled: boolean) => void>
 	parent: Editable | undefined
@@ -122,15 +123,19 @@ export class SmoothlyInputFile implements ComponentWillLoad, Input, Clearable, E
 
 	inputHandler(event: Event): void {
 		event.stopPropagation()
-		if (this.input?.files?.length)
+		if (this.input?.files?.length) {
 			this.value = this.input?.files[0]
+			this.smoothlyUserInput.emit({ name: this.name, value: this.value })
+		}
 	}
 	dropHandler(event: DragEvent): void {
 		event.preventDefault()
 		event.stopPropagation()
 		this.dragging = false
-		if (event.dataTransfer?.files.length)
+		if (event.dataTransfer?.files.length) {
 			this.value = event.dataTransfer.files[0]
+			this.smoothlyUserInput.emit({ name: this.name, value: this.value })
+		}
 	}
 	clickHandler(event: MouseEvent): void {
 		if (!this.readonly && !this.disabled && !event.composedPath().find(target => target == this.input)) {

--- a/src/components/input/index.tsx
+++ b/src/components/input/index.tsx
@@ -53,6 +53,7 @@ export class SmoothlyInput implements Clearable, Input, Editable {
 	@Event() smoothlyBlur: EventEmitter<void>
 	@Event() smoothlyChange: EventEmitter<Record<string, any>>
 	@Event() smoothlyInput: EventEmitter<Record<string, any>>
+	@Event() smoothlyUserInput: EventEmitter<Input.UserInput>
 
 	@Method()
 	async getValue(): Promise<any | undefined> {
@@ -209,8 +210,9 @@ export class SmoothlyInput implements Clearable, Input, Editable {
 						disabled={this.disabled}
 						readOnly={this.readonly}
 						pattern={this.state?.pattern && this.state?.pattern.source}
-						onKeyDown={event => {
+						onKeyDown={async event => {
 							this.state = this.stateHandler.onKeyDown(event, this.state)
+							this.smoothlyUserInput.emit({ name: this.name, value: await this.getValue() })
 							if (!this.readonly && !this.disabled)
 								this.smoothlyKeydown.emit(Key.create(this.name, event))
 						}}

--- a/src/components/input/index.tsx
+++ b/src/components/input/index.tsx
@@ -224,8 +224,10 @@ export class SmoothlyInput implements Clearable, Input, Editable {
 								this.state = this.stateHandler.onBlur(event, this.state)
 								this.smoothlyBlur.emit()
 								this.smoothlyInput.emit({ [this.name]: this.stateHandler.getValue(this.state) })
-								if (Deep.notEqual(lastValue, this.stateHandler.getValue(this.state)))
+								if (Deep.notEqual(lastValue, this.stateHandler.getValue(this.state))) {
 									this.smoothlyChange.emit({ [this.name]: this.stateHandler.getValue(this.state) })
+									this.smoothlyUserInput.emit({ name: this.name, value: this.stateHandler.getValue(this.state) })
+								}
 							}
 						}}
 					/>

--- a/src/components/input/index.tsx
+++ b/src/components/input/index.tsx
@@ -180,6 +180,8 @@ export class SmoothlyInput implements Clearable, Input, Editable {
 	@Listen("beforeinput")
 	onEvent(event: InputEvent) {
 		this.state = this.stateHandler.onInputEvent(event, this.state)
+		if (event.type == "input" || event.defaultPrevented)
+			this.smoothlyUserInput.emit({ name: this.name, value: this.stateHandler.getValue(this.state) })
 	}
 	copyText(value?: string) {
 		if (value) {
@@ -212,7 +214,6 @@ export class SmoothlyInput implements Clearable, Input, Editable {
 						pattern={this.state?.pattern && this.state?.pattern.source}
 						onKeyDown={async event => {
 							this.state = this.stateHandler.onKeyDown(event, this.state)
-							this.smoothlyUserInput.emit({ name: this.name, value: await this.getValue() })
 							if (!this.readonly && !this.disabled)
 								this.smoothlyKeydown.emit(Key.create(this.name, event))
 						}}

--- a/src/components/input/month/index.tsx
+++ b/src/components/input/month/index.tsx
@@ -44,6 +44,7 @@ export class SmoothlyInputMonth implements ComponentWillLoad, Input, Editable {
 	@State() allowPreviousMonth = true
 	@State() allowNextMonth = true
 	@Event() smoothlyInput: EventEmitter<Data>
+	@Event() smoothlyUserInput: EventEmitter<Input.UserInput>
 	@Event() smoothlyInputLoad: EventEmitter<(parent: Editable) => void>
 	@Event() smoothlyFormDisable: EventEmitter<(disabled: boolean) => void>
 	@Event() smoothlyInputLooks: EventEmitter<(looks?: Looks, color?: Color) => void>
@@ -173,6 +174,13 @@ export class SmoothlyInputMonth implements ComponentWillLoad, Input, Editable {
 					inCalendar={this.inCalendar}
 					showLabel={this.showLabel}
 					onSmoothlyInput={e => this.inputHandler(e)}
+					onSmoothlyUserInput={e => {
+						const month = e.detail.value
+						if (month && isoly.Date.is(month)) {
+							const value = isoly.Date.firstOfMonth(month)
+							this.smoothlyUserInput.emit({ name: this.name, value })
+						}
+					}}
 					searchDisabled>
 					<div slot={"label"}>
 						<slot name={"year-label"} />
@@ -196,6 +204,13 @@ export class SmoothlyInputMonth implements ComponentWillLoad, Input, Editable {
 					inCalendar={this.inCalendar}
 					showLabel={this.showLabel}
 					onSmoothlyInput={e => this.inputHandler(e)}
+					onSmoothlyUserInput={e => {
+						const year = e.detail.value
+						if (year && isoly.Date.is(year)) {
+							const value = isoly.Date.firstOfMonth(year)
+							this.smoothlyUserInput.emit({ name: this.name, value })
+						}
+					}}
 					searchDisabled>
 					<div slot={"label"}>
 						<slot name={"month-label"} />
@@ -211,9 +226,7 @@ export class SmoothlyInputMonth implements ComponentWillLoad, Input, Editable {
 					size={"tiny"}
 					color={this.color}
 					fill={"default"}
-					class={{
-						disabled: this.readonly || !this.allowNextMonth,
-					}}
+					class={{ disabled: this.readonly || !this.allowNextMonth }}
 					onClick={() => this.allowNextMonth && this.adjustMonth(1)}
 				/>
 			</Host>

--- a/src/components/input/radio/RadioItemSelect.ts
+++ b/src/components/input/radio/RadioItemSelect.ts
@@ -1,16 +1,18 @@
 import { isly } from "isly"
 
-export interface Selectable {
+export interface RadioItemSelect {
 	value: any
 	selected: boolean
 	select: (selected: boolean) => void
+	userInitiated: boolean
 }
 
 export namespace Selected {
-	export const type = isly.object<Selectable>({
+	export const type = isly.object<RadioItemSelect>({
 		value: isly.any(),
 		selected: isly.boolean(),
 		select: isly.function(),
+		userInitiated: isly.boolean(),
 	})
 	export const is = type.is
 }

--- a/src/components/input/radio/index.tsx
+++ b/src/components/input/radio/index.tsx
@@ -17,7 +17,7 @@ import { Clearable } from "../Clearable"
 import { Editable } from "../Editable"
 import { Input } from "../Input"
 import { Looks } from "../Looks"
-import { Selectable } from "./Selected"
+import { RadioItemSelect } from "./RadioItemSelect"
 
 @Component({
 	tag: "smoothly-input-radio",
@@ -27,10 +27,10 @@ import { Selectable } from "./Selected"
 export class SmoothlyInputRadio implements Input, Clearable, Editable, ComponentWillLoad {
 	@Element() element: HTMLSmoothlyInputRadioElement
 	parent: Editable | undefined
-	private active?: Selectable
+	private active?: RadioItemSelect
 	private valueReceivedOnLoad = false
 	private observer = Editable.Observer.create(this)
-	initialValue?: Selectable
+	initialValue?: RadioItemSelect
 	@Prop({ mutable: true }) changed = false
 	@Prop({ mutable: true }) value: any = undefined
 	@Prop({ mutable: true, reflect: true }) looks?: Looks
@@ -42,6 +42,7 @@ export class SmoothlyInputRadio implements Input, Clearable, Editable, Component
 	@Prop({ reflect: true }) showLabel = true
 	@Event() smoothlyInputLooks: EventEmitter<(looks?: Looks, color?: Color) => void>
 	@Event() smoothlyInput: EventEmitter<Data>
+	@Event() smoothlyUserInput: EventEmitter<Input.UserInput>
 	@Event() smoothlyInputLoad: EventEmitter<(parent: Editable) => void>
 	@Event() smoothlyFormDisable: EventEmitter<(disabled: boolean) => void>
 	componentWillLoad(): void | Promise<void> {
@@ -63,8 +64,8 @@ export class SmoothlyInputRadio implements Input, Clearable, Editable, Component
 	smoothlyInputLoadHandler(event: CustomEvent<(parent: SmoothlyInputRadio) => void>): void {
 		Input.registerSubAction(this, event)
 	}
-	@Listen("smoothlySelect")
-	smoothlyRadioInputHandler(event: CustomEvent<Selectable>): void {
+	@Listen("smoothlyRadioItemSelect")
+	smoothlyRadioInputHandler(event: CustomEvent<RadioItemSelect>): void {
 		event.stopPropagation()
 		if ((!this.readonly && !this.disabled) || !this.valueReceivedOnLoad) {
 			if (this.clearable && this.active?.value === event.detail.value)
@@ -76,6 +77,8 @@ export class SmoothlyInputRadio implements Input, Clearable, Editable, Component
 				this.active.select(true)
 			}
 		}
+		if (event.detail.userInitiated)
+			this.smoothlyUserInput.emit({ name: this.name, value: this.value })
 		!this.valueReceivedOnLoad && (this.valueReceivedOnLoad = !this.valueReceivedOnLoad)
 	}
 	@Method()

--- a/src/components/input/radio/item/index.tsx
+++ b/src/components/input/radio/item/index.tsx
@@ -2,7 +2,7 @@ import { Component, Element, Event, EventEmitter, h, Host, Prop, State, VNode } 
 import { Input } from "../../Input"
 import { Looks } from "../../Looks"
 import { SmoothlyInputRadio } from "../index"
-import { Selectable } from "../Selected"
+import { RadioItemSelect } from "../RadioItemSelect"
 
 @Component({
 	tag: "smoothly-input-radio-item",
@@ -16,7 +16,7 @@ export class SmoothlyInputRadioItem {
 	@Prop({ mutable: true, reflect: true }) looks?: Looks
 	@Prop({ mutable: true }) name: string
 	@State() disabled?: boolean
-	@Event() smoothlySelect: EventEmitter<Selectable>
+	@Event() smoothlyRadioItemSelect: EventEmitter<RadioItemSelect>
 	@Event() smoothlyRadioItemRegister: EventEmitter<(parent: SmoothlyInputRadio) => void>
 	componentWillLoad(): void | Promise<void> {
 		this.smoothlyRadioItemRegister.emit(parent => {
@@ -26,15 +26,20 @@ export class SmoothlyInputRadioItem {
 					this.disabled = p.disabled
 			})
 		})
-		this.selected && this.inputHandler()
+		this.selected && this.inputHandler(false)
 	}
-	inputHandler(): void {
-		this.smoothlySelect.emit({ value: this.value, selected: this.selected, select: s => (this.selected = s) })
+	inputHandler(userInitiated: boolean): void {
+		this.smoothlyRadioItemSelect.emit({
+			value: this.value,
+			selected: this.selected,
+			select: s => (this.selected = s),
+			userInitiated,
+		})
 	}
 
 	render(): VNode | VNode[] {
 		return (
-			<Host onClick={() => this.inputHandler()}>
+			<Host onClick={() => this.inputHandler(true)}>
 				<input name={this.name} type="radio" checked={this.selected} disabled={this.disabled} />
 				<smoothly-icon name={this.selected ? "checkmark-circle" : "ellipse-outline"} size="small" tooltip="Select" />
 				<label>

--- a/src/components/input/range/index.tsx
+++ b/src/components/input/range/index.tsx
@@ -163,7 +163,6 @@ export class SmoothlyInputRange implements Input, Clearable, Editable, Component
 						onSmoothlyInput={async e => {
 							e.stopPropagation()
 							this.setValue(Input.Element.is(e.target) ? Number(await e.target.getValue()) : undefined)
-							this.smoothlyUserInput.emit({ name: this.name, value: this.value })
 						}}
 						value={this.type == "percent" ? this.value : this.value?.toString()}
 						placeholder={this.outputSide === "right" ? "-" : undefined}

--- a/src/components/input/range/index.tsx
+++ b/src/components/input/range/index.tsx
@@ -48,6 +48,7 @@ export class SmoothlyInputRange implements Input, Clearable, Editable, Component
 	@State() showInput = false
 	@Event() smoothlyInputLooks: EventEmitter<(looks?: Looks, color?: Color) => void>
 	@Event() smoothlyInput: EventEmitter<Record<string, any>>
+	@Event() smoothlyUserInput: EventEmitter<Input.UserInput>
 	@Event() smoothlyInputLoad: EventEmitter<(parent: Editable) => void>
 	@Event() smoothlyFormDisable: EventEmitter<(disabled: boolean) => void>
 	componentWillLoad(): void | Promise<void> {
@@ -162,6 +163,7 @@ export class SmoothlyInputRange implements Input, Clearable, Editable, Component
 						onSmoothlyInput={async e => {
 							e.stopPropagation()
 							this.setValue(Input.Element.is(e.target) ? Number(await e.target.getValue()) : undefined)
+							this.smoothlyUserInput.emit({ name: this.name, value: this.value })
 						}}
 						value={this.type == "percent" ? this.value : this.value?.toString()}
 						placeholder={this.outputSide === "right" ? "-" : undefined}
@@ -181,6 +183,7 @@ export class SmoothlyInputRange implements Input, Clearable, Editable, Component
 						onInput={event => {
 							event.stopPropagation()
 							this.setValue((event.target as HTMLInputElement).valueAsNumber)
+							this.smoothlyUserInput.emit({ name: this.name, value: this.value })
 						}}
 						value={this.value ?? this.min}
 					/>

--- a/src/components/input/select/index.tsx
+++ b/src/components/input/select/index.tsx
@@ -219,7 +219,8 @@ export class SmoothlyInputSelect implements Input, Editable, Clearable, Componen
 			!this.showSelected && item.selected && (item.hidden = true)
 		}
 		this.displaySelected()
-		this.smoothlyUserInput.emit({ name: this.name, value: await this.getValue() })
+		if (event.detail.userInitiated)
+			this.smoothlyUserInput.emit({ name: this.name, value: await this.getValue() })
 	}
 	@Watch("open")
 	onClosed(open: boolean, before: boolean): void {


### PR DESCRIPTION
`smoothlyUserInput` only when the user interacts with the input (just like regular input events).

## Motivation
`smoothlyInput` is poorly suited for listening to directly, since it emits for any change (regardless if it was user- or code-initiated). But `smoothlyInput` is still needed for smoothly-form to function correctly.

`smoothlyUserInput` will emit `{ name: string, value: any }` which is nicer to handle when when directly listening to an input.

## Future improvement / Current flaw
Currently and `smoothly-input-clear`/`smoothly-input-reset` inside or outside an input does trigger `smoothlyUserInput`, which it probably should. However this does not mean that `clear` and `reset` methods should trigger userInput since they can also be used programmatically.


## Demo for smoothlyUserInput

<img width="1281" height="770" alt="image" src="https://github.com/user-attachments/assets/ece630e6-b096-4f6c-ad96-523ab73ad24b" />


## input-radio bug
`smoothly-input-radio` is buggy when changing programmatically. This needs to be fixed, probably by just high-jacking the behavior of a regular radio button instead of trying to control it ourselves.

