### PR TITLE
Enforce smoothly-tab to be child or smoothly-tabs

### DIFF
--- a/src/components/tabs/index.tsx
+++ b/src/components/tabs/index.tsx
@@ -26,7 +26,11 @@ export class SmoothlyTabs {
 	@Listen("smoothlyTabLoad")
 	onInputLoad(event: CustomEvent<(smoothlyTabs: SmoothlyTabs) => void>) {
 		event.stopPropagation()
-		if (this.isSmoothlyTabElement(event.target) && !this.tabElements.includes(event.target)) {
+		if (
+			this.isSmoothlyTabElement(event.target) &&
+			event.target.parentElement == this.element &&
+			!this.tabElements.includes(event.target)
+		) {
 			event.detail(this)
 			this.tabElements = [...this.tabElements, event.target]
 		}

--- a/src/components/tabs/tab/index.tsx
+++ b/src/components/tabs/tab/index.tsx
@@ -9,7 +9,7 @@ import { SmoothlyTabs } from ".."
 })
 export class SmoothlyTab {
 	private inputs: Record<string, Input.Element> = {}
-	private smoothlyTabs: SmoothlyTabs
+	private smoothlyTabs?: SmoothlyTabs
 	@Element() element: HTMLSmoothlyTabElement
 	@Prop() label: string
 	@Prop() name: string
@@ -28,10 +28,13 @@ export class SmoothlyTab {
 			: await Promise.all(Object.values(this.inputs).map(input => input.unregister()))
 	}
 	connectedCallback() {
-		this.smoothlyTabLoad.emit((smoothlyTabs: SmoothlyTabs) => (this.smoothlyTabs = smoothlyTabs))
+		this.smoothlyTabLoad.emit((smoothlyTabs: SmoothlyTabs) => {
+			this.smoothlyTabs?.removeTab(this.element)
+			this.smoothlyTabs = smoothlyTabs
+		})
 	}
 	disconnectedCallback() {
-		this.smoothlyTabs.removeTab(this.element)
+		this.smoothlyTabs?.removeTab(this.element)
 	}
 	async componentDidLoad() {
 		await this.openHandler()


### PR DESCRIPTION
In weird circumstances (which I don't completely understand), tabs-element can miss the event from tab when connecting to DOM.
This can lead to weird bugs when having tested tabs.

Adding a check to see that tab is a direct child or tabs, to avoid this bug.


## Example of bug
<img width="2035" height="593" alt="image" src="https://github.com/user-attachments/assets/e0760cf1-554b-46cf-bc5a-64ca0751f4cf" />
