### PR TITLE
Don't allow notification to be wider then screen

### DIFF
--- a/src/components/notification/style.css
+++ b/src/components/notification/style.css
@@ -13,7 +13,7 @@
 	align-self: center;
 }
 :host > span {
-	margin: 0 2rem 0 1rem;
+	margin-inline: 1rem 2rem;
 }
 :host > span.icon {
 	display: flex;
@@ -33,7 +33,7 @@
 	margin: 0 0.5rem;
 }
 :host > smoothly-trigger {
-	font-size: 0.7em;
+	--smoothly-icon-size: 1.6rem;
 	position: absolute;
 	right: 0;
 }

--- a/src/components/notification/style.css
+++ b/src/components/notification/style.css
@@ -1,10 +1,10 @@
 :host {
 	display: block;
 	position: relative;
-	min-width: 30em;
-	min-height: 3em;
+	min-width: min(calc(100% - 1rem), 30rem);
+	min-height: 3rem;
 	border-radius: 5px;
-	margin: 0.5em;
+	margin: 0.5rem;
 }
 :host > span.icon > smoothly-icon,
 :host > span.clean {


### PR DESCRIPTION
<table>
<tr>
<th>before</th>
<th>after</th>
</tr>
<tr>
<td>
<img width="300" height="2436" alt="Screen Shot 2025-09-12 at 11 57 15" src="https://github.com/user-attachments/assets/efd98040-9726-49c7-8a71-9a843d2e43ac" />
</td>
<td>
<img width="300" height="2436" alt="Screen Shot 2025-09-12 at 12 16 41" src="https://github.com/user-attachments/assets/115eda82-c974-429e-acb3-4b2828698f8d" />
</td>
</tr>
</table>



