### PR TITLE
smoothly-tab: add z-index for tooltip

### DIFF
--- a/src/components/tabs/tab/style.css
+++ b/src/components/tabs/tab/style.css
@@ -51,6 +51,7 @@
 	background-color: rgb(var(--smoothly-medium-color));
 	color: rgb(var(--smoothly-medium-contrast));
 	white-space: nowrap;
+	z-index: 1;
 }
 
 :host > div:nth-child(2) {


### PR DESCRIPTION
to fix this
<img width="1984" height="757" alt="image" src="https://github.com/user-attachments/assets/61f22d78-382a-459e-b2e5-fe023485be23" />
