### PR TITLE
Table cells must use .smoothly-table-cell class

### DIFF
--- a/src/components/table/cell/index.tsx
+++ b/src/components/table/cell/index.tsx
@@ -10,7 +10,7 @@ export class SmoothlyTableCell {
 
 	render(): VNode | VNode[] {
 		return (
-			<Host style={{ "--smoothly-table-cell-span": this.span?.toString(10) }}>
+			<Host class="smoothly-table-cell" style={{ "--smoothly-table-cell-span": this.span?.toString(10) }}>
 				<slot />
 			</Host>
 		)

--- a/src/components/table/demo/filler-row/index.tsx
+++ b/src/components/table/demo/filler-row/index.tsx
@@ -37,10 +37,10 @@ export class SmoothlyTableDemoFillerRow {
 						) : (
 							this.cats.map(a => (
 								<smoothly-table-row>
-									<smoothly-table-cell>{a.breed}</smoothly-table-cell>
-									<smoothly-table-cell>{a.country}</smoothly-table-cell>
-									<smoothly-table-cell>{a.coat}</smoothly-table-cell>
-									<smoothly-table-cell>{a.origin}</smoothly-table-cell>
+									<div class="smoothly-table-cell">{a.breed}</div>
+									<div class="smoothly-table-cell">{a.country}</div>
+									<div class="smoothly-table-cell">{a.coat}</div>
+									<div class="smoothly-table-cell">{a.origin}</div>
 								</smoothly-table-row>
 							))
 						)}

--- a/src/components/table/demo/nested-no-cell/index.tsx
+++ b/src/components/table/demo/nested-no-cell/index.tsx
@@ -1,4 +1,4 @@
-import { Component, h, Host, VNode } from "@stencil/core"
+import { Component, h, Host, State, VNode } from "@stencil/core"
 import { data } from "./data"
 
 @Component({
@@ -7,6 +7,10 @@ import { data } from "./data"
 	scoped: true,
 })
 export class SmoothlyTableDemoNestedNoCell {
+	// Simulate loading state
+	@State() loadingIndex?: number
+	@State() loadedRows: number[] = []
+
 	render(): VNode | VNode[] {
 		return (
 			<Host>
@@ -25,9 +29,21 @@ export class SmoothlyTableDemoNestedNoCell {
 						</smoothly-table-row>
 					</smoothly-table-head>
 					<smoothly-table-body>
-						{data.map(entry => (
-							<smoothly-table-expandable-row>
-								<smoothly-table-demo-nested-no-cell-inner color="secondary" data={entry.friends} slot={"detail"} />
+						{data.map((entry, index) => (
+							<smoothly-table-expandable-row
+								onSmoothlyTableExpandableRowChange={event => {
+									if (event.detail) {
+										this.loadingIndex = index
+										setTimeout(() => {
+											this.loadingIndex = undefined
+											this.loadedRows = [...this.loadedRows, index]
+										}, 1500)
+									}
+								}}>
+								{this.loadingIndex === index && <smoothly-spinner overlay size="small" />}
+								{this.loadedRows.includes(index) && (
+									<smoothly-table-demo-nested-no-cell-inner color="secondary" data={entry.friends} slot={"detail"} />
+								)}
 								<div class="smoothly-table-cell">{entry.id}</div>
 								<div class="smoothly-table-cell">{entry.registered}</div>
 								<div class="smoothly-table-cell">{entry.name}</div>

--- a/src/components/table/demo/nested-no-cell/index.tsx
+++ b/src/components/table/demo/nested-no-cell/index.tsx
@@ -14,35 +14,35 @@ export class SmoothlyTableDemoNestedNoCell {
 				<smoothly-table color="primary" columns={8}>
 					<smoothly-table-head>
 						<smoothly-table-row>
-							<div>Id</div>
-							<div>Registered</div>
-							<div>Name</div>
-							<div>Age</div>
-							<div>Balance</div>
-							<div>EyeColor</div>
-							<div>Gender</div>
-							<div>Company</div>
+							<div class="smoothly-table-cell">Id</div>
+							<div class="smoothly-table-cell">Registered</div>
+							<div class="smoothly-table-cell">Name</div>
+							<div class="smoothly-table-cell">Age</div>
+							<div class="smoothly-table-cell">Balance</div>
+							<div class="smoothly-table-cell">EyeColor</div>
+							<div class="smoothly-table-cell">Gender</div>
+							<div class="smoothly-table-cell">Company</div>
 						</smoothly-table-row>
 					</smoothly-table-head>
 					<smoothly-table-body>
 						{data.map(entry => (
 							<smoothly-table-expandable-row>
 								<smoothly-table-demo-nested-no-cell-inner color="secondary" data={entry.friends} slot={"detail"} />
-								<div>{entry.id}</div>
-								<div>{entry.registered}</div>
-								<div>{entry.name}</div>
-								<div>{entry.age}</div>
-								<div>{entry.balance}</div>
-								<div>{entry.eyeColor}</div>
-								<div>{entry.gender}</div>
-								<div>{entry.company}</div>
+								<div class="smoothly-table-cell">{entry.id}</div>
+								<div class="smoothly-table-cell">{entry.registered}</div>
+								<div class="smoothly-table-cell">{entry.name}</div>
+								<div class="smoothly-table-cell">{entry.age}</div>
+								<div class="smoothly-table-cell">{entry.balance}</div>
+								<div class="smoothly-table-cell">{entry.eyeColor}</div>
+								<div class="smoothly-table-cell">{entry.gender}</div>
+								<div class="smoothly-table-cell">{entry.company}</div>
 							</smoothly-table-expandable-row>
 						))}
 					</smoothly-table-body>
 					<smoothly-table-foot>
 						<smoothly-table-row>
-							<div>Footer Cell</div>
-							<div>Footer Cell</div>
+							<div class="smoothly-table-cell">Footer Cell</div>
+							<div class="smoothly-table-cell">Footer Cell</div>
 						</smoothly-table-row>
 					</smoothly-table-foot>
 				</smoothly-table>

--- a/src/components/table/demo/nested-no-cell/inner/index.tsx
+++ b/src/components/table/demo/nested-no-cell/inner/index.tsx
@@ -18,19 +18,19 @@ export class SmoothlyTableDemoNestedNoCellInner {
 				<smoothly-table columns={4}>
 					<smoothly-table-head>
 						<smoothly-table-row>
-							<div>Id</div>
-							<div>Name</div>
-							<div>Age</div>
-							<div>Balance</div>
+							<div class="smoothly-table-cell">Id</div>
+							<div class="smoothly-table-cell">Name</div>
+							<div class="smoothly-table-cell">Age</div>
+							<div class="smoothly-table-cell">Balance</div>
 						</smoothly-table-row>
 					</smoothly-table-head>
 					<smoothly-table-body>
 						{this.data?.map(entry => (
 							<smoothly-table-expandable-row>
-								<div>{entry.id}</div>
-								<div>{entry.name}</div>
-								<div>{entry.age}</div>
-								<div>{entry.balance}</div>
+								<div class="smoothly-table-cell">{entry.id}</div>
+								<div class="smoothly-table-cell">{entry.name}</div>
+								<div class="smoothly-table-cell">{entry.age}</div>
+								<div class="smoothly-table-cell">{entry.balance}</div>
 							</smoothly-table-expandable-row>
 						))}
 					</smoothly-table-body>

--- a/src/components/table/demo/nested-no-cell/style.css
+++ b/src/components/table/demo/nested-no-cell/style.css
@@ -7,3 +7,6 @@
 :host>* {
 	margin-bottom: 2rem;
 }
+:host smoothly-table-expandable-row {
+	position: relative;
+}

--- a/src/components/table/expandable/row/index.tsx
+++ b/src/components/table/expandable/row/index.tsx
@@ -27,7 +27,7 @@ export class SmoothlyTableExpandableRow {
 		return (
 			<Host onClick={(e: MouseEvent) => this.clickHandler(e)}>
 				<slot />
-				<div class={"detail"} ref={e => (this.div = e)}>
+				<div class={"smoothly-table-detail"} ref={e => (this.div = e)}>
 					<slot name="detail" />
 				</div>
 			</Host>

--- a/src/components/table/expandable/row/style.scss
+++ b/src/components/table/expandable/row/style.scss
@@ -38,7 +38,6 @@
 
 :host > div.smoothly-table-detail {
 	grid-column: 1 / -1;
-	outline: 2px solid orange;
 	cursor: default;
 	position: relative;
 	overflow: hidden;
@@ -46,15 +45,15 @@
 	color: rgb(var(--smoothly-table-expanded-foreground));
 }
 
-:host > :first-child {
+:host > .smoothly-table-cell:first-of-type {
 	@include arrow;
 }
 
-:host:has(>:hover) > :first-child {
+:host:has(>.smoothly-table-cell:hover) > .smoothly-table-cell:first-of-type {
 	@include arrow-hover;
 }
 
-:host[open] > :first-child {
+:host[open] > .smoothly-table-cell:first-of-type {
 	@include arrow-open;
 }
 

--- a/src/components/table/expandable/row/style.scss
+++ b/src/components/table/expandable/row/style.scss
@@ -8,7 +8,7 @@
 	box-shadow: 0px 1px 1px -1px rgb(var(--smoothly-table-border));
 }
 
-:host::slotted(:not(.detail)) {
+:host::slotted(.smoothly-table-cell) {
 	grid: subgrid;
 	cursor: pointer;
 	grid-column: span var(--smoothly-table-cell-span, 1);
@@ -18,7 +18,7 @@
 	white-space: nowrap;
 }
 
-:host:has(>:not(:last-child):hover) {
+:host:has(>.smoothly-table-cell:hover) {
 	background-color: rgb(var(--smoothly-table-hover-background));
 	color: rgb(var(--smoothly-table-hover-foreground));
 }
@@ -32,12 +32,13 @@
 	grid-template-rows: 0fr 1fr;
 }
 
-:host(:not([open])) > div.detail {
+:host(:not([open])) > div.smoothly-table-detail {
 	display: none;
 }
 
-:host > div:last-child {
+:host > div.smoothly-table-detail {
 	grid-column: 1 / -1;
+	outline: 2px solid orange;
 	cursor: default;
 	position: relative;
 	overflow: hidden;
@@ -57,12 +58,12 @@
 	@include arrow-open;
 }
 
-:host[open] > div:last-child {
+:host[open] > div.smoothly-table-detail {
 	overflow: visible;
 	padding: 0.5rem 1.1rem;
 }
 
-:host > div:last-child::before {
+:host > div.smoothly-table-detail::before {
 	content: "";
 	position: absolute;
 	display: flex;
@@ -77,7 +78,7 @@
 		0px 0px 1px 0px rgb(var(--smoothly-table-border));
 }
 
-:host > div:last-child::after {
+:host > div.smoothly-table-detail::after {
 	content: "";
 	position: absolute;
 	display: flex;

--- a/src/components/table/row/style.css
+++ b/src/components/table/row/style.css
@@ -5,7 +5,7 @@
 	box-sizing: border-box;
 	box-shadow: 0px 1px 1px -1px rgb(var(--smoothly-table-border));
 }
-:host::slotted(*) {
+:host::slotted(.smoothly-table-cell) {
 	grid-column: span var(--smoothly-table-cell-span, 1);
 	align-items: center;
 	padding: 0.5rem 1.1rem;


### PR DESCRIPTION
## Changes
### Force smoothly-table-expandable-row to use `.smoothly-table-cell` class on cells
- Makes it much easier to add other add extra children into table that don't need to be cell or detail, e.g. spinner.
- Avoids using the `:not` selector which just says what you aren't targeting, confusing to read and targets everything else.

### Change to using the `.smoothly-table-detail` class in `smoothly-table-expandable-row`.
`detail` is too generic and could easily accidentally be targeted by user or smoothly library.


### Preview
With this change you can add other children to smoothly-table that don't have to follow the restraints of cell or detail.

Spinner example:
Add a `<smoothly-spinner overlay />` and set `position: relative` on `smoothly-table-expandable-row`, to show when content is loading.

https://github.com/user-attachments/assets/dcbf3e85-6578-4fde-ab4b-f58dfe0e1acb



