### PR TITLE
No extra space for empty label on checkbox

### DIFF
--- a/src/components/input/checkbox/style.css
+++ b/src/components/input/checkbox/style.css
@@ -34,6 +34,9 @@
 :host:not([readonly]):not([disabled])>label {
 	cursor: pointer;
 }
+:host>label:empty {
+	display: none;
+}
 
 :host([disabled]),
 :host([disabled])>* {


### PR DESCRIPTION
## smoothly-input-checkbox without label

### Before
<img width="45" height="61" alt="image" src="https://github.com/user-attachments/assets/460ebc2b-6222-4055-9860-81b1cba0c84f" />


### After
<img width="41" height="61" alt="Screenshot from 2025-09-06 14-26-40" src="https://github.com/user-attachments/assets/1553f02b-3c5d-4c1e-91bb-76ce7cf8ed54" />

