### PR TITLE
Margin for form buttons.

### DIFF
--- a/src/components/form/style.css
+++ b/src/components/form/style.css
@@ -41,5 +41,5 @@ smoothly-form > form > div:not(:empty) {
 	display: flex;
 	justify-content: end;
 	gap: 1em;
-	margin-top: 0.5rem;
+	margin-top: 1.5rem;
 }


### PR DESCRIPTION
Its really tight between form and attached buttons beneath, before:
<img width="618" height="562" alt="image" src="https://github.com/user-attachments/assets/b56f2e8e-57e0-48a4-a55d-f501d51d3397" />

After
<img width="618" height="580" alt="image" src="https://github.com/user-attachments/assets/a52173ec-b539-4c5c-b9c8-de45c3c21c20" />
