### PR TITLE
Make button height consistent

### DIFF
--- a/src/components/button/demo/index.tsx
+++ b/src/components/button/demo/index.tsx
@@ -17,10 +17,10 @@ export class SmoothlyButtonDemo {
 							Delete
 						</smoothly-button-confirm>
 						<smoothly-button-confirm name="confirm-icon" shape="rounded" color="success" size="icon">
-							<smoothly-icon name="checkmark-outline" size="tiny" />
+							<smoothly-icon name="checkmark-outline" />
 						</smoothly-button-confirm>
 						<smoothly-button-confirm name="confirm-icon" shape="rounded" color="danger" size="icon" fill="outline">
-							<smoothly-icon name="trash-outline" size="tiny" fill="outline" />
+							<smoothly-icon name="trash-outline" fill="outline" />
 						</smoothly-button-confirm>
 					</div>
 					<smoothly-toggle-switch-demo />

--- a/src/components/button/style.css
+++ b/src/components/button/style.css
@@ -52,8 +52,10 @@
 	min-width: 8rem;
 }
 
-:host(:not([size])),
 :host([size=small]) {
+	--button-font-size: 1rem;
+}
+:host(:not([size])) {
 	--button-font-size: 1.1rem;
 }
 :host([size=large]) {

--- a/src/components/button/style.css
+++ b/src/components/button/style.css
@@ -24,7 +24,7 @@
 
 :host>a,
 :host>button {
-	font-size: 110%;
+	font-size: var(--button-font-size);
 	font-weight: 400;
 	border: 1px solid transparent;
 	outline: none;
@@ -49,12 +49,51 @@
 }
 
 :host(:not([size=icon]):not([size=flexible]))>button {
-	padding: 0.8em;
-	min-width: 8em;
+	/* padding: calc(1rem - 1px); */
+	/* min-width: 8rem; */
 }
 
-:host(:not([size=icon]):not([size=flexible])):has(smoothly-icon)>button {
-	padding: 0.6em;
+:not(:not([size])),
+:host([size=small]) {
+	--button-font-size: 1.1rem;
+}
+:host([size=large]) {
+	--button-font-size: 1.1rem;
+}
+:host(:not([size=icon]):not([size=flexible])):has(smoothly-icon[size=tiny]) {
+	--smoothly-icon-size: 1rem;
+}
+:host([size=large]) {
+	--smoothly-icon-size: 1.25rem;
+}
+:host(:not([size=icon]):not([size=flexible])):has(smoothly-icon[size=small]) {
+	--smoothly-icon-size: 1.25rem;
+}
+:host(:not([size=icon]):not([size=flexible])):has(smoothly-icon),
+:host(:not([size=icon]):not([size=flexible])):has(smoothly-icon[size=medium]) {
+	--smoothly-icon-size: 1.75rem;
+}
+:host(:not([size=icon]):not([size=flexible])):has(smoothly-icon[size=tiny]) {
+	--smoothly-icon-size: 2.75rem;
+}
+:host(:not([size=icon]):not([size=flexible])):has(smoothly-icon[size=xlarge]) {
+	--smoothly-icon-size: 4rem;
+}
+:host,
+:host([size=small]) {
+	--target-height: 3rem;
+}
+:host([size=large]) {
+	--target-height: 4rem;
+}
+:host>button {
+	--content-height: var(--button-font-size, 0);
+	padding-block: calc(((var(--target-height) - var(--content-height)) / 2) - 1px);
+	padding-inline: 0.5rem;
+	min-width: 8rem;
+}
+:host:has(smoothly-icon)>button {
+	--content-height: var(var(--smoothly-icon-size));
 }
 
 :host([size=icon])>button {
@@ -64,15 +103,7 @@
 :host([type=button])>a {
 	text-align: center;
 	text-decoration: inherit;
-	width: calc(100% - 0.6em);
-}
-
-:host([size=small])>button {
-	font-size: 100%;
-}
-
-:host([size=large])>button {
-	font-size: 130%;
+	width: calc(100% - 0.5rem);
 }
 
 :host(:not([size=icon])) {

--- a/src/components/button/style.css
+++ b/src/components/button/style.css
@@ -52,15 +52,39 @@
 	min-width: 8rem;
 }
 
+:host([size=icon]) {
+	--target-height: 3rem;
+}
+:host([size=icon])>button {
+	padding: calc(((var(--target-height) - var(--content-height)) / 2) - 1px);
+}
+:host>button {
+	padding-block: calc(((var(--target-height) - var(--content-height)) / 2) - 1px);
+}
 :host([size=small]) {
 	--button-font-size: 1rem;
+	--target-height: 2.5rem;
 }
+:host([size=small])>button {
+	padding-inline: 0.75rem;
+}
+
 :host(:not([size])) {
 	--button-font-size: 1.1rem;
+	--target-height: 3rem;
 }
+:host(:not([size]))>button {
+	padding-inline: 1rem;
+}
+
 :host([size=large]) {
 	--button-font-size: 1.3rem;
+	--target-height: 3.5rem;
 }
+:host([size=large])>button {
+	padding-inline: 1.25rem;
+}
+
 :host(:not([size=flexible])):has(smoothly-icon[size=tiny]) {
 	--smoothly-icon-size: 1.2rem;
 }
@@ -77,30 +101,12 @@
 :host(:not([size=flexible])):has(smoothly-icon[size=xlarge]) {
 	--smoothly-icon-size: 4rem;
 }
-:host([size=small]) {
-	--target-height: 2.5rem;
-}
-:host {
-	--target-height: 3rem;
-}
-:host([size=large]) {
-	--target-height: 3.5rem;
-}
-:host([size=large])>button {
-	padding-inline: 1.25rem;
-}
+
 :host {
 	--content-height: var(--button-font-size, 0);
 }
 :host:has(smoothly-icon) {
 	--content-height: var(--smoothly-icon-size);
-}
-:host>button {
-	padding-block: calc(((var(--target-height) - var(--content-height)) / 2) - 1px);
-	padding-inline: 0.5rem;
-}
-:host([size=icon])>button {
-	padding-inline: calc(((var(--target-height) - var(--content-height)) / 2) - 1px);
 }
 
 :host([type=button])>a {
@@ -110,7 +116,7 @@
 }
 
 :host(:not([size=icon])) {
-	min-width: 8em;
+	min-width: 8rem;
 }
 
 :host([size=flexible]) {

--- a/src/components/button/style.css
+++ b/src/components/button/style.css
@@ -61,20 +61,17 @@
 	--button-font-size: 1.3rem;
 }
 :host(:not([size=icon]):not([size=flexible])):has(smoothly-icon[size=tiny]) {
-	--smoothly-icon-size: 1rem;
-}
-:host([size=large]) {
-	--smoothly-icon-size: 1.25rem;
+	--smoothly-icon-size: 1.2rem;
 }
 :host(:not([size=icon]):not([size=flexible])):has(smoothly-icon[size=small]) {
-	--smoothly-icon-size: 1.25rem;
+	--smoothly-icon-size: 1.4rem;
 }
 :host(:not([size=icon]):not([size=flexible])):has(smoothly-icon),
 :host(:not([size=icon]):not([size=flexible])):has(smoothly-icon[size=medium]) {
-	--smoothly-icon-size: 1.75rem;
+	--smoothly-icon-size: 1.8rem;
 }
 :host(:not([size=icon]):not([size=flexible])):has(smoothly-icon[size=tiny]) {
-	--smoothly-icon-size: 2.75rem;
+	--smoothly-icon-size: 2.8rem;
 }
 :host(:not([size=icon]):not([size=flexible])):has(smoothly-icon[size=xlarge]) {
 	--smoothly-icon-size: 4rem;
@@ -84,7 +81,10 @@
 	--target-height: 3rem;
 }
 :host([size=large]) {
-	--target-height: 4rem;
+	--target-height: 3.5rem;
+}
+:host([size=large])>button {
+	padding-inline: 1.25rem;
 }
 :host {
 	--content-height: var(--button-font-size, 0);

--- a/src/components/button/style.css
+++ b/src/components/button/style.css
@@ -53,12 +53,12 @@
 	/* min-width: 8rem; */
 }
 
-:not(:not([size])),
+:host(:not([size])),
 :host([size=small]) {
 	--button-font-size: 1.1rem;
 }
 :host([size=large]) {
-	--button-font-size: 1.1rem;
+	--button-font-size: 1.3rem;
 }
 :host(:not([size=icon]):not([size=flexible])):has(smoothly-icon[size=tiny]) {
 	--smoothly-icon-size: 1rem;

--- a/src/components/button/style.css
+++ b/src/components/button/style.css
@@ -115,10 +115,6 @@
 	width: calc(100% - 0.5rem);
 }
 
-:host(:not([size=icon])) {
-	min-width: 8rem;
-}
-
 :host([size=flexible]) {
 	min-width: unset;
 	padding: 0;

--- a/src/components/button/style.css
+++ b/src/components/button/style.css
@@ -88,15 +88,15 @@
 :host {
 	--content-height: var(--button-font-size, 0);
 }
+:host:has(smoothly-icon) {
+	--content-height: var(--smoothly-icon-size);
+}
 :host>button {
 	padding-block: calc(((var(--target-height) - var(--content-height)) / 2) - 1px);
 	padding-inline: 0.5rem;
 }
 :host([size=icon])>button {
 	padding-inline: calc(((var(--target-height) - var(--content-height)) / 2) - 1px);
-}
-:host:has(smoothly-icon) {
-	--content-height: var(--smoothly-icon-size);
 }
 
 :host([type=button])>a {

--- a/src/components/button/style.css
+++ b/src/components/button/style.css
@@ -69,7 +69,7 @@
 :host(:not([size=flexible])):has(smoothly-icon[size=medium]) {
 	--smoothly-icon-size: 1.8rem;
 }
-:host(:not([size=flexible])):has(smoothly-icon[size=tiny]) {
+:host(:not([size=flexible])):has(smoothly-icon[size=large]) {
 	--smoothly-icon-size: 2.8rem;
 }
 :host(:not([size=flexible])):has(smoothly-icon[size=xlarge]) {

--- a/src/components/button/style.css
+++ b/src/components/button/style.css
@@ -51,40 +51,14 @@
 :host(:not([size=icon]):not([size=flexible]))>button {
 	min-width: 8rem;
 }
-
-:host([size=icon]) {
-	--target-height: 3rem;
-}
-:host([size=icon])>button {
-	padding: calc(((var(--target-height) - var(--content-height)) / 2) - 1px);
+:host {
+	--content-height: var(--button-font-size, 0);
 }
 :host>button {
 	padding-block: calc(((var(--target-height) - var(--content-height)) / 2) - 1px);
 }
-:host([size=small]) {
-	--button-font-size: 1rem;
-	--target-height: 2.5rem;
-}
-:host([size=small])>button {
-	padding-inline: 0.75rem;
-}
 
-:host(:not([size])) {
-	--button-font-size: 1.1rem;
-	--target-height: 3rem;
-}
-:host(:not([size]))>button {
-	padding-inline: 1rem;
-}
-
-:host([size=large]) {
-	--button-font-size: 1.3rem;
-	--target-height: 3.5rem;
-}
-:host([size=large])>button {
-	padding-inline: 1.25rem;
-}
-
+/* icon */
 :host(:not([size=flexible])):has(smoothly-icon[size=tiny]) {
 	--smoothly-icon-size: 1.2rem;
 }
@@ -101,13 +75,43 @@
 :host(:not([size=flexible])):has(smoothly-icon[size=xlarge]) {
 	--smoothly-icon-size: 4rem;
 }
-
-:host {
-	--content-height: var(--button-font-size, 0);
+:host([size=icon]) {
+	--target-height: 3rem;
+}
+:host([size=icon])>button {
+	padding: calc(((var(--target-height) - var(--content-height)) / 2) - 1px);
 }
 :host:has(smoothly-icon) {
 	--content-height: var(--smoothly-icon-size);
 }
+
+/* small */
+:host([size=small]) {
+	--button-font-size: 1rem;
+	--target-height: 2.5rem;
+}
+:host([size=small])>button {
+	padding-inline: 0.75rem;
+}
+
+/* medium */
+:host(:not([size])) {
+	--button-font-size: 1.1rem;
+	--target-height: 3rem;
+}
+:host(:not([size]))>button {
+	padding-inline: 1rem;
+}
+
+/* large */
+:host([size=large]) {
+	--button-font-size: 1.3rem;
+	--target-height: 3.5rem;
+}
+:host([size=large])>button {
+	padding-inline: 1.25rem;
+}
+
 
 :host([type=button])>a {
 	text-align: center;

--- a/src/components/button/style.css
+++ b/src/components/button/style.css
@@ -86,14 +86,16 @@
 :host([size=large]) {
 	--target-height: 4rem;
 }
-:host>button {
+:host {
 	--content-height: var(--button-font-size, 0);
+}
+:host>button {
 	padding-block: calc(((var(--target-height) - var(--content-height)) / 2) - 1px);
 	padding-inline: 0.5rem;
 	min-width: 8rem;
 }
-:host:has(smoothly-icon)>button {
-	--content-height: var(var(--smoothly-icon-size));
+:host:has(smoothly-icon) {
+	--content-height: var(--smoothly-icon-size);
 }
 
 :host([size=icon])>button {

--- a/src/components/button/style.css
+++ b/src/components/button/style.css
@@ -49,8 +49,7 @@
 }
 
 :host(:not([size=icon]):not([size=flexible]))>button {
-	/* padding: calc(1rem - 1px); */
-	/* min-width: 8rem; */
+	min-width: 8rem;
 }
 
 :host(:not([size])),
@@ -92,7 +91,6 @@
 :host>button {
 	padding-block: calc(((var(--target-height) - var(--content-height)) / 2) - 1px);
 	padding-inline: 0.5rem;
-	min-width: 8rem;
 }
 :host:has(smoothly-icon) {
 	--content-height: var(--smoothly-icon-size);

--- a/src/components/button/style.css
+++ b/src/components/button/style.css
@@ -60,23 +60,23 @@
 
 /* icon */
 :host(:not([size=flexible])):has(smoothly-icon[size=tiny]) {
-	--smoothly-icon-size: 1.2rem;
+	--smoothly-icon-size: 1rem;
 }
 :host(:not([size=flexible])):has(smoothly-icon[size=small]) {
-	--smoothly-icon-size: 1.4rem;
+	--smoothly-icon-size: 1.2rem;
 }
 :host(:not([size=flexible])):has(smoothly-icon),
 :host(:not([size=flexible])):has(smoothly-icon[size=medium]) {
-	--smoothly-icon-size: 1.8rem;
+	--smoothly-icon-size: 1.4rem;
 }
 :host(:not([size=flexible])):has(smoothly-icon[size=large]) {
-	--smoothly-icon-size: 2.8rem;
+	--smoothly-icon-size: 1.8rem;
 }
 :host(:not([size=flexible])):has(smoothly-icon[size=xlarge]) {
-	--smoothly-icon-size: 4rem;
+	--smoothly-icon-size: 2.8rem;
 }
 :host([size=icon]) {
-	--target-height: 3rem;
+	--target-height: 2.5rem;
 }
 :host([size=icon])>button {
 	padding: calc(((var(--target-height) - var(--content-height)) / 2) - 1px);
@@ -87,8 +87,8 @@
 
 /* small */
 :host([size=small]) {
-	--button-font-size: 1rem;
-	--target-height: 2.5rem;
+	--button-font-size: 0.875rem;
+	--target-height: 2rem;
 }
 :host([size=small])>button {
 	padding-inline: 0.75rem;
@@ -96,8 +96,8 @@
 
 /* medium */
 :host(:not([size])) {
-	--button-font-size: 1.1rem;
-	--target-height: 3rem;
+	--button-font-size: 1rem;
+	--target-height: 2.5rem;
 }
 :host(:not([size]))>button {
 	padding-inline: 1rem;
@@ -105,8 +105,8 @@
 
 /* large */
 :host([size=large]) {
-	--button-font-size: 1.3rem;
-	--target-height: 3.5rem;
+	--button-font-size: 1.1rem;
+	--target-height: 3rem;
 }
 :host([size=large])>button {
 	padding-inline: 1.25rem;

--- a/src/components/button/style.css
+++ b/src/components/button/style.css
@@ -75,8 +75,10 @@
 :host(:not([size=flexible])):has(smoothly-icon[size=xlarge]) {
 	--smoothly-icon-size: 4rem;
 }
-:host,
 :host([size=small]) {
+	--target-height: 2.5rem;
+}
+:host {
 	--target-height: 3rem;
 }
 :host([size=large]) {

--- a/src/components/button/style.css
+++ b/src/components/button/style.css
@@ -59,20 +59,20 @@
 :host([size=large]) {
 	--button-font-size: 1.3rem;
 }
-:host(:not([size=icon]):not([size=flexible])):has(smoothly-icon[size=tiny]) {
+:host(:not([size=flexible])):has(smoothly-icon[size=tiny]) {
 	--smoothly-icon-size: 1.2rem;
 }
-:host(:not([size=icon]):not([size=flexible])):has(smoothly-icon[size=small]) {
+:host(:not([size=flexible])):has(smoothly-icon[size=small]) {
 	--smoothly-icon-size: 1.4rem;
 }
-:host(:not([size=icon]):not([size=flexible])):has(smoothly-icon),
-:host(:not([size=icon]):not([size=flexible])):has(smoothly-icon[size=medium]) {
+:host(:not([size=flexible])):has(smoothly-icon),
+:host(:not([size=flexible])):has(smoothly-icon[size=medium]) {
 	--smoothly-icon-size: 1.8rem;
 }
-:host(:not([size=icon]):not([size=flexible])):has(smoothly-icon[size=tiny]) {
+:host(:not([size=flexible])):has(smoothly-icon[size=tiny]) {
 	--smoothly-icon-size: 2.8rem;
 }
-:host(:not([size=icon]):not([size=flexible])):has(smoothly-icon[size=xlarge]) {
+:host(:not([size=flexible])):has(smoothly-icon[size=xlarge]) {
 	--smoothly-icon-size: 4rem;
 }
 :host,
@@ -92,12 +92,11 @@
 	padding-block: calc(((var(--target-height) - var(--content-height)) / 2) - 1px);
 	padding-inline: 0.5rem;
 }
+:host([size=icon])>button {
+	padding-inline: calc(((var(--target-height) - var(--content-height)) / 2) - 1px);
+}
 :host:has(smoothly-icon) {
 	--content-height: var(--smoothly-icon-size);
-}
-
-:host([size=icon])>button {
-	padding: 0.5em;
 }
 
 :host([type=button])>a {

--- a/src/components/confirm/index.tsx
+++ b/src/components/confirm/index.tsx
@@ -46,12 +46,7 @@ export class SmoothlyButtonConfirm {
 					disabled={this.disabled}
 					type={"button"}
 					onClick={event => this.clickHandler(event)}>
-					<smoothly-icon
-						name={"alert-outline"}
-						fill={this.fill}
-						color="warning"
-						// size={this.size === "icon" ? "tiny" : "small"}
-					/>
+					<smoothly-icon name={"alert-outline"} fill={this.fill} color="warning" />
 				</smoothly-button>
 				<smoothly-button
 					fill={this.fill}

--- a/src/components/confirm/index.tsx
+++ b/src/components/confirm/index.tsx
@@ -50,7 +50,7 @@ export class SmoothlyButtonConfirm {
 						name={"alert-outline"}
 						fill={this.fill}
 						color="warning"
-						size={this.size === "icon" ? "tiny" : "small"}
+						// size={this.size === "icon" ? "tiny" : "small"}
 					/>
 				</smoothly-button>
 				<smoothly-button

--- a/src/components/icon/style.css
+++ b/src/components/icon/style.css
@@ -27,16 +27,16 @@
 	display: none;
 }
 :host[size=tiny] {
-	--smoothly-icon-size: 1rem;
+	--smoothly-icon-size: 1.2rem;
 }
 :host[size=small] {
-	--smoothly-icon-size: 1.25rem;
+	--smoothly-icon-size: 1.4rem;
 }
 :host[size=medium] {
-	--smoothly-icon-size: 1.75rem;
+	--smoothly-icon-size: 1.8rem;
 }
 :host[size=large] {
-	--smoothly-icon-size: 2.75rem;
+	--smoothly-icon-size: 2.8rem;
 }
 :host[size=xlarge] {
 	--smoothly-icon-size: 4rem;

--- a/src/components/icon/style.css
+++ b/src/components/icon/style.css
@@ -42,8 +42,8 @@
 	--smoothly-icon-size: 4rem;
 }
 :host {
-	width: var(--smoothly-icon-size, 1.75rem);
-	height: var(--smoothly-icon-size, 1.75rem);
+	width: var(--smoothly-icon-size, 1.8rem);
+	height: var(--smoothly-icon-size, 1.8rem);
 }
 :host::slotted(svg) {
 	/* this is needed for svg to work on safari */

--- a/src/components/icon/style.css
+++ b/src/components/icon/style.css
@@ -27,23 +27,23 @@
 	display: none;
 }
 :host[size=tiny] {
-	--smoothly-icon-size: 1.2em;
+	--smoothly-icon-size: 1rem;
 }
 :host[size=small] {
-	--smoothly-icon-size: 1.4em;
+	--smoothly-icon-size: 1.25rem;
 }
 :host[size=medium] {
-	--smoothly-icon-size: 1.8em;
+	--smoothly-icon-size: 1.75rem;
 }
 :host[size=large] {
-	--smoothly-icon-size: 2.8em;
+	--smoothly-icon-size: 2.75rem;
 }
 :host[size=xlarge] {
-	--smoothly-icon-size: 4em;
+	--smoothly-icon-size: 4rem;
 }
 :host {
-	width: var(--smoothly-icon-size, 1.8em);
-	height: var(--smoothly-icon-size, 1.8em);
+	width: var(--smoothly-icon-size, 1.75rem);
+	height: var(--smoothly-icon-size, 1.75rem);
 }
 :host::slotted(svg) {
 	/* this is needed for svg to work on safari */

--- a/src/components/input/clear/index.tsx
+++ b/src/components/input/clear/index.tsx
@@ -59,7 +59,7 @@ export class SmoothlyInputClear {
 					color={this.color}
 					fill={this.fill ?? (this.type == "input" ? "clear" : undefined)}>
 					<slot />
-					<smoothly-icon name="close" size="tiny" />
+					<smoothly-icon name="close" />
 				</smoothly-button>
 			</Host>
 		)

--- a/src/components/input/clear/style.css
+++ b/src/components/input/clear/style.css
@@ -7,6 +7,9 @@
 :host(:not([display])) {
 	display: none;
 }
+:host smoothly-button {
+	margin: 0;
+}
 
 :host([type="input"])::slotted(smoothly-button>button) {
 	cursor: pointer;

--- a/src/components/input/edit/index.tsx
+++ b/src/components/input/edit/index.tsx
@@ -46,7 +46,7 @@ export class SmoothlyInputEdit implements ComponentWillLoad {
 					color={this.color}
 					fill={this.fill ?? (this.type == "input" ? "clear" : undefined)}>
 					<slot />
-					<smoothly-icon class="default" name="create-outline" size="tiny" />
+					<smoothly-icon class="default" name="create-outline" />
 				</smoothly-button>
 			</Host>
 		)

--- a/src/components/input/edit/style.css
+++ b/src/components/input/edit/style.css
@@ -3,6 +3,9 @@
 :host(:not([display])) {
 	display: none;
 }
+:host smoothly-button {
+	margin: 0;
+}
 
 :host([editable]){
 	opacity: 0.5;

--- a/src/components/input/reset/index.tsx
+++ b/src/components/input/reset/index.tsx
@@ -60,7 +60,7 @@ export class SmoothlyInputReset {
 					fill={this.fill ?? (this.type == "input" ? "clear" : undefined)}
 					onClick={event => this.clickHandler(event)}>
 					<slot />
-					<smoothly-icon flip="x" name="refresh-outline" size="tiny" />
+					<smoothly-icon flip="x" name="refresh-outline" />
 				</smoothly-button>
 			</Host>
 		)

--- a/src/components/input/reset/style.css
+++ b/src/components/input/reset/style.css
@@ -3,6 +3,9 @@
 :host(:not([display])) {
 	display: none;
 }
+:host smoothly-button {
+	margin: 0;
+}
 
 :host([type="input"])::slotted(smoothly-button>button) {
 	cursor: pointer;

--- a/src/components/input/shared.css
+++ b/src/components/input/shared.css
@@ -7,6 +7,9 @@
 	box-sizing: border-box;
 	border-radius: var(--smoothly-input-border-radius);
 }
+:host smoothly-icon:not([size]) {
+	--smoothly-icon-size: 1.2rem
+}
 
 :host[looks="border"] {
 	border: rgb(var(--smoothly-input-border)) solid 1px;

--- a/src/components/input/submit/index.tsx
+++ b/src/components/input/submit/index.tsx
@@ -53,7 +53,7 @@ export class SmoothlyInputSubmit implements ComponentWillLoad {
 						fill={this.fill}
 						onSmoothlyConfirm={() => this.clickHandler()}>
 						<slot />
-						<smoothly-icon name="trash-outline" fill="solid" size="tiny" />
+						<smoothly-icon name="trash-outline" fill="solid" />
 					</smoothly-button-confirm>
 				) : (
 					<smoothly-button
@@ -66,7 +66,7 @@ export class SmoothlyInputSubmit implements ComponentWillLoad {
 						fill={this.fill}
 						onClick={() => this.clickHandler()}>
 						<slot />
-						{this.icon && <smoothly-icon name={this.icon} fill="solid" size="tiny" />}
+						{this.icon && <smoothly-icon name={this.icon} fill="solid" />}
 					</smoothly-button>
 				)}
 			</Host>

--- a/src/components/input/submit/style.css
+++ b/src/components/input/submit/style.css
@@ -7,6 +7,9 @@
 :host(:not([display])) {
 	display: none;
 }
+:host smoothly-button {
+	margin: 0;
+}
 
 :host::slotted(smoothly-button button > * > * + smoothly-icon),
 :host::slotted(smoothly-button-confirm button > * > * + smoothly-icon) {


### PR DESCRIPTION
Keep button height consistent regardless if it includes icon, text or both.

## Preview
`size=small` -> `2rem`
<table>
  <tr>
    <td>
<img width="741" height="406" alt="Screenshot from 2025-07-16 15-36-36" src="https://github.com/user-attachments/assets/dd1ba4c3-cdfc-4775-a8d0-3c3e3053cb5a" />
    </td>
    <td>
<img width="741" height="420" alt="Screenshot from 2025-07-16 15-35-59" src="https://github.com/user-attachments/assets/417961e4-3319-4f31-be1b-8926cf9283f3" />

</td>
  </tr>
</table>



- `size=undefined` -> `2.5rem`

<table>
  <tr>
    <td>
<img width="741" height="429" alt="Screenshot from 2025-07-16 15-36-26" src="https://github.com/user-attachments/assets/ea50ded6-6f2a-4d67-ad53-87c9b02b48bf" />
    </td>
    <td>
<img width="741" height="420" alt="Screenshot from 2025-07-16 15-35-51" src="https://github.com/user-attachments/assets/0dfdaff4-6cb5-474c-90f3-203eea2b270b" />
    </td>
  </tr>
</table>



- `size=large` -> `3rem`
<table>
  <tr>
    <td>
<img width="741" height="443" alt="Screenshot from 2025-07-16 15-36-07" src="https://github.com/user-attachments/assets/70e4c655-eada-4434-8bce-dc225ab9246a" /> 
    </td>
    <td>
<img width="741" height="451" alt="Screenshot from 2025-07-16 15-36-45" src="https://github.com/user-attachments/assets/8eb8bffb-2a04-41c5-902d-1c44e36bf505" />
</td>
  </tr>
</table>

