### PR TITLE
Make table-details :before always visible.

### DIFF
--- a/src/components/table/expandable/cell/style.scss
+++ b/src/components/table/expandable/cell/style.scss
@@ -60,7 +60,6 @@
 	position: absolute;
 	display: flex;
 	box-sizing: border-box;
-	z-index: -1;
 	top: 0;
 	bottom: 0;
 	left: -1em;
@@ -75,7 +74,6 @@
 	content: "";
 	position: absolute;
 	display: flex;
-	z-index: -1;
 	top: 0;
 	bottom: 0;
 	right: -1em;


### PR DESCRIPTION
Expandable cells in tables in expandable cells would not get their ::before's and ::after's

Before:
<img width="644" height="367" alt="image" src="https://github.com/user-attachments/assets/f9cddbdd-5869-4e5f-a2a3-1843e3384efa" />

After:
<img width="644" height="367" alt="image" src="https://github.com/user-attachments/assets/ad9d1ed9-d325-4f23-aeb5-a44feab8881f" />
