### PR TITLE
Split input-date into parts (Year,Month,Day) - new implementation for writting date

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6084,9 +6084,9 @@
 			}
 		},
 		"node_modules/vite-node/node_modules/vite": {
-			"version": "6.3.5",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz",
-			"integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
+			"version": "6.4.1",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
+			"integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6302,9 +6302,9 @@
 			}
 		},
 		"node_modules/vitest/node_modules/vite": {
-			"version": "6.3.5",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz",
-			"integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
+			"version": "6.4.1",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
+			"integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -363,6 +363,7 @@ export namespace Components {
     interface SmoothlyInputDateDemo {
     }
     interface SmoothlyInputDateRange {
+        "alwaysShowFormat": boolean;
         "clear": () => Promise<void>;
         "color"?: Color;
         "disabled"?: boolean;
@@ -2662,6 +2663,7 @@ declare namespace LocalJSX {
     interface SmoothlyInputDateDemo {
     }
     interface SmoothlyInputDateRange {
+        "alwaysShowFormat"?: boolean;
         "color"?: Color;
         "disabled"?: boolean;
         "end"?: isoly.Date | undefined;

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -338,6 +338,7 @@ export namespace Components {
     interface SmoothlyInputColorDemo {
     }
     interface SmoothlyInputDate {
+        "alwaysShowFormat": boolean;
         "clear": () => Promise<void>;
         "color"?: Color;
         "disabled"?: boolean;
@@ -352,6 +353,7 @@ export namespace Components {
         "min": isoly.Date;
         "name": string;
         "open": boolean;
+        "placeholder"?: string;
         "readonly": boolean;
         "register": () => Promise<void>;
         "reset": () => Promise<void>;
@@ -2640,6 +2642,7 @@ declare namespace LocalJSX {
     interface SmoothlyInputColorDemo {
     }
     interface SmoothlyInputDate {
+        "alwaysShowFormat"?: boolean;
         "color"?: Color;
         "disabled"?: boolean;
         "errorMessage"?: string;
@@ -2656,6 +2659,7 @@ declare namespace LocalJSX {
         "onSmoothlyUserInput"?: (event: SmoothlyInputDateCustomEvent<Input.UserInput>) => void;
         "onSmoothlyValueChange"?: (event: SmoothlyInputDateCustomEvent<isoly.Date>) => void;
         "open"?: boolean;
+        "placeholder"?: string;
         "readonly"?: boolean;
         "showLabel"?: boolean;
         "value"?: isoly.Date;

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -338,7 +338,7 @@ export namespace Components {
     interface SmoothlyInputColorDemo {
     }
     interface SmoothlyInputDate {
-        "alwaysShowFormat": boolean;
+        "alwaysShowGuide": boolean;
         "clear": () => Promise<void>;
         "color"?: Color;
         "disabled"?: boolean;
@@ -365,7 +365,7 @@ export namespace Components {
     interface SmoothlyInputDateDemo {
     }
     interface SmoothlyInputDateRange {
-        "alwaysShowFormat": boolean;
+        "alwaysShowGuide": boolean;
         "clear": () => Promise<void>;
         "color"?: Color;
         "disabled"?: boolean;
@@ -2643,7 +2643,7 @@ declare namespace LocalJSX {
     interface SmoothlyInputColorDemo {
     }
     interface SmoothlyInputDate {
-        "alwaysShowFormat"?: boolean;
+        "alwaysShowGuide"?: boolean;
         "color"?: Color;
         "disabled"?: boolean;
         "errorMessage"?: string;
@@ -2668,7 +2668,7 @@ declare namespace LocalJSX {
     interface SmoothlyInputDateDemo {
     }
     interface SmoothlyInputDateRange {
-        "alwaysShowFormat"?: boolean;
+        "alwaysShowGuide"?: boolean;
         "color"?: Color;
         "disabled"?: boolean;
         "end"?: isoly.Date | undefined;

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -120,6 +120,18 @@ export namespace Components {
         "text": "alpha2" | "name" | "none";
         "value": isoly.CountryCode.Alpha2;
     }
+    interface SmoothlyDateText {
+        "deselect": () => Promise<void>;
+        "disabled": boolean;
+        "invalid": boolean;
+        "locale": isoly.Locale;
+        "placeholder": string;
+        "readonly": boolean;
+        "select": (place?: "start" | "end") => Promise<void>;
+        "setValue": (value: isoly.Date | undefined) => Promise<void>;
+        "showLabel": boolean;
+        "value"?: isoly.Date;
+    }
     interface SmoothlyDialog {
         "closable": boolean;
         "color": Color | undefined;
@@ -335,6 +347,7 @@ export namespace Components {
         "getValue": () => Promise<isoly.Date | undefined>;
         "invalid"?: boolean;
         "listen": (listener: Editable.Observer.Listener) => Promise<void>;
+        "locale": isoly.Locale;
         "looks"?: Looks;
         "max": isoly.Date;
         "min": isoly.Date;
@@ -348,13 +361,15 @@ export namespace Components {
         "unregister": () => Promise<void>;
         "value"?: isoly.Date;
     }
+    interface SmoothlyInputDateDemo {
+    }
     interface SmoothlyInputDateRange {
         "clear": () => Promise<void>;
         "color"?: Color;
         "disabled"?: boolean;
         "edit": (editable: boolean) => Promise<void>;
         "end": isoly.Date | undefined;
-        "getValue": () => Promise<isoly.DateRange | undefined>;
+        "getValue": () => Promise<Partial<isoly.DateRange | undefined>>;
         "invalid"?: boolean;
         "listen": (listener: Editable.Observer.Listener) => Promise<void>;
         "looks"?: Looks;
@@ -743,6 +758,10 @@ export interface SmoothlyCheckboxCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLSmoothlyCheckboxElement;
 }
+export interface SmoothlyDateTextCustomEvent<T> extends CustomEvent<T> {
+    detail: T;
+    target: HTMLSmoothlyDateTextElement;
+}
 export interface SmoothlyDisplayDemoCustomEvent<T> extends CustomEvent<T> {
     detail: T;
     target: HTMLSmoothlyDisplayDemoElement;
@@ -1063,6 +1082,27 @@ declare global {
     var HTMLSmoothlyCountryElement: {
         prototype: HTMLSmoothlyCountryElement;
         new (): HTMLSmoothlyCountryElement;
+    };
+    interface HTMLSmoothlyDateTextElementEventMap {
+        "smoothlyDateTextChange": isoly.Date | undefined;
+        "smoothlyDateTextFocusChange": boolean;
+        "smoothlyDateTextDone": void;
+        "smoothlyDateTextPrevious": void;
+        "smoothlyDateTextNext": void;
+    }
+    interface HTMLSmoothlyDateTextElement extends Components.SmoothlyDateText, HTMLStencilElement {
+        addEventListener<K extends keyof HTMLSmoothlyDateTextElementEventMap>(type: K, listener: (this: HTMLSmoothlyDateTextElement, ev: SmoothlyDateTextCustomEvent<HTMLSmoothlyDateTextElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+        addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLSmoothlyDateTextElementEventMap>(type: K, listener: (this: HTMLSmoothlyDateTextElement, ev: SmoothlyDateTextCustomEvent<HTMLSmoothlyDateTextElementEventMap[K]>) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+        removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
+    }
+    var HTMLSmoothlyDateTextElement: {
+        prototype: HTMLSmoothlyDateTextElement;
+        new (): HTMLSmoothlyDateTextElement;
     };
     interface HTMLSmoothlyDialogElement extends Components.SmoothlyDialog, HTMLStencilElement {
     }
@@ -1493,9 +1533,15 @@ declare global {
         prototype: HTMLSmoothlyInputDateElement;
         new (): HTMLSmoothlyInputDateElement;
     };
+    interface HTMLSmoothlyInputDateDemoElement extends Components.SmoothlyInputDateDemo, HTMLStencilElement {
+    }
+    var HTMLSmoothlyInputDateDemoElement: {
+        prototype: HTMLSmoothlyInputDateDemoElement;
+        new (): HTMLSmoothlyInputDateDemoElement;
+    };
     interface HTMLSmoothlyInputDateRangeElementEventMap {
-        "smoothlyInput": { [name: string]: isoly.DateRange | undefined };
-        "smoothlyUserInput": Input.UserInput;
+        "smoothlyInput": { [name: string]: Partial<isoly.DateRange> | undefined };
+        "smoothlyUserInput": Input.UserInput<Partial<isoly.DateRange> | undefined>;
         "smoothlyInputLoad": (parent: Editable) => void;
         "smoothlyInputLooks": (looks?: Looks, color?: Color) => void;
         "smoothlyFormDisable": (disabled: boolean) => void;
@@ -2177,6 +2223,7 @@ declare global {
         "smoothly-checkbox": HTMLSmoothlyCheckboxElement;
         "smoothly-color": HTMLSmoothlyColorElement;
         "smoothly-country": HTMLSmoothlyCountryElement;
+        "smoothly-date-text": HTMLSmoothlyDateTextElement;
         "smoothly-dialog": HTMLSmoothlyDialogElement;
         "smoothly-dialog-demo": HTMLSmoothlyDialogDemoElement;
         "smoothly-display": HTMLSmoothlyDisplayElement;
@@ -2214,6 +2261,7 @@ declare global {
         "smoothly-input-color": HTMLSmoothlyInputColorElement;
         "smoothly-input-color-demo": HTMLSmoothlyInputColorDemoElement;
         "smoothly-input-date": HTMLSmoothlyInputDateElement;
+        "smoothly-input-date-demo": HTMLSmoothlyInputDateDemoElement;
         "smoothly-input-date-range": HTMLSmoothlyInputDateRangeElement;
         "smoothly-input-date-time": HTMLSmoothlyInputDateTimeElement;
         "smoothly-input-demo": HTMLSmoothlyInputDemoElement;
@@ -2365,6 +2413,20 @@ declare namespace LocalJSX {
     interface SmoothlyCountry {
         "text"?: "alpha2" | "name" | "none";
         "value"?: isoly.CountryCode.Alpha2;
+    }
+    interface SmoothlyDateText {
+        "disabled"?: boolean;
+        "invalid"?: boolean;
+        "locale"?: isoly.Locale;
+        "onSmoothlyDateTextChange"?: (event: SmoothlyDateTextCustomEvent<isoly.Date | undefined>) => void;
+        "onSmoothlyDateTextDone"?: (event: SmoothlyDateTextCustomEvent<void>) => void;
+        "onSmoothlyDateTextFocusChange"?: (event: SmoothlyDateTextCustomEvent<boolean>) => void;
+        "onSmoothlyDateTextNext"?: (event: SmoothlyDateTextCustomEvent<void>) => void;
+        "onSmoothlyDateTextPrevious"?: (event: SmoothlyDateTextCustomEvent<void>) => void;
+        "placeholder"?: string;
+        "readonly"?: boolean;
+        "showLabel"?: boolean;
+        "value"?: isoly.Date;
     }
     interface SmoothlyDialog {
         "closable"?: boolean;
@@ -2581,6 +2643,7 @@ declare namespace LocalJSX {
         "disabled"?: boolean;
         "errorMessage"?: string;
         "invalid"?: boolean;
+        "locale"?: isoly.Locale;
         "looks"?: Looks;
         "max"?: isoly.Date;
         "min"?: isoly.Date;
@@ -2596,6 +2659,8 @@ declare namespace LocalJSX {
         "showLabel"?: boolean;
         "value"?: isoly.Date;
     }
+    interface SmoothlyInputDateDemo {
+    }
     interface SmoothlyInputDateRange {
         "color"?: Color;
         "disabled"?: boolean;
@@ -2606,10 +2671,10 @@ declare namespace LocalJSX {
         "min"?: isoly.Date;
         "name"?: string;
         "onSmoothlyFormDisable"?: (event: SmoothlyInputDateRangeCustomEvent<(disabled: boolean) => void>) => void;
-        "onSmoothlyInput"?: (event: SmoothlyInputDateRangeCustomEvent<{ [name: string]: isoly.DateRange | undefined }>) => void;
+        "onSmoothlyInput"?: (event: SmoothlyInputDateRangeCustomEvent<{ [name: string]: Partial<isoly.DateRange> | undefined }>) => void;
         "onSmoothlyInputLoad"?: (event: SmoothlyInputDateRangeCustomEvent<(parent: Editable) => void>) => void;
         "onSmoothlyInputLooks"?: (event: SmoothlyInputDateRangeCustomEvent<(looks?: Looks, color?: Color) => void>) => void;
-        "onSmoothlyUserInput"?: (event: SmoothlyInputDateRangeCustomEvent<Input.UserInput>) => void;
+        "onSmoothlyUserInput"?: (event: SmoothlyInputDateRangeCustomEvent<Input.UserInput<Partial<isoly.DateRange> | undefined>>) => void;
         "placeholder"?: string;
         "readonly"?: boolean;
         "showLabel"?: boolean;
@@ -2979,6 +3044,7 @@ declare namespace LocalJSX {
         "smoothly-checkbox": SmoothlyCheckbox;
         "smoothly-color": SmoothlyColor;
         "smoothly-country": SmoothlyCountry;
+        "smoothly-date-text": SmoothlyDateText;
         "smoothly-dialog": SmoothlyDialog;
         "smoothly-dialog-demo": SmoothlyDialogDemo;
         "smoothly-display": SmoothlyDisplay;
@@ -3016,6 +3082,7 @@ declare namespace LocalJSX {
         "smoothly-input-color": SmoothlyInputColor;
         "smoothly-input-color-demo": SmoothlyInputColorDemo;
         "smoothly-input-date": SmoothlyInputDate;
+        "smoothly-input-date-demo": SmoothlyInputDateDemo;
         "smoothly-input-date-range": SmoothlyInputDateRange;
         "smoothly-input-date-time": SmoothlyInputDateTime;
         "smoothly-input-demo": SmoothlyInputDemo;
@@ -3093,6 +3160,7 @@ declare module "@stencil/core" {
             "smoothly-checkbox": LocalJSX.SmoothlyCheckbox & JSXBase.HTMLAttributes<HTMLSmoothlyCheckboxElement>;
             "smoothly-color": LocalJSX.SmoothlyColor & JSXBase.HTMLAttributes<HTMLSmoothlyColorElement>;
             "smoothly-country": LocalJSX.SmoothlyCountry & JSXBase.HTMLAttributes<HTMLSmoothlyCountryElement>;
+            "smoothly-date-text": LocalJSX.SmoothlyDateText & JSXBase.HTMLAttributes<HTMLSmoothlyDateTextElement>;
             "smoothly-dialog": LocalJSX.SmoothlyDialog & JSXBase.HTMLAttributes<HTMLSmoothlyDialogElement>;
             "smoothly-dialog-demo": LocalJSX.SmoothlyDialogDemo & JSXBase.HTMLAttributes<HTMLSmoothlyDialogDemoElement>;
             "smoothly-display": LocalJSX.SmoothlyDisplay & JSXBase.HTMLAttributes<HTMLSmoothlyDisplayElement>;
@@ -3130,6 +3198,7 @@ declare module "@stencil/core" {
             "smoothly-input-color": LocalJSX.SmoothlyInputColor & JSXBase.HTMLAttributes<HTMLSmoothlyInputColorElement>;
             "smoothly-input-color-demo": LocalJSX.SmoothlyInputColorDemo & JSXBase.HTMLAttributes<HTMLSmoothlyInputColorDemoElement>;
             "smoothly-input-date": LocalJSX.SmoothlyInputDate & JSXBase.HTMLAttributes<HTMLSmoothlyInputDateElement>;
+            "smoothly-input-date-demo": LocalJSX.SmoothlyInputDateDemo & JSXBase.HTMLAttributes<HTMLSmoothlyInputDateDemoElement>;
             "smoothly-input-date-range": LocalJSX.SmoothlyInputDateRange & JSXBase.HTMLAttributes<HTMLSmoothlyInputDateRangeElement>;
             "smoothly-input-date-time": LocalJSX.SmoothlyInputDateTime & JSXBase.HTMLAttributes<HTMLSmoothlyInputDateTimeElement>;
             "smoothly-input-demo": LocalJSX.SmoothlyInputDemo & JSXBase.HTMLAttributes<HTMLSmoothlyInputDemoElement>;

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -374,6 +374,7 @@ export namespace Components {
         "getValue": () => Promise<Partial<isoly.DateRange | undefined>>;
         "invalid"?: boolean;
         "listen": (listener: Editable.Observer.Listener) => Promise<void>;
+        "locale": isoly.Locale;
         "looks"?: Looks;
         "max"?: isoly.Date;
         "min"?: isoly.Date;
@@ -2672,6 +2673,7 @@ declare namespace LocalJSX {
         "disabled"?: boolean;
         "end"?: isoly.Date | undefined;
         "invalid"?: boolean;
+        "locale"?: isoly.Locale;
         "looks"?: Looks;
         "max"?: isoly.Date;
         "min"?: isoly.Date;

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -125,7 +125,6 @@ export namespace Components {
         "disabled": boolean;
         "invalid": boolean;
         "locale": isoly.Locale;
-        "placeholder": string;
         "readonly": boolean;
         "select": (place?: "start" | "end") => Promise<void>;
         "setValue": (value: isoly.Date | undefined) => Promise<void>;
@@ -2425,7 +2424,6 @@ declare namespace LocalJSX {
         "onSmoothlyDateTextHasText"?: (event: SmoothlyDateTextCustomEvent<boolean>) => void;
         "onSmoothlyDateTextNext"?: (event: SmoothlyDateTextCustomEvent<void>) => void;
         "onSmoothlyDateTextPrevious"?: (event: SmoothlyDateTextCustomEvent<void>) => void;
-        "placeholder"?: string;
         "readonly"?: boolean;
         "showLabel"?: boolean;
         "value"?: isoly.Date;

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -1084,6 +1084,7 @@ declare global {
         new (): HTMLSmoothlyCountryElement;
     };
     interface HTMLSmoothlyDateTextElementEventMap {
+        "smoothlyDateTextHasText": boolean;
         "smoothlyDateTextChange": isoly.Date | undefined;
         "smoothlyDateTextFocusChange": boolean;
         "smoothlyDateTextDone": void;
@@ -2421,6 +2422,7 @@ declare namespace LocalJSX {
         "onSmoothlyDateTextChange"?: (event: SmoothlyDateTextCustomEvent<isoly.Date | undefined>) => void;
         "onSmoothlyDateTextDone"?: (event: SmoothlyDateTextCustomEvent<void>) => void;
         "onSmoothlyDateTextFocusChange"?: (event: SmoothlyDateTextCustomEvent<boolean>) => void;
+        "onSmoothlyDateTextHasText"?: (event: SmoothlyDateTextCustomEvent<boolean>) => void;
         "onSmoothlyDateTextNext"?: (event: SmoothlyDateTextCustomEvent<void>) => void;
         "onSmoothlyDateTextPrevious"?: (event: SmoothlyDateTextCustomEvent<void>) => void;
         "placeholder"?: string;

--- a/src/components/form/demo/pet/index.tsx
+++ b/src/components/form/demo/pet/index.tsx
@@ -13,7 +13,7 @@ export class SmoothlyFormDemoPet {
 		firstName?: string
 		lastName?: string
 		birthday?: string
-		ownedRange?: isoly.DateRange
+		ownedRange?: Partial<isoly.DateRange>
 		height?: number
 		favoriteHat?: string
 		favoriteColor?: RGB

--- a/src/components/input/Input.ts
+++ b/src/components/input/Input.ts
@@ -15,7 +15,7 @@ export interface Input extends Input.Element {
 	parent: Editable | undefined
 }
 export namespace Input {
-	export type UserInput = { name: string; value: any }
+	export type UserInput<T = any> = { name: string; value: T }
 	export interface Element {
 		register: () => Promise<void>
 		unregister: () => Promise<void>

--- a/src/components/input/date/index.tsx
+++ b/src/components/input/date/index.tsx
@@ -151,12 +151,12 @@ export class SmoothlyInputDate implements ComponentWillLoad, Clearable, Input, E
 				tabindex={this.disabled ? undefined : 0}
 				class={{ "has-value": !!this.value, "has-text": this.hasText, "floating-label": this.alwaysShowFormat }}
 				onClick={(e: MouseEvent) => {
-					const includesTextElement = this.dateTextElement && e.composedPath().includes(this.dateTextElement)
-					const includesCalendar = this.calendarElement && e.composedPath().includes(this.calendarElement)
-					if (!this.readonly && !this.disabled && !includesTextElement && !includesCalendar) {
+					const includesTextElement = !!this.dateTextElement && e.composedPath().includes(this.dateTextElement)
+					const includesCalendar = !!this.calendarElement && e.composedPath().includes(this.calendarElement)
+					if (!this.readonly && !this.disabled && !includesTextElement && !includesCalendar)
 						this.dateTextElement?.select()
-						this.open = !this.open
-					}
+					if (!this.readonly && !this.disabled && !includesCalendar)
+						this.open = !this.open || includesTextElement
 				}}>
 				<slot name="start" />
 				<label class={"label float-on-focus"}>

--- a/src/components/input/date/index.tsx
+++ b/src/components/input/date/index.tsx
@@ -36,6 +36,8 @@ export class SmoothlyInputDate implements ComponentWillLoad, Clearable, Input, E
 	@Prop({ reflect: true }) disabled?: boolean
 	@Prop() invalid?: boolean = false
 	@Prop({ reflect: true }) errorMessage?: string
+	@Prop({ reflect: true }) placeholder?: string
+	@Prop({ reflect: true }) alwaysShowFormat = false
 	parent: Editable | undefined
 	changed = false
 	isDifferentFromInitial = false
@@ -147,7 +149,7 @@ export class SmoothlyInputDate implements ComponentWillLoad, Clearable, Input, E
 		return (
 			<Host
 				tabindex={this.disabled ? undefined : 0}
-				class={{ "has-value": !!this.value, "has-text": this.hasText }}
+				class={{ "has-value": !!this.value, "has-text": this.hasText, "floating-label": this.alwaysShowFormat }}
 				onClick={(e: MouseEvent) => {
 					const includesTextElement = this.dateTextElement && e.composedPath().includes(this.dateTextElement)
 					const includesCalendar = this.calendarElement && e.composedPath().includes(this.calendarElement)
@@ -160,6 +162,7 @@ export class SmoothlyInputDate implements ComponentWillLoad, Clearable, Input, E
 				<label class={"label float-on-focus"}>
 					<slot />
 				</label>
+				{this.placeholder && <span class="smoothly-date-placeholder">{this.placeholder}</span>}
 				<smoothly-date-text
 					ref={el => (this.dateTextElement = el)}
 					locale={this.locale}

--- a/src/components/input/date/index.tsx
+++ b/src/components/input/date/index.tsx
@@ -137,6 +137,14 @@ export class SmoothlyInputDate implements ComponentWillLoad, Clearable, Input, E
 		if (!this.readonly && !this.disabled && !includesCalendar && !includesIconsElement)
 			this.open = !this.open || includesTextElement
 	}
+	onUserChangedValue(event: CustomEvent<isoly.Date | undefined>) {
+		event.stopPropagation()
+		const newValue = event.detail ?? undefined // normalize null to undefined
+		if (this.value != newValue) {
+			this.value = newValue
+			this.smoothlyUserInput.emit({ name: this.name, value: this.value })
+		}
+	}
 	@Method()
 	async edit(editable: boolean) {
 		this.readonly = !editable
@@ -173,20 +181,10 @@ export class SmoothlyInputDate implements ComponentWillLoad, Clearable, Input, E
 					disabled={this.disabled}
 					showLabel={this.showLabel}
 					value={this.value}
-					onSmoothlyDateTextHasText={e => (this.hasText = e.detail)}
-					onSmoothlyDateTextFocusChange={e => (this.hasFocus = e.detail)}
-					onSmoothlyDateTextChange={e => {
-						e.stopPropagation()
-						const newValue = e.detail ?? undefined
-						if (this.value != newValue) {
-							this.value = newValue
-							this.smoothlyUserInput.emit({ name: this.name, value: this.value })
-						}
-					}}
-					onSmoothlyDateTextDone={() => {
-						this.open = false
-						this.dateTextElement?.deselect()
-					}}
+					onSmoothlyDateTextHasText={e => (e.stopPropagation(), (this.hasText = e.detail))}
+					onSmoothlyDateTextFocusChange={e => (e.stopPropagation(), (this.hasFocus = e.detail))}
+					onSmoothlyDateTextChange={e => this.onUserChangedValue(e)}
+					onSmoothlyDateTextDone={e => (e.stopPropagation(), (this.open = false), this.dateTextElement?.deselect())}
 				/>
 				<span class="icons" ref={el => (this.iconsElement = el)}>
 					<slot name={"end"} />
@@ -196,14 +194,7 @@ export class SmoothlyInputDate implements ComponentWillLoad, Clearable, Input, E
 						ref={el => (this.calendarElement = el)}
 						doubleInput={false}
 						value={this.value}
-						onSmoothlyValueChange={event => {
-							const newValue = event.detail ?? undefined
-							if (this.value != newValue) {
-								this.value = newValue
-								this.smoothlyUserInput.emit({ name: this.name, value: this.value })
-								event.stopPropagation()
-							}
-						}}
+						onSmoothlyValueChange={e => this.onUserChangedValue(e)}
 						max={this.max}
 						min={this.min}>
 						<div slot={"year-label"}>

--- a/src/components/input/date/index.tsx
+++ b/src/components/input/date/index.tsx
@@ -38,7 +38,7 @@ export class SmoothlyInputDate implements ComponentWillLoad, Clearable, Input, E
 	@Prop() invalid?: boolean = false
 	@Prop({ reflect: true }) errorMessage?: string
 	@Prop({ reflect: true }) placeholder?: string
-	@Prop({ reflect: true }) alwaysShowFormat = false
+	@Prop({ reflect: true }) alwaysShowGuide = false
 	parent: Editable | undefined
 	changed = false
 	isDifferentFromInitial = false
@@ -159,7 +159,7 @@ export class SmoothlyInputDate implements ComponentWillLoad, Clearable, Input, E
 		return (
 			<Host
 				tabindex={this.disabled ? undefined : 0}
-				class={{ "has-value": !!this.value, "has-text": this.hasText, "floating-label": this.alwaysShowFormat }}
+				class={{ "has-value": !!this.value, "has-text": this.hasText, "floating-label": this.alwaysShowGuide }}
 				onClick={(e: MouseEvent) => this.onClick(e)}>
 				<slot name="start" />
 				<label class={"label float-on-focus"}>

--- a/src/components/input/date/index.tsx
+++ b/src/components/input/date/index.tsx
@@ -26,6 +26,7 @@ import { Looks } from "../Looks"
 })
 export class SmoothlyInputDate implements ComponentWillLoad, Clearable, Input, Editable {
 	private dateTextElement?: HTMLSmoothlyDateTextElement
+	private iconsElement?: HTMLElement
 	private calendarElement?: HTMLElement
 	@Element() element: HTMLElement
 	@Prop({ reflect: true }) locale: isoly.Locale = navigator.language as isoly.Locale
@@ -153,9 +154,10 @@ export class SmoothlyInputDate implements ComponentWillLoad, Clearable, Input, E
 				onClick={(e: MouseEvent) => {
 					const includesTextElement = !!this.dateTextElement && e.composedPath().includes(this.dateTextElement)
 					const includesCalendar = !!this.calendarElement && e.composedPath().includes(this.calendarElement)
-					if (!this.readonly && !this.disabled && !includesTextElement && !includesCalendar)
+					const includesIconsElement = !!this.iconsElement && e.composedPath().includes(this.iconsElement)
+					if (!this.readonly && !this.disabled && !includesTextElement && !includesCalendar && !includesIconsElement)
 						this.dateTextElement?.select()
-					if (!this.readonly && !this.disabled && !includesCalendar)
+					if (!this.readonly && !this.disabled && !includesCalendar && !includesIconsElement)
 						this.open = !this.open || includesTextElement
 				}}>
 				<slot name="start" />
@@ -185,7 +187,7 @@ export class SmoothlyInputDate implements ComponentWillLoad, Clearable, Input, E
 						this.dateTextElement?.deselect()
 					}}
 				/>
-				<span class="icons">
+				<span class="icons" ref={el => (this.iconsElement = el)}>
 					<slot name={"end"} />
 				</span>
 				{this.open && !this.readonly && (

--- a/src/components/input/date/index.tsx
+++ b/src/components/input/date/index.tsx
@@ -37,6 +37,7 @@ export class SmoothlyInputDate implements ComponentWillLoad, Clearable, Input, E
 	@Prop() invalid?: boolean = false
 	@Prop({ reflect: true }) errorMessage?: string
 	parent: Editable | undefined
+	changed = false
 	isDifferentFromInitial = false
 	private hasFocus = false
 	private initialValue?: isoly.Date
@@ -46,7 +47,7 @@ export class SmoothlyInputDate implements ComponentWillLoad, Clearable, Input, E
 	@Prop({ mutable: true }) max: isoly.Date
 	@Prop({ mutable: true }) min: isoly.Date
 	@Prop({ reflect: true }) showLabel = true
-	@State() changed = false
+	@State() hasText = false
 	@Event() smoothlyInputLoad: EventEmitter<(parent: Editable) => void>
 	@Event() smoothlyValueChange: EventEmitter<isoly.Date>
 	@Event() smoothlyInput: EventEmitter<Record<string, any>>
@@ -146,7 +147,7 @@ export class SmoothlyInputDate implements ComponentWillLoad, Clearable, Input, E
 		return (
 			<Host
 				tabindex={this.disabled ? undefined : 0}
-				class={{ "has-value": !!this.value }}
+				class={{ "has-value": !!this.value, "has-text": this.hasText }}
 				onClick={(e: MouseEvent) => {
 					const includesTextElement = this.dateTextElement && e.composedPath().includes(this.dateTextElement)
 					const includesCalendar = this.calendarElement && e.composedPath().includes(this.calendarElement)
@@ -166,6 +167,7 @@ export class SmoothlyInputDate implements ComponentWillLoad, Clearable, Input, E
 					disabled={this.disabled}
 					showLabel={this.showLabel}
 					value={this.value}
+					onSmoothlyDateTextHasText={e => (this.hasText = e.detail)}
 					onSmoothlyDateTextFocusChange={e => (this.hasFocus = e.detail)}
 					onSmoothlyDateTextChange={e => {
 						e.stopPropagation()

--- a/src/components/input/date/index.tsx
+++ b/src/components/input/date/index.tsx
@@ -128,6 +128,15 @@ export class SmoothlyInputDate implements ComponentWillLoad, Clearable, Input, E
 	onWindowClick(event: Event): void {
 		!event.composedPath().includes(this.element) && this.open && (this.open = !this.open)
 	}
+	onClick(event: MouseEvent): void {
+		const includesTextElement = !!this.dateTextElement && event.composedPath().includes(this.dateTextElement)
+		const includesCalendar = !!this.calendarElement && event.composedPath().includes(this.calendarElement)
+		const includesIconsElement = !!this.iconsElement && event.composedPath().includes(this.iconsElement)
+		if (!this.readonly && !this.disabled && !includesTextElement && !includesCalendar && !includesIconsElement)
+			this.dateTextElement?.select()
+		if (!this.readonly && !this.disabled && !includesCalendar && !includesIconsElement)
+			this.open = !this.open || includesTextElement
+	}
 	@Method()
 	async edit(editable: boolean) {
 		this.readonly = !editable
@@ -151,15 +160,7 @@ export class SmoothlyInputDate implements ComponentWillLoad, Clearable, Input, E
 			<Host
 				tabindex={this.disabled ? undefined : 0}
 				class={{ "has-value": !!this.value, "has-text": this.hasText, "floating-label": this.alwaysShowFormat }}
-				onClick={(e: MouseEvent) => {
-					const includesTextElement = !!this.dateTextElement && e.composedPath().includes(this.dateTextElement)
-					const includesCalendar = !!this.calendarElement && e.composedPath().includes(this.calendarElement)
-					const includesIconsElement = !!this.iconsElement && e.composedPath().includes(this.iconsElement)
-					if (!this.readonly && !this.disabled && !includesTextElement && !includesCalendar && !includesIconsElement)
-						this.dateTextElement?.select()
-					if (!this.readonly && !this.disabled && !includesCalendar && !includesIconsElement)
-						this.open = !this.open || includesTextElement
-				}}>
+				onClick={(e: MouseEvent) => this.onClick(e)}>
 				<slot name="start" />
 				<label class={"label float-on-focus"}>
 					<slot />

--- a/src/components/input/date/range/index.tsx
+++ b/src/components/input/date/range/index.tsx
@@ -101,6 +101,14 @@ export class SmoothlyInputDateRange implements Clearable, Input, Editable {
 		if (!this.readonly && !this.disabled)
 			this.open = !this.open || includesTextElement
 	}
+	async onSmoothlyDateTextChange(event: CustomEvent<isoly.Date | undefined>, startOrEnd: "start" | "end") {
+		event.stopPropagation()
+		const newValue = event.detail ?? undefined
+		if (this[startOrEnd] != newValue) {
+			this[startOrEnd] = newValue
+			this.smoothlyUserInput.emit({ name: this.name, value: await this.getValue() })
+		}
+	}
 	async disconnectedCallback() {
 		if (!this.element.isConnected)
 			await this.unregister()
@@ -165,16 +173,9 @@ export class SmoothlyInputDateRange implements Clearable, Input, Editable {
 						ref={el => (this.startTextElement = el)}
 						class="start-date-text"
 						locale={this.locale}
-						onSmoothlyDateTextHasText={e => (this.startHasText = e.detail)}
-						onSmoothlyDateTextFocusChange={e => (this.hasFocus = e.detail)}
-						onSmoothlyDateTextChange={async e => {
-							e.stopPropagation()
-							const newValue = e.detail ?? undefined
-							if (this.start != newValue) {
-								this.start = newValue
-								this.smoothlyUserInput.emit({ name: this.name, value: await this.getValue() })
-							}
-						}}
+						onSmoothlyDateTextHasText={e => (e.stopPropagation(), (this.startHasText = e.detail))}
+						onSmoothlyDateTextFocusChange={e => (e.stopPropagation(), (this.hasFocus = e.detail))}
+						onSmoothlyDateTextChange={e => this.onSmoothlyDateTextChange(e, "start")}
 						onSmoothlyDateTextNext={() => this.endTextElement?.select()}
 						onSmoothlyDateTextDone={() => this.endTextElement?.select()}
 						value={this.start}
@@ -190,14 +191,7 @@ export class SmoothlyInputDateRange implements Clearable, Input, Editable {
 						locale={this.locale}
 						onSmoothlyDateTextHasText={e => (this.endHasText = e.detail)}
 						onSmoothlyDateTextFocusChange={e => (this.hasFocus = e.detail)}
-						onSmoothlyDateTextChange={async e => {
-							e.stopPropagation()
-							const newValue = e.detail ?? undefined
-							if (this.end != newValue) {
-								this.end = newValue
-								this.smoothlyUserInput.emit({ name: this.name, value: await this.getValue() })
-							}
-						}}
+						onSmoothlyDateTextChange={e => this.onSmoothlyDateTextChange(e, "end")}
 						onSmoothlyDateTextPrevious={() => this.startTextElement?.select("end")}
 						onSmoothlyDateTextDone={() => this.startTextElement?.deselect()}
 						value={this.end}
@@ -214,14 +208,8 @@ export class SmoothlyInputDateRange implements Clearable, Input, Editable {
 					<smoothly-calendar
 						doubleInput={true}
 						onSmoothlyValueChange={e => e.stopPropagation()}
-						onSmoothlyStartChange={e => {
-							e.stopPropagation()
-							this.start = e.detail
-						}}
-						onSmoothlyEndChange={e => {
-							e.stopPropagation()
-							this.end = e.detail
-						}}
+						onSmoothlyStartChange={e => (e.stopPropagation(), (this.start = e.detail))}
+						onSmoothlyEndChange={e => (e.stopPropagation(), (this.end = e.detail))}
 						onSmoothlyDateSet={e => e.stopPropagation()}
 						onSmoothlyDateRangeSet={e => {
 							e.stopPropagation()

--- a/src/components/input/date/range/index.tsx
+++ b/src/components/input/date/range/index.tsx
@@ -54,8 +54,6 @@ export class SmoothlyInputDateRange implements Clearable, Input, Editable {
 		!this.readonly && this.smoothlyFormDisable.emit(readonly => (this.readonly = readonly))
 		this.observer.publish()
 	}
-	// TODO: disable search fields in month selectors so that the input becomes typeable and then fix input handler
-	// I don't understand the comment above
 	@Watch("start")
 	startChanged(_: isoly.Date | undefined, oldValue: isoly.Date | undefined) {
 		this.updateValue(oldValue, this.end)

--- a/src/components/input/date/range/index.tsx
+++ b/src/components/input/date/range/index.tsx
@@ -151,15 +151,13 @@ export class SmoothlyInputDateRange implements Clearable, Input, Editable {
 				<span
 					class="smoothly-date-range-input-part"
 					onClick={(e: MouseEvent) => {
-						const includesStartTextElement = this.startTextElement && e.composedPath().includes(this.startTextElement)
-						const includesEndTextElement = this.endTextElement && e.composedPath().includes(this.endTextElement)
+						const includesStartTextElement = !!this.startTextElement && e.composedPath().includes(this.startTextElement)
+						const includesEndTextElement = !!this.endTextElement && e.composedPath().includes(this.endTextElement)
 						const includesTextElement = includesStartTextElement || includesEndTextElement
-						if (!includesTextElement && !this.readonly && !this.disabled) {
+						if (!includesTextElement && !this.readonly && !this.disabled)
 							this.start && !this.end ? this.endTextElement?.select() : this.startTextElement?.select()
-						}
-						if (!this.readonly && !this.disabled) {
-							this.open = !this.open
-						}
+						if (!this.readonly && !this.disabled)
+							this.open = !this.open || includesTextElement
 					}}>
 					<slot name="start" />
 					<label class={"label float-on-focus"}>

--- a/src/components/input/date/range/index.tsx
+++ b/src/components/input/date/range/index.tsx
@@ -54,12 +54,10 @@ export class SmoothlyInputDateRange implements Clearable, Input, Editable {
 	// I don't understand the comment above
 	@Watch("start")
 	startChanged(_: isoly.Date | undefined, oldValue: isoly.Date | undefined) {
-		console.trace("date-range startChanged", this.start, this.end)
 		this.updateValue(oldValue, this.end)
 	}
 	@Watch("end")
 	endChanged(_: isoly.Date | undefined, oldValue: isoly.Date | undefined) {
-		console.log("date-range endChanged", this.start, this.end)
 		this.updateValue(this.start, oldValue)
 	}
 
@@ -166,7 +164,6 @@ export class SmoothlyInputDateRange implements Clearable, Input, Editable {
 								this.start = newValue
 								this.smoothlyUserInput.emit({ name: this.name, value: await this.getValue() })
 							}
-							console.log("onSmoothlyDateTextChange start", newValue, this.start, this.end)
 						}}
 						onSmoothlyDateTextNext={() => this.endTextElement?.select()}
 						onSmoothlyDateTextDone={() => this.endTextElement?.select()}
@@ -189,7 +186,6 @@ export class SmoothlyInputDateRange implements Clearable, Input, Editable {
 								this.end = newValue
 								this.smoothlyUserInput.emit({ name: this.name, value: await this.getValue() })
 							}
-							console.log("onSmoothlyDateTextChange end", newValue, this.start, this.end)
 						}}
 						onSmoothlyDateTextPrevious={() => this.startTextElement?.select("end")}
 						onSmoothlyDateTextDone={() => this.startTextElement?.deselect()}

--- a/src/components/input/date/range/index.tsx
+++ b/src/components/input/date/range/index.tsx
@@ -25,7 +25,7 @@ export class SmoothlyInputDateRange implements Clearable, Input, Editable {
 	@Prop({ mutable: true }) start: isoly.Date | undefined
 	@Prop({ mutable: true }) end: isoly.Date | undefined
 	@Prop({ reflect: true }) placeholder: string
-	@Prop({ reflect: true }) alwaysShowFormat = false
+	@Prop({ reflect: true }) alwaysShowGuide = false
 	@Prop() invalid?: boolean = false
 	@Prop() max?: isoly.Date
 	@Prop() min?: isoly.Date
@@ -144,7 +144,7 @@ export class SmoothlyInputDateRange implements Clearable, Input, Editable {
 				class={{
 					"has-value": !!(this.start || this.end),
 					"has-text": !!(this.startHasText || this.endHasText),
-					"floating-label": this.alwaysShowFormat,
+					"floating-label": this.alwaysShowGuide,
 				}}>
 				<span
 					class="smoothly-date-range-input-part"

--- a/src/components/input/date/range/index.tsx
+++ b/src/components/input/date/range/index.tsx
@@ -34,6 +34,8 @@ export class SmoothlyInputDateRange implements Clearable, Input, Editable {
 	private initialStart?: isoly.Date
 	private initialEnd?: isoly.Date
 	@State() open: boolean
+	@State() startHasText = false
+	@State() endHasText = false
 	@Event() smoothlyInput: EventEmitter<{ [name: string]: Partial<isoly.DateRange> | undefined }>
 	@Event() smoothlyUserInput: EventEmitter<Input.UserInput<Partial<isoly.DateRange> | undefined>>
 	@Event() smoothlyInputLoad: EventEmitter<(parent: Editable) => void>
@@ -137,7 +139,9 @@ export class SmoothlyInputDateRange implements Clearable, Input, Editable {
 	}
 	render() {
 		return (
-			<Host tabindex={this.disabled ? undefined : 0} class={{ "has-value": !!(this.start || this.end) }}>
+			<Host
+				tabindex={this.disabled ? undefined : 0}
+				class={{ "has-value": !!(this.start || this.end), "has-text": !!(this.startHasText || this.endHasText) }}>
 				<span
 					class="smoothly-date-range-input-part"
 					onClick={(e: MouseEvent) => {
@@ -156,6 +160,7 @@ export class SmoothlyInputDateRange implements Clearable, Input, Editable {
 					<smoothly-date-text
 						ref={el => (this.startTextElement = el)}
 						class="start-date-text"
+						onSmoothlyDateTextHasText={e => (this.startHasText = e.detail)}
 						onSmoothlyDateTextFocusChange={e => (this.hasFocus = e.detail)}
 						onSmoothlyDateTextChange={async e => {
 							e.stopPropagation()
@@ -178,6 +183,7 @@ export class SmoothlyInputDateRange implements Clearable, Input, Editable {
 					<smoothly-date-text
 						ref={el => (this.endTextElement = el)}
 						class="end-date-text"
+						onSmoothlyDateTextHasText={e => (this.endHasText = e.detail)}
 						onSmoothlyDateTextFocusChange={e => (this.hasFocus = e.detail)}
 						onSmoothlyDateTextChange={async e => {
 							e.stopPropagation()

--- a/src/components/input/date/range/index.tsx
+++ b/src/components/input/date/range/index.tsx
@@ -24,6 +24,7 @@ export class SmoothlyInputDateRange implements Clearable, Input, Editable {
 	@Prop({ mutable: true }) start: isoly.Date | undefined
 	@Prop({ mutable: true }) end: isoly.Date | undefined
 	@Prop({ reflect: true }) placeholder: string
+	@Prop({ reflect: true }) alwaysShowFormat = false
 	@Prop() invalid?: boolean = false
 	@Prop() max?: isoly.Date
 	@Prop() min?: isoly.Date
@@ -141,7 +142,11 @@ export class SmoothlyInputDateRange implements Clearable, Input, Editable {
 		return (
 			<Host
 				tabindex={this.disabled ? undefined : 0}
-				class={{ "has-value": !!(this.start || this.end), "has-text": !!(this.startHasText || this.endHasText) }}>
+				class={{
+					"has-value": !!(this.start || this.end),
+					"has-text": !!(this.startHasText || this.endHasText),
+					"floating-label": this.alwaysShowFormat,
+				}}>
 				<span
 					class="smoothly-date-range-input-part"
 					onClick={(e: MouseEvent) => {

--- a/src/components/input/date/range/index.tsx
+++ b/src/components/input/date/range/index.tsx
@@ -92,6 +92,15 @@ export class SmoothlyInputDateRange implements Clearable, Input, Editable {
 	onWindowClick(event: Event): void {
 		!event.composedPath().includes(this.element) && this.open && (this.open = !this.open)
 	}
+	onClick(event: MouseEvent): void {
+		const includesStartTextElement = !!this.startTextElement && event.composedPath().includes(this.startTextElement)
+		const includesEndTextElement = !!this.endTextElement && event.composedPath().includes(this.endTextElement)
+		const includesTextElement = includesStartTextElement || includesEndTextElement
+		if (!includesTextElement && !this.readonly && !this.disabled)
+			this.start && !this.end ? this.endTextElement?.select() : this.startTextElement?.select()
+		if (!this.readonly && !this.disabled)
+			this.open = !this.open || includesTextElement
+	}
 	async disconnectedCallback() {
 		if (!this.element.isConnected)
 			await this.unregister()
@@ -146,17 +155,7 @@ export class SmoothlyInputDateRange implements Clearable, Input, Editable {
 					"has-text": !!(this.startHasText || this.endHasText),
 					"floating-label": this.alwaysShowGuide,
 				}}>
-				<span
-					class="smoothly-date-range-input-part"
-					onClick={(e: MouseEvent) => {
-						const includesStartTextElement = !!this.startTextElement && e.composedPath().includes(this.startTextElement)
-						const includesEndTextElement = !!this.endTextElement && e.composedPath().includes(this.endTextElement)
-						const includesTextElement = includesStartTextElement || includesEndTextElement
-						if (!includesTextElement && !this.readonly && !this.disabled)
-							this.start && !this.end ? this.endTextElement?.select() : this.startTextElement?.select()
-						if (!this.readonly && !this.disabled)
-							this.open = !this.open || includesTextElement
-					}}>
+				<span class="smoothly-date-range-input-part" onClick={(e: MouseEvent) => this.onClick(e)}>
 					<slot name="start" />
 					<label class={"label float-on-focus"}>
 						<slot />

--- a/src/components/input/date/range/index.tsx
+++ b/src/components/input/date/range/index.tsx
@@ -23,7 +23,7 @@ export class SmoothlyInputDateRange implements Clearable, Input, Editable {
 	@Prop({ reflect: true }) showLabel = true
 	@Prop({ mutable: true }) start: isoly.Date | undefined
 	@Prop({ mutable: true }) end: isoly.Date | undefined
-	@Prop() placeholder: string
+	@Prop({ reflect: true }) placeholder: string
 	@Prop() invalid?: boolean = false
 	@Prop() max?: isoly.Date
 	@Prop() min?: isoly.Date
@@ -157,6 +157,7 @@ export class SmoothlyInputDateRange implements Clearable, Input, Editable {
 					<label class={"label float-on-focus"}>
 						<slot />
 					</label>
+					{this.placeholder && <span class="smoothly-date-range-placeholder">{this.placeholder}</span>}
 					<smoothly-date-text
 						ref={el => (this.startTextElement = el)}
 						class="start-date-text"
@@ -176,7 +177,6 @@ export class SmoothlyInputDateRange implements Clearable, Input, Editable {
 						readonly={this.readonly}
 						disabled={this.disabled}
 						invalid={this.invalid}
-						placeholder={this.placeholder}
 						showLabel={this.showLabel}
 					/>
 					<span class="smoothly-date-range-separator"> – </span>
@@ -199,7 +199,6 @@ export class SmoothlyInputDateRange implements Clearable, Input, Editable {
 						readonly={this.readonly}
 						disabled={this.disabled}
 						invalid={this.invalid}
-						placeholder={this.placeholder}
 						showLabel={this.showLabel}
 					/>
 				</span>

--- a/src/components/input/date/range/index.tsx
+++ b/src/components/input/date/range/index.tsx
@@ -179,7 +179,7 @@ export class SmoothlyInputDateRange implements Clearable, Input, Editable {
 						placeholder={this.placeholder}
 						showLabel={this.showLabel}
 					/>
-					<span class="smoothly-date-range-separator"> — </span>
+					<span class="smoothly-date-range-separator"> – </span>
 					<smoothly-date-text
 						ref={el => (this.endTextElement = el)}
 						class="end-date-text"

--- a/src/components/input/date/range/index.tsx
+++ b/src/components/input/date/range/index.tsx
@@ -15,6 +15,7 @@ export class SmoothlyInputDateRange implements Clearable, Input, Editable {
 	private startTextElement?: HTMLSmoothlyDateTextElement
 	private endTextElement?: HTMLSmoothlyDateTextElement
 	@Element() element: HTMLElement
+	@Prop({ reflect: true }) locale: isoly.Locale = navigator.language as isoly.Locale
 	@Prop({ reflect: true }) name: string = "dateRange"
 	@Prop({ reflect: true, mutable: true }) color?: Color
 	@Prop({ reflect: true, mutable: true }) looks?: Looks
@@ -155,6 +156,8 @@ export class SmoothlyInputDateRange implements Clearable, Input, Editable {
 						const includesTextElement = includesStartTextElement || includesEndTextElement
 						if (!includesTextElement && !this.readonly && !this.disabled) {
 							this.start && !this.end ? this.endTextElement?.select() : this.startTextElement?.select()
+						}
+						if (!this.readonly && !this.disabled) {
 							this.open = !this.open
 						}
 					}}>
@@ -166,6 +169,7 @@ export class SmoothlyInputDateRange implements Clearable, Input, Editable {
 					<smoothly-date-text
 						ref={el => (this.startTextElement = el)}
 						class="start-date-text"
+						locale={this.locale}
 						onSmoothlyDateTextHasText={e => (this.startHasText = e.detail)}
 						onSmoothlyDateTextFocusChange={e => (this.hasFocus = e.detail)}
 						onSmoothlyDateTextChange={async e => {
@@ -188,6 +192,7 @@ export class SmoothlyInputDateRange implements Clearable, Input, Editable {
 					<smoothly-date-text
 						ref={el => (this.endTextElement = el)}
 						class="end-date-text"
+						locale={this.locale}
 						onSmoothlyDateTextHasText={e => (this.endHasText = e.detail)}
 						onSmoothlyDateTextFocusChange={e => (this.hasFocus = e.detail)}
 						onSmoothlyDateTextChange={async e => {

--- a/src/components/input/date/range/index.tsx
+++ b/src/components/input/date/range/index.tsx
@@ -139,15 +139,7 @@ export class SmoothlyInputDateRange implements Clearable, Input, Editable {
 	}
 	render() {
 		return (
-			<Host
-				onFocusin={() => {
-					console.log("focusin")
-				}}
-				onFocusout={() => {
-					console.log("focusout")
-				}}
-				tabindex={this.disabled ? undefined : 0}
-				class={{ "has-value": !!(this.start || this.end) }}>
+			<Host tabindex={this.disabled ? undefined : 0} class={{ "has-value": !!(this.start || this.end) }}>
 				<span
 					class="smoothly-date-range-input-part"
 					onClick={(e: MouseEvent) => {

--- a/src/components/input/date/range/style.scss
+++ b/src/components/input/date/range/style.scss
@@ -18,13 +18,19 @@
 	white-space: pre;
 }
 
+:host .smoothly-date-range-placeholder {
+	margin-inline: var(--input-padding-side);
+	display: none;
+}
+
+:host:not(:focus-within):not(.has-text) .smoothly-date-range-placeholder {
+	display: block;
+	opacity: 0.5;
+}
+
 :host:not(:focus-within):not(.has-text) smoothly-date-text,
 :host:not(:focus-within):not(.has-text) .smoothly-date-range-separator {
 	visibility: hidden;
-}
-
-:host[show-label] smoothly-date-text {
-	margin-block: var(--input-value-padding-top) var(--input-value-padding-bottom);
 }
 
 :host:not([show-label]) smoothly-date-text,
@@ -33,15 +39,19 @@
 }
 
 :host smoothly-date-text.start-date-text {
-	margin-inline: var(--input-padding-side) auto;
+	margin-inline: var(--input-padding-side) 0;
 }
 
 :host smoothly-date-text.end-date-text {
-	margin-inline: auto var(--input-padding-side);
+	margin-inline: 0 var(--input-padding-side);
 }
 
+:host[show-label] .smoothly-date-range-placeholder,
+:host[show-label] smoothly-date-text,
 :host[show-label] .smoothly-date-range-separator {
-	padding-block: var(--input-value-padding-top) var(--input-value-padding-bottom);
+	margin-block: var(--input-value-padding-top) var(--input-value-padding-bottom);
+
+	// padding-block: var(--input-value-padding-top) var(--input-value-padding-bottom);
 }
 
 :host:not([readonly]) > .smoothly-date-range-input-part > smoothly-input {

--- a/src/components/input/date/range/style.scss
+++ b/src/components/input/date/range/style.scss
@@ -6,6 +6,10 @@
 	background-color: rgb(var(--smoothly-input-background));
 }
 
+:host [slot=start] {
+	align-self: center;
+}
+
 :host .label {
 	left: var(--input-padding-side);
 }

--- a/src/components/input/date/range/style.scss
+++ b/src/components/input/date/range/style.scss
@@ -23,13 +23,13 @@
 	display: none;
 }
 
-:host:not(:focus-within):not(.has-text) .smoothly-date-range-placeholder {
+:host:not([always-show-format]):not(:focus-within):not(.has-text) .smoothly-date-range-placeholder {
 	display: block;
 	opacity: 0.5;
 }
 
-:host:not(:focus-within):not(.has-text) smoothly-date-text,
-:host:not(:focus-within):not(.has-text) .smoothly-date-range-separator {
+:host:not([always-show-format]):not(:focus-within):not(.has-text) smoothly-date-text,
+:host:not([always-show-format]):not(:focus-within):not(.has-text) .smoothly-date-range-separator {
 	visibility: hidden;
 }
 

--- a/src/components/input/date/range/style.scss
+++ b/src/components/input/date/range/style.scss
@@ -10,6 +10,31 @@
 	}
 }
 
+:host:not(:focus-within):not(.has-value):has(.has-text) smoothly-date-text:not(.has-text),
+:host:not(:focus-within):not(.has-value):has(.has-text) .smoothly-date-range-separator {
+	visibility: hidden;
+}
+
+:host[show-label] smoothly-date-text {
+	margin-block: var(--input-value-padding-top) var(--input-value-padding-bottom);
+}
+
+:host:not([show-label]) smoothly-date-text {
+	margin-block: auto;
+}
+
+:host smoothly-date-text.start-date-text {
+	margin-inline: var(--input-padding-side);
+}
+
+:host smoothly-date-text.end-date-text {
+	margin-inline: var(--input-padding-side) auto;
+}
+
+:host[show-label] .smoothly-date-range-separator {
+	padding-block: var(--input-value-padding-top) var(--input-value-padding-bottom);
+}
+
 :host:not([readonly]) > .smoothly-date-range-input-part > smoothly-input {
 	cursor: pointer;
 }

--- a/src/components/input/date/range/style.scss
+++ b/src/components/input/date/range/style.scss
@@ -4,10 +4,6 @@
 	position: relative;
 	display: flex;
 	background-color: rgb(var(--smoothly-input-background));
-
-	&:focus-within smoothly-input {
-		outline: none;
-	}
 }
 
 :host .label {
@@ -23,14 +19,16 @@
 	display: none;
 }
 
-:host:not([always-show-format]):not(:focus-within):not(.has-text) .smoothly-date-range-placeholder {
-	display: block;
-	opacity: 0.5;
-}
+:host:not([always-show-format]):not(:focus-within):not(.has-text) {
+	& .smoothly-date-range-placeholder {
+		display: block;
+		opacity: 0.5;
+	}
 
-:host:not([always-show-format]):not(:focus-within):not(.has-text) smoothly-date-text,
-:host:not([always-show-format]):not(:focus-within):not(.has-text) .smoothly-date-range-separator {
-	visibility: hidden;
+	& smoothly-date-text,
+	& .smoothly-date-range-separator {
+		visibility: hidden;
+	}
 }
 
 :host smoothly-date-text.start-date-text {
@@ -53,12 +51,11 @@
 	margin-block: auto;
 }
 
-:host:not([readonly]) > .smoothly-date-range-input-part > smoothly-input {
+:host:not([readonly]) {
 	cursor: pointer;
 }
 
-:host[disabled],
-:host[disabled] > .smoothly-date-range-input-part > smoothly-input {
+:host[disabled] {
 	cursor: not-allowed;
 }
 
@@ -91,13 +88,6 @@
 	background-color: var(--smoothly-input-background);
 	border-radius: 0.25rem;
 	cursor: pointer;
-}
-
-:host > .smoothly-date-range-input-part > smoothly-input {
-	min-width: 15rem;
-	width: 100%;
-	background-color: transparent;
-	--input-min-height: calc(var(--input-min-height) - 2px);
 }
 
 :host > span.icons {

--- a/src/components/input/date/range/style.scss
+++ b/src/components/input/date/range/style.scss
@@ -14,6 +14,10 @@
 	left: var(--input-padding-side);
 }
 
+:host .smoothly-date-range-separator {
+	white-space: pre;
+}
+
 :host:not(:focus-within):not(.has-text) smoothly-date-text,
 :host:not(:focus-within):not(.has-text) .smoothly-date-range-separator {
 	visibility: hidden;
@@ -29,11 +33,11 @@
 }
 
 :host smoothly-date-text.start-date-text {
-	margin-inline: var(--input-padding-side);
+	margin-inline: var(--input-padding-side) auto;
 }
 
 :host smoothly-date-text.end-date-text {
-	margin-inline: var(--input-padding-side) auto;
+	margin-inline: auto var(--input-padding-side);
 }
 
 :host[show-label] .smoothly-date-range-separator {

--- a/src/components/input/date/range/style.scss
+++ b/src/components/input/date/range/style.scss
@@ -33,11 +33,6 @@
 	visibility: hidden;
 }
 
-:host:not([show-label]) smoothly-date-text,
-:host:not([show-label]) .smoothly-date-range-separator {
-	margin-block: auto;
-}
-
 :host smoothly-date-text.start-date-text {
 	margin-inline: var(--input-padding-side) 0;
 }
@@ -50,8 +45,12 @@
 :host[show-label] smoothly-date-text,
 :host[show-label] .smoothly-date-range-separator {
 	margin-block: var(--input-value-padding-top) var(--input-value-padding-bottom);
+}
 
-	// padding-block: var(--input-value-padding-top) var(--input-value-padding-bottom);
+:host:not([show-label]) .smoothly-date-range-placeholder,
+:host:not([show-label]) smoothly-date-text,
+:host:not([show-label]) .smoothly-date-range-separator {
+	margin-block: auto;
 }
 
 :host:not([readonly]) > .smoothly-date-range-input-part > smoothly-input {

--- a/src/components/input/date/range/style.scss
+++ b/src/components/input/date/range/style.scss
@@ -23,7 +23,7 @@
 	display: none;
 }
 
-:host:not([always-show-format]):not(:focus-within):not(.has-text) {
+:host:not([always-show-guide]):not(:focus-within):not(.has-text) {
 	& .smoothly-date-range-placeholder {
 		display: block;
 		opacity: 0.5;

--- a/src/components/input/date/range/style.scss
+++ b/src/components/input/date/range/style.scss
@@ -23,7 +23,8 @@
 	margin-block: var(--input-value-padding-top) var(--input-value-padding-bottom);
 }
 
-:host:not([show-label]) smoothly-date-text {
+:host:not([show-label]) smoothly-date-text,
+:host:not([show-label]) .smoothly-date-range-separator {
 	margin-block: auto;
 }
 

--- a/src/components/input/date/range/style.scss
+++ b/src/components/input/date/range/style.scss
@@ -10,8 +10,12 @@
 	}
 }
 
-:host:not(:focus-within):not(.has-value):has(.has-text) smoothly-date-text:not(.has-text),
-:host:not(:focus-within):not(.has-value):has(.has-text) .smoothly-date-range-separator {
+:host .label {
+	left: var(--input-padding-side);
+}
+
+:host:not(:focus-within):not(.has-text) smoothly-date-text,
+:host:not(:focus-within):not(.has-text) .smoothly-date-range-separator {
 	visibility: hidden;
 }
 
@@ -80,12 +84,6 @@
 	width: 100%;
 	background-color: transparent;
 	--input-min-height: calc(var(--input-min-height) - 2px);
-}
-
-:host > .smoothly-date-range-input-part > span {
-	padding-block: 0.5rem;
-	padding-inline: 0.2rem;
-	align-self: center;
 }
 
 :host > span.icons {

--- a/src/components/input/date/style.css
+++ b/src/components/input/date/style.css
@@ -11,12 +11,12 @@
 :host .smoothly-date-placeholder {
 	display: none;
 }
-:host:not([always-show-format]):not(:focus-within):not(.has-text) .smoothly-date-placeholder {
+:host:not([always-show-guide]):not(:focus-within):not(.has-text) .smoothly-date-placeholder {
 	opacity: 0.5;
 	display: block;
 }
 
-:host:not([always-show-format]):not(:focus-within):not(.has-text) smoothly-date-text {
+:host:not([always-show-guide]):not(:focus-within):not(.has-text) smoothly-date-text {
 	visibility: hidden;
 }
 

--- a/src/components/input/date/style.css
+++ b/src/components/input/date/style.css
@@ -9,6 +9,22 @@
 	min-height: var(--input-min-height);
 }
 
+:host:not(:focus-within):not(.has-value) smoothly-date-text:not(.has-text) {
+	visibility: hidden;
+}
+
+:host>.label {
+	left: var(--input-padding-side);
+}
+:host[show-label] > smoothly-date-text {
+	margin-inline: var(--input-padding-side) auto;
+	margin-block: var(--input-value-padding-top) var(--input-value-padding-bottom);
+}
+:host:not([show-label]) > smoothly-date-text {
+	margin-inline: var(--input-padding-side) auto;
+	margin-block: auto;
+}
+
 :host>smoothly-input {
 	width: 100%;
 	--input-min-height: calc(var(--input-min-height) - 2px);

--- a/src/components/input/date/style.css
+++ b/src/components/input/date/style.css
@@ -8,18 +8,27 @@
 	box-sizing: border-box;
 	min-height: var(--input-min-height);
 }
+:host .smoothly-date-placeholder {
+	display: none;
+}
+:host:not([always-show-format]):not(:focus-within):not(.has-text) .smoothly-date-placeholder {
+	opacity: 0.5;
+	display: block;
+}
 
-:host:not(:focus-within):not(.has-value) smoothly-date-text:not(.has-text) {
+:host:not([always-show-format]):not(:focus-within):not(.has-text) smoothly-date-text {
 	visibility: hidden;
 }
 
 :host>.label {
 	left: var(--input-padding-side);
 }
+:host[show-label] > .smoothly-date-placeholder,
 :host[show-label] > smoothly-date-text {
 	margin-inline: var(--input-padding-side) auto;
 	margin-block: var(--input-value-padding-top) var(--input-value-padding-bottom);
 }
+:host:not([show-label]) > .smoothly-date-placeholder,
 :host:not([show-label]) > smoothly-date-text {
 	margin-inline: var(--input-padding-side) auto;
 	margin-block: auto;

--- a/src/components/input/date/style.css
+++ b/src/components/input/date/style.css
@@ -33,23 +33,12 @@
 	margin-inline: var(--input-padding-side) auto;
 	margin-block: auto;
 }
-
-:host>smoothly-input {
-	width: 100%;
-	--input-min-height: calc(var(--input-min-height) - 2px);
-}
-
-:host:not([readonly])>smoothly-input>div>input {
+:host:not([readonly]) {
 	cursor: pointer;
 }
 
-:host[disabled],
-:host[disabled]>smoothly-input>div>input {
+:host[disabled] {
 	cursor: not-allowed;
-}
-
-:host[looks=transparent] smoothly-input {
-	outline: none;
 }
 
 :host>smoothly-calendar {

--- a/src/components/input/date/style.css
+++ b/src/components/input/date/style.css
@@ -25,7 +25,7 @@
 }
 :host[show-label] > .smoothly-date-placeholder,
 :host[show-label] > smoothly-date-text {
-	margin-inline: var(--input-padding-side) auto;
+	margin-inline: var(--input-padding-side);
 	margin-block: var(--input-value-padding-top) var(--input-value-padding-bottom);
 }
 :host:not([show-label]) > .smoothly-date-placeholder,
@@ -79,4 +79,5 @@
 	display: flex;
 	flex-direction: row;
 	align-items: center;
+	margin-left: auto;
 }

--- a/src/components/input/date/text/DateFormat.spec.ts
+++ b/src/components/input/date/text/DateFormat.spec.ts
@@ -10,8 +10,8 @@ describe("DateFormat", () => {
 		[{ M: "01" }, 31],
 		[{ M: "04" }, 30],
 		[{}, 31],
-	])("Parts.maxDay %p", (parts, expected) => {
-		expect(DateFormat.Parts.maxDay(parts)).toBe(expected)
+	])("Parts.lastDay %p", (parts, expected) => {
+		expect(DateFormat.Parts.lastDay(parts)).toBe(expected)
 	})
 
 	it.each([

--- a/src/components/input/date/text/DateFormat.spec.ts
+++ b/src/components/input/date/text/DateFormat.spec.ts
@@ -1,0 +1,31 @@
+import { DateFormat } from "./DateFormat"
+
+describe("DateFormat", () => {
+	it.each([
+		[{ Y: "2024", M: "02" }, 29],
+		[{ Y: "2023", M: "02" }, 28],
+		[{ Y: "2024", M: "01" }, 31],
+		[{ Y: "2024", M: "04" }, 30],
+		[{ M: "02" }, 29],
+		[{ M: "01" }, 31],
+		[{ M: "04" }, 30],
+		[{}, 31],
+	])("Parts.maxDay %p", (parts, expected) => {
+		expect(DateFormat.Parts.maxDay(parts)).toBe(expected)
+	})
+
+	it.each([
+		[{ Y: "2024", M: "02", D: "29" }, "2024-02-29"],
+		[{ Y: "2023", M: "02", D: "29" }, "2023-02-28"],
+		[{ Y: "2024", M: "04", D: "31" }, "2024-04-30"],
+		[{ Y: "2024", M: "04" }, undefined],
+		[{ Y: "2024" }, undefined],
+		[{ M: "04", D: "31" }, undefined],
+		[{ D: "31" }, undefined],
+		[{}, undefined],
+		[{ Y: "201", M: "01", D: "01" }, undefined], // Not padded
+	])("Part.toDate %p", (parts: DateFormat.Parts, expected: string | undefined) => {
+		expect(DateFormat.Parts.toDate(parts)).toBe(expected)
+		expect(DateFormat.Parts.toDate(parts)).not.toBe(null)
+	})
+})

--- a/src/components/input/date/text/DateFormat.ts
+++ b/src/components/input/date/text/DateFormat.ts
@@ -87,7 +87,7 @@ export namespace DateFormat {
 		export function getPart(order: Order, index: number): Part {
 			return order.charAt(index) as Part
 		}
-		export function toParts(order: Order): Part[] {
+		export function toArray(order: Order): Part[] {
 			return order.split("") as Part[]
 		}
 	}

--- a/src/components/input/date/text/DateFormat.ts
+++ b/src/components/input/date/text/DateFormat.ts
@@ -10,6 +10,9 @@ export namespace DateFormat {
 	export type Part = "Y" | "M" | "D"
 	export type Parts = { [part in Part]?: string }
 	export namespace Part {
+		export function isComplete(part: Part, value: string | undefined): boolean {
+			return (value?.length ?? 0) >= DateFormat.Part.lengthOf(part)
+		}
 		export function lengthOf(part: Part): number {
 			return guides[part].length
 		}

--- a/src/components/input/date/text/DateFormat.ts
+++ b/src/components/input/date/text/DateFormat.ts
@@ -19,7 +19,7 @@ export namespace DateFormat {
 		}
 	}
 	export namespace Parts {
-		export function maxDay(parts: Parts): number {
+		export function lastDay(parts: Parts): number {
 			if (parts.Y && parts.M && parseInt(parts.M) >= 1 && parseInt(parts.M) <= 12) {
 				const lastDate = isoly.Date.lastOfMonth(`${parts.Y.padStart(4, "0")}-${parts.M.padStart(2, "0")}-01`)
 				return isoly.Date.getDay(lastDate)

--- a/src/components/input/date/text/DateFormat.ts
+++ b/src/components/input/date/text/DateFormat.ts
@@ -84,6 +84,12 @@ export namespace DateFormat {
 					return "YMD"
 			}
 		}
+		export function getPart(order: Order, index: number): Part {
+			return order.charAt(index) as Part
+		}
+		export function toParts(order: Order): Part[] {
+			return order.split("") as Part[]
+		}
 	}
 
 	export type Separator = "-" | "/" | "."

--- a/src/components/input/date/text/DateFormat.ts
+++ b/src/components/input/date/text/DateFormat.ts
@@ -15,10 +15,7 @@ export namespace DateFormat {
 		}
 		export function getGuide(part: Part, filledLength: number | undefined): string {
 			const ghost = DateFormat.ghosts[part]
-			if (filledLength === undefined) {
-				return ghost
-			}
-			return ghost.substring(0, ghost.length - filledLength)
+			return ghost.substring(0, ghost.length - (filledLength ?? 0))
 		}
 	}
 	export namespace Parts {

--- a/src/components/input/date/text/DateFormat.ts
+++ b/src/components/input/date/text/DateFormat.ts
@@ -1,7 +1,7 @@
 import { isoly } from "isoly"
 
 export namespace DateFormat {
-	export const ghosts = {
+	export const guides = {
 		Y: "YYYY",
 		M: "MM",
 		D: "DD",
@@ -11,11 +11,11 @@ export namespace DateFormat {
 	export type Parts = { [part in Part]?: string }
 	export namespace Part {
 		export function lengthOf(part: Part): number {
-			return ghosts[part].length
+			return guides[part].length
 		}
 		export function getGuide(part: Part, filledLength: number | undefined): string {
-			const ghost = DateFormat.ghosts[part]
-			return ghost.substring(0, ghost.length - (filledLength ?? 0))
+			const guide = DateFormat.guides[part]
+			return guide.substring(0, guide.length - (filledLength ?? 0))
 		}
 	}
 	export namespace Parts {

--- a/src/components/input/date/text/DateFormat.ts
+++ b/src/components/input/date/text/DateFormat.ts
@@ -1,0 +1,115 @@
+import { isoly } from "isoly"
+
+export namespace DateFormat {
+	export const ghosts = {
+		Y: "YYYY",
+		M: "MM",
+		D: "DD",
+	} as const
+
+	export type Part = "Y" | "M" | "D"
+	export type Parts = { [part in Part]?: string }
+	export namespace Part {
+		export function length(part: Part): number {
+			return ghosts[part].length
+		}
+		export function getGuide(part: Part, filledLength: number | undefined): string {
+			const ghost = DateFormat.ghosts[part]
+			if (filledLength === undefined) {
+				return ghost
+			}
+			return ghost.substring(0, ghost.length - filledLength)
+		}
+	}
+	export namespace Parts {
+		export function maxDay(parts: Parts): number {
+			if (parts.Y && parts.M && parseInt(parts.M) >= 1 && parseInt(parts.M) <= 12) {
+				const lastDate = isoly.Date.lastOfMonth(`${parts.Y.padStart(4, "0")}-${parts.M.padStart(2, "0")}-01`)
+				return isoly.Date.getDay(lastDate)
+			} else if (parts.M && parseInt(parts.M) >= 1 && parseInt(parts.M) <= 12) {
+				// Assume leap year
+				const lastDate = isoly.Date.lastOfMonth(`2004-${parts.M.padStart(2, "0")}-01`)
+				return isoly.Date.getDay(lastDate)
+			}
+			return 31
+		}
+		export function toDate(parts: Parts): isoly.Date | undefined {
+			if (parts.Y && parts.Y.length == 4 && parts.M && parts.M.length == 2 && parts.D && parts.D.length == 2) {
+				const value = `${parts.Y}-${parts.M}-${parts.D}`
+				const lastOfMonth = isoly.Date.lastOfMonth(`${parts.Y}-${parts.M}-01`)
+				return lastOfMonth < value ? lastOfMonth : value
+			}
+			return undefined
+		}
+		export function fromDate(value: isoly.Date): Required<DateFormat.Parts>
+		export function fromDate(value: undefined): undefined
+		export function fromDate(value: isoly.Date | undefined): Required<DateFormat.Parts> | undefined
+		export function fromDate(value: isoly.Date | undefined): Required<DateFormat.Parts> | undefined {
+			if (value) {
+				return {
+					Y: value.substring(0, 4).padStart(4, "0"),
+					M: value.substring(5, 7).padStart(2, "0"),
+					D: value.substring(8, 10).padStart(2, "0"),
+				}
+			}
+			return undefined
+		}
+	}
+
+	export type Order = "YMD" | "DMY" | "MDY"
+
+	export namespace Order {
+		export function fromLocale(locale: isoly.Locale): Order {
+			switch (locale) {
+				case "en-US":
+					return "MDY"
+				case "sq-AL":
+				case "es-AR":
+				case "it-IT":
+				case "en-GB":
+				case "fr-FR":
+				case "et-EE":
+				case "de-AT":
+				case "de-DE":
+				case "he-IL":
+				case "is-IS":
+				case "lv-LV":
+				case "pl-PL":
+				case "ru-RU":
+				case "fi-FI":
+				case "hi-IN":
+				case "en-IN":
+					return "DMY"
+				default:
+					return "YMD"
+			}
+		}
+	}
+
+	export type Separator = "-" | "/" | "."
+	export namespace Separator {
+		export function fromLocale(locale: isoly.Locale): Separator {
+			switch (locale) {
+				case "sq-AL":
+				case "es-AR":
+				case "it-IT":
+				case "en-GB":
+				case "fr-FR":
+				case "en-US":
+					return "/"
+				case "et-EE":
+				case "de-AT":
+				case "de-DE":
+				case "he-IL":
+				case "is-IS":
+				case "lv-LV":
+				case "pl-PL":
+				case "ru-RU":
+				case "fi-FI":
+					return "."
+				default:
+					return "-"
+			}
+		}
+	}
+}

--- a/src/components/input/date/text/DateFormat.ts
+++ b/src/components/input/date/text/DateFormat.ts
@@ -10,7 +10,7 @@ export namespace DateFormat {
 	export type Part = "Y" | "M" | "D"
 	export type Parts = { [part in Part]?: string }
 	export namespace Part {
-		export function length(part: Part): number {
+		export function lengthOf(part: Part): number {
 			return ghosts[part].length
 		}
 		export function getGuide(part: Part, filledLength: number | undefined): string {

--- a/src/components/input/date/text/InputSelection.ts
+++ b/src/components/input/date/text/InputSelection.ts
@@ -1,0 +1,88 @@
+export namespace InputSelection {
+	export function isAtStart(event: KeyboardEvent): boolean {
+		const el = event.currentTarget as HTMLElement
+		const sel = window.getSelection()
+		if (!sel || sel.rangeCount === 0 || !el.contains(sel.anchorNode))
+			return false
+
+		// Only trigger if there is no selection (caret only)
+		if (!sel.isCollapsed)
+			return false
+
+		const range = sel.getRangeAt(0)
+		const preRange = range.cloneRange()
+		preRange.selectNodeContents(el)
+		preRange.setEnd(range.startContainer, range.startOffset)
+
+		return preRange.toString().length === 0
+	}
+
+	export function isAtEnd(event: KeyboardEvent): boolean {
+		const el = event.currentTarget as HTMLElement
+		const sel = window.getSelection()
+		if (!sel || sel.rangeCount === 0 || !el.contains(sel.anchorNode))
+			return false
+
+		// Only trigger if there is no selection (caret only)
+		if (!sel.isCollapsed)
+			return false
+
+		const range = sel.getRangeAt(0)
+		const postRange = range.cloneRange()
+		postRange.selectNodeContents(el)
+		postRange.setStart(range.endContainer, range.endOffset)
+
+		return postRange.toString().length === 0
+	}
+
+	export function selectAll(el?: HTMLElement) {
+		if (!el)
+			return
+		el.focus()
+		const range = document.createRange()
+		range.selectNodeContents(el) // Select all content inside
+
+		const sel = window.getSelection()
+		if (!sel)
+			return
+
+		sel.removeAllRanges()
+		sel.addRange(range) // Apply the selection
+	}
+
+	export function setPosition(el: HTMLElement | undefined, index: number) {
+		if (!el)
+			return
+
+		el.focus()
+
+		const selection = window.getSelection()
+		if (!selection)
+			return
+
+		const range = document.createRange()
+		const textNode = el.firstChild || el
+
+		const position = Math.max(0, Math.min(index, el.innerText.length))
+		range.setStart(textNode, position)
+		range.collapse(true)
+
+		selection.removeAllRanges()
+		selection.addRange(range)
+	}
+
+	export function isCollapsed(el: HTMLElement): boolean {
+		const sel = window.getSelection()
+		if (!sel || sel.rangeCount === 0)
+			return true // nothing selected at all
+
+		const range = sel.getRangeAt(0)
+
+		// Make sure selection is inside our element
+		if (!el.contains(range.startContainer) || !el.contains(range.endContainer)) {
+			return true
+		}
+
+		return range.collapsed
+	}
+}

--- a/src/components/input/date/text/index.tsx
+++ b/src/components/input/date/text/index.tsx
@@ -145,6 +145,35 @@ export class SmoothlyInputDateRangeText {
 			}
 		}
 	}
+	keyDownHandler(e: KeyboardEvent) {
+		const text = this.getInnerText(e.target)
+		const index = this.focusedIndex ?? 0
+		if (InputSelection.isAtStart(e) && e.key == "ArrowLeft") {
+			this.autoAdvanceIfPossible(index)
+			this.setFocus(index - 1)
+			e.preventDefault() // Keep selection
+		} else if (InputSelection.isAtEnd(e) && e.key == "ArrowRight") {
+			this.autoAdvanceIfPossible(index)
+			this.setFocus(index + 1)
+			e.preventDefault() // Keep selection
+		} else if (e.key == "Home" || e.key == "ArrowUp") {
+			this.autoAdvanceIfPossible(index)
+			this.setFocus(0)
+			e.preventDefault() // Keep selection
+		} else if (e.key == "End" || e.key == "ArrowDown") {
+			this.autoAdvanceIfPossible(index)
+			this.setFocus(2)
+			e.preventDefault() // Keep selection
+		} else if (InputSelection.isAtStart(e) && e.key == "Backspace" && text == "") {
+			this.autoAdvanceIfPossible(index)
+			this.setFocus(index - 1)
+			e.preventDefault() // Prevent delete previous part
+		} else if (InputSelection.isAtEnd(e) && e.key == "Delete" && text == "") {
+			this.autoAdvanceIfPossible(index)
+			this.setFocus(index + 1)
+			e.preventDefault() // Prevent delete next part
+		}
+	}
 
 	commitPart(part: DateFormat.Part, value: number, index: number, max: number) {
 		const clamped = Math.max(1, Math.min(value, max))
@@ -193,34 +222,7 @@ export class SmoothlyInputDateRangeText {
 							}}
 							onFocus={() => (this.focusedIndex = index)}
 							onBlur={() => (this.focusedIndex = undefined)}
-							onKeyDown={(e: KeyboardEvent) => {
-								const text = this.getInnerText(e.target)
-								if (InputSelection.isAtStart(e) && e.key == "ArrowLeft") {
-									this.autoAdvanceIfPossible(index)
-									this.setFocus(index - 1)
-									e.preventDefault() // Keep selection
-								} else if (InputSelection.isAtEnd(e) && e.key == "ArrowRight") {
-									this.autoAdvanceIfPossible(index)
-									this.setFocus(index + 1)
-									e.preventDefault() // Keep selection
-								} else if (e.key == "Home" || e.key == "ArrowUp") {
-									this.autoAdvanceIfPossible(index)
-									this.setFocus(0)
-									e.preventDefault() // Keep selection
-								} else if (e.key == "End" || e.key == "ArrowDown") {
-									this.autoAdvanceIfPossible(index)
-									this.setFocus(2)
-									e.preventDefault() // Keep selection
-								} else if (InputSelection.isAtStart(e) && e.key == "Backspace" && text == "") {
-									this.autoAdvanceIfPossible(index)
-									this.setFocus(index - 1)
-									e.preventDefault() // Prevent delete previous part
-								} else if (InputSelection.isAtEnd(e) && e.key == "Delete" && text == "") {
-									this.autoAdvanceIfPossible(index)
-									this.setFocus(index + 1)
-									e.preventDefault() // Prevent delete next part
-								}
-							}}
+							onKeyDown={(e: KeyboardEvent) => this.keyDownHandler(e)}
 							key={index}
 							ref={el => (this.partElements[index] = el)}
 							contenteditable={!(this.readonly || this.disabled)}>

--- a/src/components/input/date/text/index.tsx
+++ b/src/components/input/date/text/index.tsx
@@ -186,7 +186,7 @@ export class SmoothlyInputDateRangeText {
 	render() {
 		return (
 			<Host class={{ "has-text": Object.values(this.parts).some(part => !!part) }}>
-				{DateFormat.Order.toParts(this.order).map((part, index) => (
+				{DateFormat.Order.toArray(this.order).map((part, index) => (
 					<span
 						onClick={() => {
 							if (!this.readonly && !this.disabled)

--- a/src/components/input/date/text/index.tsx
+++ b/src/components/input/date/text/index.tsx
@@ -125,7 +125,7 @@ export class SmoothlyInputDateRangeText {
 
 		if (["D", "M"].includes(part)) {
 			const isDay = part == "D"
-			const max = isDay ? DateFormat.Parts.maxDay(this.parts) : 12
+			const max = isDay ? DateFormat.Parts.lastDay(this.parts) : 12
 			const singleDigitThreshold = isDay ? 3 : 1
 			const numberValue = parseInt(value)
 			if (value.length >= 2) {
@@ -190,7 +190,7 @@ export class SmoothlyInputDateRangeText {
 		const part = DateFormat.Order.getPart(this.order, index)
 		const value = this.parts[part] ?? ""
 		if (part == "D" && value.length == 1) {
-			this.autoAdvancePart(part, parseInt(value), index, DateFormat.Parts.maxDay(this.parts))
+			this.autoAdvancePart(part, parseInt(value), index, DateFormat.Parts.lastDay(this.parts))
 		} else if (part == "M" && value.length == 1) {
 			this.autoAdvancePart(part, parseInt(value), index, 12)
 		}

--- a/src/components/input/date/text/index.tsx
+++ b/src/components/input/date/text/index.tsx
@@ -24,7 +24,6 @@ export class SmoothlyInputDateRangeText {
 	@Prop({ reflect: true }) readonly: boolean
 	@Prop({ reflect: true }) disabled: boolean
 	@Prop({ reflect: true }) invalid: boolean
-	@Prop({ reflect: true }) placeholder: string
 	@Prop({ reflect: true }) showLabel = true
 	@Prop() value?: isoly.Date // Only used for initial value
 	@State() parts: DateFormat.Parts = {}

--- a/src/components/input/date/text/index.tsx
+++ b/src/components/input/date/text/index.tsx
@@ -99,11 +99,11 @@ export class SmoothlyInputDateRangeText {
 		const part = this.order[this.focusedIndex ?? 0] as "Y" | "M" | "D"
 		const value = this.getInnerText(e.target)
 		const nonDigitData = e.data && /\D/.test(e.data)
-		const hasMaxLength = value.length >= DateFormat.Part.lengthOf(part)
+		const isComplete = DateFormat.Part.isComplete(part, value)
 		const noRangedSelection = InputSelection.isCollapsed(e.target as HTMLElement)
 		if (
 			(e.inputType == "insertText" || e.inputType == "insertFromPaste") &&
-			(nonDigitData || (hasMaxLength && noRangedSelection))
+			(nonDigitData || (isComplete && noRangedSelection))
 		) {
 			e.preventDefault()
 		}
@@ -134,7 +134,7 @@ export class SmoothlyInputDateRangeText {
 				this.autoAdvancePart(part, numberValue, index, max)
 			}
 		}
-		if (value.length >= DateFormat.Part.lengthOf(part)) {
+		if (DateFormat.Part.isComplete(part, value)) {
 			this.setFocus(index + 1)
 		}
 		const roundedValue = DateFormat.Parts.toDate(this.parts)

--- a/src/components/input/date/text/index.tsx
+++ b/src/components/input/date/text/index.tsx
@@ -105,7 +105,7 @@ export class SmoothlyInputDateRangeText {
 		const part = this.order[this.focusedIndex ?? 0] as "Y" | "M" | "D"
 		const value = this.getInnerText(e.target)
 		const nonDigitData = e.data && /\D/.test(e.data)
-		const hasMaxLength = value.length >= DateFormat.Part.length(part)
+		const hasMaxLength = value.length >= DateFormat.Part.lengthOf(part)
 		const noRangedSelection = InputSelection.isCollapsed(e.target as HTMLElement)
 		if (
 			(e.inputType == "insertText" || e.inputType == "insertFromPaste") &&
@@ -140,7 +140,7 @@ export class SmoothlyInputDateRangeText {
 				this.autoAdvancePart(part, numberValue, index, max)
 			}
 		}
-		if (value.length >= DateFormat.Part.length(part)) {
+		if (value.length >= DateFormat.Part.lengthOf(part)) {
 			this.setFocus(index + 1)
 		}
 		const roundedValue = DateFormat.Parts.toDate(this.parts)
@@ -195,7 +195,7 @@ export class SmoothlyInputDateRangeText {
 						<span
 							class={{
 								"smoothly-date-text-part": true,
-								"filled-part": (this.parts[part]?.length ?? 0) >= DateFormat.Part.length(part),
+								"filled-part": (this.parts[part]?.length ?? 0) >= DateFormat.Part.lengthOf(part),
 							}}
 							onFocus={() => (this.focusedIndex = index)}
 							onBlur={() => (this.focusedIndex = undefined)}

--- a/src/components/input/date/text/index.tsx
+++ b/src/components/input/date/text/index.tsx
@@ -121,7 +121,7 @@ export class SmoothlyInputDateRangeText {
 
 	@Listen("input", { capture: true })
 	inputHandler(e: InputEvent) {
-		const part = this.order[this.focusedIndex ?? 0] as "Y" | "M" | "D"
+		const part = DateFormat.Order.getPart(this.order, this.focusedIndex ?? 0)
 		const index = this.focusedIndex ?? 0
 		const value = this.getInnerText(e.target)
 		this.parts = {
@@ -164,7 +164,7 @@ export class SmoothlyInputDateRangeText {
 	}
 
 	autoAdvanceIfPossible(index: number) {
-		const part = this.order[index] as "Y" | "M" | "D"
+		const part = DateFormat.Order.getPart(this.order, index)
 		const value = this.parts[part] ?? ""
 		if (part == "D" && value.length == 1) {
 			this.autoAdvancePart(part, parseInt(value), index, DateFormat.Parts.maxDay(this.parts))
@@ -186,7 +186,7 @@ export class SmoothlyInputDateRangeText {
 	render() {
 		return (
 			<Host class={{ "has-text": Object.values(this.parts).some(part => !!part) }}>
-				{[...this.order].map((part: "Y" | "M" | "D", index: number) => (
+				{DateFormat.Order.toParts(this.order).map((part, index) => (
 					<span
 						onClick={() => {
 							if (!this.readonly && !this.disabled)

--- a/src/components/input/date/text/index.tsx
+++ b/src/components/input/date/text/index.tsx
@@ -128,29 +128,20 @@ export class SmoothlyInputDateRangeText {
 			...this.parts,
 			[part]: value,
 		}
-		if (part == "D") {
+
+		if (["D", "M"].includes(part)) {
+			const isDay = part == "D"
+			const max = isDay ? DateFormat.Parts.maxDay(this.parts) : 12
+			const singleDigitThreshold = isDay ? 3 : 1
+			const input = parseInt(value)
+
 			if (value.length >= 2) {
-				const maxDay = DateFormat.Parts.maxDay(this.parts)
-				const dayString = Math.max(1, Math.min(parseInt(value), maxDay))
-					.toString()
-					.padStart(2, "0")
-				this.setPart("D", dayString)
+				const clamped = Math.max(1, Math.min(input, max))
+				this.setPart(part, clamped.toString().padStart(2, "0"))
 				InputSelection.setPosition(this.partElements[index], 2)
-			} else if (value.length == 1 && parseInt(value) > 3) {
-				const dayString = parseInt(value).toString().padStart(2, "0")
-				this.setPart("D", dayString)
-				this.setFocus(index + 1)
-			}
-		} else if (part == "M") {
-			if (value.length >= 2) {
-				const monthString = Math.max(1, Math.min(parseInt(value), 12))
-					.toString()
-					.padStart(2, "0")
-				this.setPart("M", monthString)
-				InputSelection.setPosition(this.partElements[index], 2)
-			} else if (value.length == 1 && parseInt(value) > 1) {
-				const monthString = Math.min(parseInt(value), 12).toString().padStart(2, "0")
-				this.setPart("M", monthString)
+			} else if (value.length == 1 && input > singleDigitThreshold) {
+				const clamped = Math.max(1, Math.min(input, max))
+				this.setPart(part, clamped.toString().padStart(2, "0"))
 				this.setFocus(index + 1)
 			}
 		}

--- a/src/components/input/date/text/index.tsx
+++ b/src/components/input/date/text/index.tsx
@@ -197,8 +197,6 @@ export class SmoothlyInputDateRangeText {
 						<span
 							class={{
 								"smoothly-date-text-part": true,
-								[`smoothly-date-text-${part}`]: true,
-								focused: this.focusedIndex === index,
 								"filled-part": (this.parts[part]?.length ?? 0) >= DateFormat.Part.length(part),
 							}}
 							onFocus={() => (this.focusedIndex = index)}

--- a/src/components/input/date/text/index.tsx
+++ b/src/components/input/date/text/index.tsx
@@ -105,7 +105,6 @@ export class SmoothlyInputDateRangeText {
 		const nonDigitData = e.data && /\D/.test(e.data)
 		const hasMaxLength = value.length >= DateFormat.Part.length(part)
 		const noRangedSelection = InputSelection.isCollapsed(e.target as HTMLElement)
-		console.log("beforeInput", e.inputType, e.data)
 		if (
 			(e.inputType == "insertText" || e.inputType == "insertFromPaste") &&
 			(nonDigitData || (hasMaxLength && noRangedSelection))
@@ -177,7 +176,6 @@ export class SmoothlyInputDateRangeText {
 	}
 
 	setFocus(index: number) {
-		console.log("setFocus", index)
 		if (index < 0) {
 			this.smoothlyDateTextPrevious.emit()
 		} else if (index > 2) {

--- a/src/components/input/date/text/index.tsx
+++ b/src/components/input/date/text/index.tsx
@@ -141,8 +141,10 @@ export class SmoothlyInputDateRangeText {
 				this.setFocus(index + 1)
 			}
 		} else if (part == "M") {
-			if (parseInt(value) > 12) {
-				const monthString = "12"
+			if (value.length == 2) {
+				const monthString = Math.max(1, Math.min(parseInt(value), 12))
+					.toString()
+					.padStart(2, "0")
 				this.setPart("M", monthString)
 				InputSelection.setPosition(this.partElements[index], 2)
 			} else if (value.length == 1 && parseInt(value) > 1) {

--- a/src/components/input/date/text/index.tsx
+++ b/src/components/input/date/text/index.tsx
@@ -228,7 +228,7 @@ export class SmoothlyInputDateRangeText {
 							contenteditable={!(this.readonly || this.disabled)}>
 							{/* year or month or day written here */}
 						</span>
-						<span class="ghost">{DateFormat.Part.getGuide(part, this.parts[part]?.length)}</span>
+						<span class="guide">{DateFormat.Part.getGuide(part, this.parts[part]?.length)}</span>
 						{index < 2 && <span class="smoothly-date-separator">{this.separator}</span>}
 					</span>
 				))}

--- a/src/components/input/date/text/index.tsx
+++ b/src/components/input/date/text/index.tsx
@@ -94,10 +94,14 @@ export class SmoothlyInputDateRangeText {
 		this.partElements[this.focusedIndex ?? 0]?.blur()
 	}
 
+	getInnerText(target: EventTarget | null) {
+		return (target as HTMLSpanElement).innerText.replace(/\n/g, "").replace(/\D/g, "")
+	}
+
 	@Listen("beforeinput")
 	beforeInputHandler(e: InputEvent) {
 		const part = this.order[this.focusedIndex ?? 0] as "Y" | "M" | "D"
-		const value = (e.target as HTMLSpanElement).innerText.replace(/\n/g, "").replace(/\D/g, "")
+		const value = this.getInnerText(e.target)
 		const nonDigitData = e.data && /\D/.test(e.data)
 		const hasMaxLength = value.length >= DateFormat.Part.length(part)
 		const noRangedSelection = InputSelection.isCollapsed(e.target as HTMLElement)
@@ -118,7 +122,7 @@ export class SmoothlyInputDateRangeText {
 	inputHandler(e: InputEvent) {
 		const part = this.order[this.focusedIndex ?? 0] as "Y" | "M" | "D"
 		const index = this.focusedIndex ?? 0
-		const value = (e.target as HTMLSpanElement).innerText.replace(/\n/g, "").replace(/\D/g, "")
+		const value = this.getInnerText(e.target)
 		this.parts = {
 			...this.parts,
 			[part]: value,
@@ -201,8 +205,8 @@ export class SmoothlyInputDateRangeText {
 							}}
 							onFocus={() => (this.focusedIndex = index)}
 							onBlur={() => (this.focusedIndex = undefined)}
-							onKeyDown={e => {
-								const text = (e.target as HTMLSpanElement).innerText.replace(/\n/g, "").replace(/\D/g, "")
+							onKeyDown={(e: KeyboardEvent) => {
+								const text = this.getInnerText(e.target)
 								if (InputSelection.isAtStart(e) && e.key == "ArrowLeft") {
 									this.completePartIfPossible(index)
 									this.setFocus(index - 1)

--- a/src/components/input/date/text/index.tsx
+++ b/src/components/input/date/text/index.tsx
@@ -5,7 +5,7 @@ import { InputSelection } from "./InputSelection"
 
 @Component({
 	tag: "smoothly-date-text",
-	styleUrl: "./style.css",
+	styleUrl: "style.css",
 	scoped: true,
 })
 export class SmoothlyInputDateRangeText {

--- a/src/components/input/date/text/index.tsx
+++ b/src/components/input/date/text/index.tsx
@@ -129,19 +129,20 @@ export class SmoothlyInputDateRangeText {
 			[part]: value,
 		}
 		if (part == "D") {
-			if (value.length >= 2 && parseInt(value) > 28) {
+			if (value.length >= 2) {
 				const maxDay = DateFormat.Parts.maxDay(this.parts)
-				if (parseInt(value) > maxDay) {
-					this.setPart("D", maxDay.toString().padStart(2, "0"))
-					InputSelection.setPosition(this.partElements[index], 2)
-				}
+				const dayString = Math.max(1, Math.min(parseInt(value), maxDay))
+					.toString()
+					.padStart(2, "0")
+				this.setPart("D", dayString)
+				InputSelection.setPosition(this.partElements[index], 2)
 			} else if (value.length == 1 && parseInt(value) > 3) {
 				const dayString = parseInt(value).toString().padStart(2, "0")
 				this.setPart("D", dayString)
 				this.setFocus(index + 1)
 			}
 		} else if (part == "M") {
-			if (value.length == 2) {
+			if (value.length >= 2) {
 				const monthString = Math.max(1, Math.min(parseInt(value), 12))
 					.toString()
 					.padStart(2, "0")

--- a/src/components/input/date/text/index.tsx
+++ b/src/components/input/date/text/index.tsx
@@ -32,6 +32,7 @@ export class SmoothlyInputDateRangeText {
 	@State() order: DateFormat.Order
 	@State() separator: DateFormat.Separator
 	@State() focusedIndex?: number
+	@Event() smoothlyDateTextHasText: EventEmitter<boolean>
 	@Event() smoothlyDateTextChange: EventEmitter<isoly.Date | undefined>
 	@Event() smoothlyDateTextFocusChange: EventEmitter<boolean>
 	@Event() smoothlyDateTextDone: EventEmitter<void>
@@ -53,6 +54,7 @@ export class SmoothlyInputDateRangeText {
 			this.smoothlyDateTextChange.emit(value)
 			this.previousEmittedValue = value
 		}
+		this.smoothlyDateTextHasText.emit(Object.values(this.parts).some(part => !!part))
 	}
 	@Watch("focusedIndex")
 	focusedIndexHandler() {

--- a/src/components/input/date/text/index.tsx
+++ b/src/components/input/date/text/index.tsx
@@ -157,6 +157,21 @@ export class SmoothlyInputDateRangeText {
 			}
 		}
 	}
+
+	completePartIfPossible(index: number) {
+		const part = this.order[index] as "Y" | "M" | "D"
+		const value = this.parts[part] ?? ""
+		if (part == "D" && value.length == 1) {
+			if (parseInt(value) > 0) {
+				const dayString = Math.min(parseInt(value), DateFormat.Parts.maxDay(this.parts)).toString().padStart(2, "0")
+				this.setPart("D", dayString)
+			}
+		} else if (part == "M" && value.length == 1) {
+			const monthString = Math.min(parseInt(value), 12).toString().padStart(2, "0")
+			this.setPart("M", monthString)
+		}
+	}
+
 	setFocus(index: number) {
 		console.log("setFocus", index)
 		if (index < 0) {
@@ -189,21 +204,27 @@ export class SmoothlyInputDateRangeText {
 							onKeyDown={e => {
 								const text = (e.target as HTMLSpanElement).innerText.replace(/\n/g, "").replace(/\D/g, "")
 								if (InputSelection.isAtStart(e) && e.key == "ArrowLeft") {
+									this.completePartIfPossible(index)
 									this.setFocus(index - 1)
 									e.preventDefault() // Keep selection
 								} else if (InputSelection.isAtEnd(e) && e.key == "ArrowRight") {
+									this.completePartIfPossible(index)
 									this.setFocus(index + 1)
 									e.preventDefault() // Keep selection
 								} else if (e.key == "Home" || e.key == "ArrowUp") {
+									this.completePartIfPossible(index)
 									this.setFocus(0)
 									e.preventDefault() // Keep selection
 								} else if (e.key == "End" || e.key == "ArrowDown") {
+									this.completePartIfPossible(index)
 									this.setFocus(2)
 									e.preventDefault() // Keep selection
 								} else if (InputSelection.isAtStart(e) && e.key == "Backspace" && text == "") {
+									this.completePartIfPossible(index)
 									this.setFocus(index - 1)
 									e.preventDefault() // Prevent delete previous part
 								} else if (InputSelection.isAtEnd(e) && e.key == "Delete" && text == "") {
+									this.completePartIfPossible(index)
 									this.setFocus(index + 1)
 									e.preventDefault() // Prevent delete next part
 								}

--- a/src/components/input/date/text/index.tsx
+++ b/src/components/input/date/text/index.tsx
@@ -1,0 +1,223 @@
+import { Component, Element, Event, EventEmitter, h, Host, Listen, Method, Prop, State, Watch } from "@stencil/core"
+import { isoly } from "isoly"
+import { DateFormat } from "./DateFormat"
+import { InputSelection } from "./InputSelection"
+
+/* 
+ The regular input is not suitable for displaying a date range in text mode,
+ So we create a custom component for that specific purpose.
+*/
+
+@Component({
+	tag: "smoothly-date-text",
+	styleUrl: "./style.css",
+	scoped: true,
+})
+export class SmoothlyInputDateRangeText {
+	@Element() element: HTMLElement
+	private partElements: { [partIndex in number]: HTMLSpanElement | undefined } = {
+		0: undefined,
+		1: undefined,
+		2: undefined,
+	}
+	@Prop() locale: isoly.Locale = navigator.language as isoly.Locale
+	@Prop({ reflect: true }) readonly: boolean
+	@Prop({ reflect: true }) disabled: boolean
+	@Prop({ reflect: true }) invalid: boolean
+	@Prop({ reflect: true }) placeholder: string
+	@Prop({ reflect: true }) showLabel = true
+	@Prop() value?: isoly.Date // Only used for initial value
+	@State() parts: DateFormat.Parts = {}
+	private previousEmittedValue?: isoly.Date
+	@State() order: DateFormat.Order
+	@State() separator: DateFormat.Separator
+	@State() focusedIndex?: number
+	@Event() smoothlyDateTextChange: EventEmitter<isoly.Date | undefined>
+	@Event() smoothlyDateTextFocusChange: EventEmitter<boolean>
+	@Event() smoothlyDateTextDone: EventEmitter<void>
+	@Event() smoothlyDateTextPrevious: EventEmitter<void>
+	@Event() smoothlyDateTextNext: EventEmitter<void>
+
+	componentWillLoad() {
+		this.order = DateFormat.Order.fromLocale(this.locale)
+		this.separator = DateFormat.Separator.fromLocale(this.locale)
+	}
+	async componentDidLoad() {
+		await this.setValue(this.value)
+	}
+
+	@Watch("parts")
+	partsHandler() {
+		const value = DateFormat.Parts.toDate(this.parts)
+		if (value != this.previousEmittedValue) {
+			this.smoothlyDateTextChange.emit(value)
+			this.previousEmittedValue = value
+		}
+	}
+	@Watch("focusedIndex")
+	focusedIndexHandler() {
+		this.smoothlyDateTextFocusChange.emit(typeof this.focusedIndex == "number")
+	}
+
+	@Method()
+	async setValue(value: isoly.Date | undefined) {
+		const parts = DateFormat.Parts.fromDate(value)
+		this.setAllParts(parts)
+	}
+
+	setAllParts(parts?: DateFormat.Parts) {
+		this.parts = parts ?? {}
+		const yearIndex = this.order.indexOf("Y")
+		const monthIndex = this.order.indexOf("M")
+		const dayIndex = this.order.indexOf("D")
+		this.partElements[yearIndex] && (this.partElements[yearIndex]!.innerText = this.parts.Y ?? "")
+		this.partElements[monthIndex] && (this.partElements[monthIndex]!.innerText = this.parts.M ?? "")
+		this.partElements[dayIndex] && (this.partElements[dayIndex]!.innerText = this.parts.D ?? "")
+	}
+
+	setPart(part: "Y" | "M" | "D", value: string | undefined) {
+		this.parts = {
+			...this.parts,
+			[part]: value,
+		}
+		const index = this.order.indexOf(part)
+		this.partElements[index] && (this.partElements[index]!.innerText = value ?? "")
+	}
+
+	@Method()
+	async select(place: "start" | "end" = "start") {
+		const index = place == "start" ? 0 : 2
+		this.setFocus(index)
+	}
+	@Method()
+	async deselect() {
+		this.partElements[this.focusedIndex ?? 0]?.blur()
+	}
+
+	@Listen("beforeinput")
+	beforeInputHandler(e: InputEvent) {
+		const part = this.order[this.focusedIndex ?? 0] as "Y" | "M" | "D"
+		const value = (e.target as HTMLSpanElement).innerText.replace(/\n/g, "").replace(/\D/g, "")
+		const nonDigitData = e.data && /\D/.test(e.data)
+		const hasMaxLength = value.length >= DateFormat.Part.length(part)
+		const noRangedSelection = InputSelection.isCollapsed(e.target as HTMLElement)
+		console.log("beforeInput", e.inputType, e.data)
+		if (
+			(e.inputType == "insertText" || e.inputType == "insertFromPaste") &&
+			(nonDigitData || (hasMaxLength && noRangedSelection))
+		) {
+			e.preventDefault()
+		}
+		if (e.inputType == "insertParagraph" || e.inputType == "insertLineBreak") {
+			this.smoothlyDateTextDone.emit()
+			e.preventDefault()
+		}
+	}
+
+	@Listen("input", { capture: true })
+	inputHandler(e: InputEvent) {
+		const part = this.order[this.focusedIndex ?? 0] as "Y" | "M" | "D"
+		const index = this.focusedIndex ?? 0
+		const value = (e.target as HTMLSpanElement).innerText.replace(/\n/g, "").replace(/\D/g, "")
+		this.parts = {
+			...this.parts,
+			[part]: value,
+		}
+		if (part == "D") {
+			if (value.length >= 2 && parseInt(value) > 28) {
+				const maxDay = DateFormat.Parts.maxDay(this.parts)
+				if (parseInt(value) > maxDay) {
+					this.setPart("D", maxDay.toString().padStart(2, "0"))
+					InputSelection.setPosition(this.partElements[index], 2)
+				}
+			} else if (value.length == 1 && parseInt(value) > 3) {
+				const dayString = parseInt(value).toString().padStart(2, "0")
+				this.setPart("D", dayString)
+				this.setFocus(index + 1)
+			}
+		} else if (part == "M") {
+			if (parseInt(value) > 12) {
+				const monthString = "12"
+				this.setPart("M", monthString)
+				InputSelection.setPosition(this.partElements[index], 2)
+			} else if (value.length == 1 && parseInt(value) > 1) {
+				const monthString = Math.min(parseInt(value), 12).toString().padStart(2, "0")
+				this.setPart("M", monthString)
+				this.setFocus(index + 1)
+			}
+		}
+		if (value.length >= DateFormat.Part.length(part)) {
+			this.setFocus(index + 1)
+		}
+		const roundedValue = DateFormat.Parts.toDate(this.parts)
+		if (roundedValue) {
+			const roundedParts = DateFormat.Parts.fromDate(roundedValue)
+			if (this.parts.D !== roundedParts?.D) {
+				this.setPart("D", roundedParts?.D)
+			}
+		}
+	}
+	setFocus(index: number) {
+		console.log("setFocus", index)
+		if (index < 0) {
+			this.smoothlyDateTextPrevious.emit()
+		} else if (index > 2) {
+			this.smoothlyDateTextNext.emit()
+		} else {
+			InputSelection.selectAll(this.partElements[index])
+		}
+	}
+
+	render() {
+		return (
+			<Host class={{ "has-text": Object.values(this.parts).some(part => !!part) }}>
+				{[...this.order].map((part: "Y" | "M" | "D", index: number) => (
+					<span
+						onClick={() => {
+							if (!this.readonly && !this.disabled)
+								this.setFocus(index)
+						}}>
+						<span
+							class={{
+								"smoothly-date-text-part": true,
+								[`smoothly-date-text-${part}`]: true,
+								focused: this.focusedIndex === index,
+								"filled-part": (this.parts[part]?.length ?? 0) >= DateFormat.Part.length(part),
+							}}
+							onFocus={() => (this.focusedIndex = index)}
+							onBlur={() => (this.focusedIndex = undefined)}
+							onKeyDown={e => {
+								const text = (e.target as HTMLSpanElement).innerText.replace(/\n/g, "").replace(/\D/g, "")
+								if (InputSelection.isAtStart(e) && e.key == "ArrowLeft") {
+									this.setFocus(index - 1)
+									e.preventDefault() // Keep selection
+								} else if (InputSelection.isAtEnd(e) && e.key == "ArrowRight") {
+									this.setFocus(index + 1)
+									e.preventDefault() // Keep selection
+								} else if (e.key == "Home" || e.key == "ArrowUp") {
+									this.setFocus(0)
+									e.preventDefault() // Keep selection
+								} else if (e.key == "End" || e.key == "ArrowDown") {
+									this.setFocus(2)
+									e.preventDefault() // Keep selection
+								} else if (InputSelection.isAtStart(e) && e.key == "Backspace" && text == "") {
+									this.setFocus(index - 1)
+									e.preventDefault() // Prevent delete previous part
+								} else if (InputSelection.isAtEnd(e) && e.key == "Delete" && text == "") {
+									this.setFocus(index + 1)
+									e.preventDefault() // Prevent delete next part
+								}
+							}}
+							key={index}
+							ref={el => (this.partElements[index] = el)}
+							contenteditable={!(this.readonly || this.disabled)}>
+							{/* year or month or day written here */}
+						</span>
+						<span class="ghost">{DateFormat.Part.getGuide(part, this.parts[part]?.length)}</span>
+						{index < 2 && <span class="smoothly-date-separator">{this.separator}</span>}
+					</span>
+				))}
+			</Host>
+		)
+	}
+}

--- a/src/components/input/date/text/index.tsx
+++ b/src/components/input/date/text/index.tsx
@@ -167,12 +167,13 @@ export class SmoothlyInputDateRangeText {
 		const part = this.order[index] as "Y" | "M" | "D"
 		const value = this.parts[part] ?? ""
 		if (part == "D" && value.length == 1) {
-			if (parseInt(value) > 0) {
-				const dayString = Math.min(parseInt(value), DateFormat.Parts.maxDay(this.parts)).toString().padStart(2, "0")
-				this.setPart("D", dayString)
-			}
+			const day = parseInt(value)
+			const maxDay = DateFormat.Parts.maxDay(this.parts)
+			const dayString = Math.max(1, Math.min(day, maxDay)).toString().padStart(2, "0")
+			this.setPart("D", dayString)
 		} else if (part == "M" && value.length == 1) {
-			const monthString = Math.min(parseInt(value), 12).toString().padStart(2, "0")
+			const month = parseInt(value)
+			const monthString = Math.max(1, Math.min(month, 12)).toString().padStart(2, "0")
 			this.setPart("M", monthString)
 		}
 	}

--- a/src/components/input/date/text/index.tsx
+++ b/src/components/input/date/text/index.tsx
@@ -210,15 +210,11 @@ export class SmoothlyInputDateRangeText {
 		return (
 			<Host class={{ "has-text": Object.values(this.parts).some(part => !!part) }}>
 				{DateFormat.Order.toArray(this.order).map((part, index) => (
-					<span
-						onClick={() => {
-							if (!this.readonly && !this.disabled)
-								this.setFocus(index)
-						}}>
+					<span onClick={() => !this.readonly && !this.disabled && this.setFocus(index)}>
 						<span
 							class={{
 								"smoothly-date-text-part": true,
-								"filled-part": (this.parts[part]?.length ?? 0) >= DateFormat.Part.lengthOf(part),
+								"is-complete": DateFormat.Part.isComplete(part, this.parts[part]),
 							}}
 							onFocus={() => (this.focusedIndex = index)}
 							onBlur={() => (this.focusedIndex = undefined)}

--- a/src/components/input/date/text/index.tsx
+++ b/src/components/input/date/text/index.tsx
@@ -3,11 +3,6 @@ import { isoly } from "isoly"
 import { DateFormat } from "./DateFormat"
 import { InputSelection } from "./InputSelection"
 
-/* 
- The regular input is not suitable for displaying a date range in text mode,
- So we create a custom component for that specific purpose.
-*/
-
 @Component({
 	tag: "smoothly-date-text",
 	styleUrl: "./style.css",

--- a/src/components/input/date/text/style.css
+++ b/src/components/input/date/text/style.css
@@ -11,6 +11,6 @@
 	opacity: var(--guide-opacity);
 }
 
-:host .smoothly-date-text-part:not(.filled-part) + .guide + .smoothly-date-separator {
+:host .smoothly-date-text-part:not(.is-complete) + .guide + .smoothly-date-separator {
 	opacity: var(--guide-opacity);
 }

--- a/src/components/input/date/text/style.css
+++ b/src/components/input/date/text/style.css
@@ -1,16 +1,16 @@
 
 :host {
-	--ghost-opacity: 0.5;
+	--guide-opacity: 0.5;
 }
 
 :host .smoothly-date-text-part:focus {
 	outline: none;
 }
 
-:host .ghost {
-	opacity: var(--ghost-opacity);
+:host .guide {
+	opacity: var(--guide-opacity);
 }
 
-:host .smoothly-date-text-part:not(.filled-part) + .ghost + .smoothly-date-separator {
-	opacity: var(--ghost-opacity);
+:host .smoothly-date-text-part:not(.filled-part) + .guide + .smoothly-date-separator {
+	opacity: var(--guide-opacity);
 }

--- a/src/components/input/date/text/style.css
+++ b/src/components/input/date/text/style.css
@@ -2,11 +2,6 @@
 :host {
 	display: block;
 	--ghost-opacity: 0.5;
-	outline: 2px solid red;
-}
-
-:host .label {
-	left: var(--input-padding-side);
 }
 
 :host {

--- a/src/components/input/date/text/style.css
+++ b/src/components/input/date/text/style.css
@@ -1,15 +1,6 @@
 
 :host {
-	display: block;
 	--ghost-opacity: 0.5;
-}
-
-:host {
-	display: flex;
-	align-items: center;
-	/* height: 100%; */
-	height: fit-content;
-	box-sizing: border-box;
 }
 
 :host .smoothly-date-text-part:focus {

--- a/src/components/input/date/text/style.css
+++ b/src/components/input/date/text/style.css
@@ -1,0 +1,30 @@
+
+:host {
+	display: block;
+	--ghost-opacity: 0.5;
+	outline: 2px solid red;
+}
+
+:host .label {
+	left: var(--input-padding-side);
+}
+
+:host {
+	display: flex;
+	align-items: center;
+	/* height: 100%; */
+	height: fit-content;
+	box-sizing: border-box;
+}
+
+:host .smoothly-date-text-part:focus {
+	outline: none;
+}
+
+:host .ghost {
+	opacity: var(--ghost-opacity);
+}
+
+:host .smoothly-date-text-part:not(.filled-part) + .ghost + .smoothly-date-separator {
+	opacity: var(--ghost-opacity);
+}

--- a/src/components/input/demo/date/index.tsx
+++ b/src/components/input/demo/date/index.tsx
@@ -1,4 +1,4 @@
-import { Component, h, Host, State } from "@stencil/core"
+import { Component, Fragment, h, Host, State } from "@stencil/core"
 import { isoly } from "isoly"
 
 @Component({
@@ -8,6 +8,7 @@ import { isoly } from "isoly"
 })
 export class SmoothlyInputDateDemo {
 	@State() date?: isoly.Date
+	@State() alwaysShowFormat = false
 
 	render() {
 		return (
@@ -20,12 +21,37 @@ export class SmoothlyInputDateDemo {
 						onClick={() => (this.date = this.date ? isoly.Date.next(this.date) : isoly.Date.now())}>
 						Set date
 					</smoothly-button>
+					<smoothly-input-checkbox
+						looks="transparent"
+						onSmoothlyUserInput={e => {
+							this.alwaysShowFormat = e.detail.value
+							console.log(this.alwaysShowFormat)
+						}}>
+						Always Show Format
+					</smoothly-input-checkbox>
 				</div>
 				{(["en-US", "en-GB", "de-DE", "se-SE"] as isoly.Locale[]).map(locale => (
-					<smoothly-input-date locale={locale} name={locale} looks="border" value={this.date}>
-						{locale}
-						<smoothly-input-clear slot="end" />
-					</smoothly-input-date>
+					<Fragment>
+						<smoothly-input-date
+							locale={locale}
+							name={locale}
+							looks="border"
+							value={this.date}
+							alwaysShowFormat={this.alwaysShowFormat}>
+							{locale}
+							<smoothly-input-clear slot="end" />
+						</smoothly-input-date>
+						<smoothly-input-date-range
+							locale={locale}
+							name={locale + "-range"}
+							looks="border"
+							start={this.date}
+							end={this.date ? isoly.Date.next(this.date) : undefined}
+							alwaysShowFormat={this.alwaysShowFormat}>
+							{locale} Range
+							<smoothly-input-clear slot="end" />
+						</smoothly-input-date-range>
+					</Fragment>
 				))}
 			</Host>
 		)

--- a/src/components/input/demo/date/index.tsx
+++ b/src/components/input/demo/date/index.tsx
@@ -8,7 +8,7 @@ import { isoly } from "isoly"
 })
 export class SmoothlyInputDateDemo {
 	@State() date?: isoly.Date
-	@State() alwaysShowFormat = false
+	@State() alwaysShowGuide = false
 
 	render() {
 		return (
@@ -24,10 +24,10 @@ export class SmoothlyInputDateDemo {
 					<smoothly-input-checkbox
 						looks="transparent"
 						onSmoothlyUserInput={e => {
-							this.alwaysShowFormat = e.detail.value
-							console.log(this.alwaysShowFormat)
+							this.alwaysShowGuide = e.detail.value
+							console.log(this.alwaysShowGuide)
 						}}>
-						Always Show Format
+						Always Show Guide
 					</smoothly-input-checkbox>
 				</div>
 				{(["en-US", "en-GB", "de-DE", "se-SE"] as isoly.Locale[]).map(locale => (
@@ -37,7 +37,7 @@ export class SmoothlyInputDateDemo {
 							name={locale}
 							looks="border"
 							value={this.date}
-							alwaysShowFormat={this.alwaysShowFormat}>
+							alwaysShowGuide={this.alwaysShowGuide}>
 							{locale}
 							<smoothly-input-clear slot="end" />
 						</smoothly-input-date>
@@ -47,7 +47,7 @@ export class SmoothlyInputDateDemo {
 							looks="border"
 							start={this.date}
 							end={this.date ? isoly.Date.next(this.date) : undefined}
-							alwaysShowFormat={this.alwaysShowFormat}>
+							alwaysShowGuide={this.alwaysShowGuide}>
 							{locale} Range
 							<smoothly-input-clear slot="end" />
 						</smoothly-input-date-range>

--- a/src/components/input/demo/date/index.tsx
+++ b/src/components/input/demo/date/index.tsx
@@ -1,0 +1,33 @@
+import { Component, h, Host, State } from "@stencil/core"
+import { isoly } from "isoly"
+
+@Component({
+	tag: "smoothly-input-date-demo",
+	styleUrl: "style.css",
+	scoped: true,
+})
+export class SmoothlyInputDateDemo {
+	@State() date?: isoly.Date
+
+	render() {
+		return (
+			<Host>
+				<div>
+					<h2>Date input</h2>
+					<p>Different locales formatting the same date</p>
+					<smoothly-button
+						color="primary"
+						onClick={() => (this.date = this.date ? isoly.Date.next(this.date) : isoly.Date.now())}>
+						Set date
+					</smoothly-button>
+				</div>
+				{(["en-US", "en-GB", "de-DE", "se-SE"] as isoly.Locale[]).map(locale => (
+					<smoothly-input-date locale={locale} name={locale} looks="border" value={this.date}>
+						{locale}
+						<smoothly-input-clear slot="end" />
+					</smoothly-input-date>
+				))}
+			</Host>
+		)
+	}
+}

--- a/src/components/input/demo/date/style.css
+++ b/src/components/input/demo/date/style.css
@@ -1,7 +1,12 @@
 :host {
+	display: grid;
+	grid-template-columns: repeat(auto-fill, minmax(20rem, 1fr));
 	min-width: 40rem;
 	margin: auto;
-	display: flex;
 	flex-direction: column;
 	gap: 0.5rem;
+}
+
+:host :not(smoothly-input-date):not(smoothly-input-date-range) {
+	grid-column: 1 / -1;
 }

--- a/src/components/input/demo/date/style.css
+++ b/src/components/input/demo/date/style.css
@@ -1,7 +1,7 @@
 :host {
 	display: grid;
-	grid-template-columns: repeat(auto-fill, minmax(20rem, 1fr));
-	min-width: 40rem;
+	grid-template-columns: repeat(auto-fit, minmax(20rem, 1fr));
+	max-width: min(42rem, 100%);
 	margin: auto;
 	flex-direction: column;
 	gap: 0.5rem;

--- a/src/components/input/demo/date/style.css
+++ b/src/components/input/demo/date/style.css
@@ -1,0 +1,7 @@
+:host {
+	min-width: 40rem;
+	margin: auto;
+	display: flex;
+	flex-direction: column;
+	gap: 0.5rem;
+}

--- a/src/components/input/demo/index.tsx
+++ b/src/components/input/demo/index.tsx
@@ -16,6 +16,7 @@ export class SmoothlyInputDemo {
 		return (
 			<Host>
 				<smoothly-input-demo-standard />
+				<smoothly-input-date-demo />
 				<smoothly-input-demo-user-input />
 				<div class="inputs">
 					<h2>Calendar</h2>

--- a/src/components/input/demo/standard/index.tsx
+++ b/src/components/input/demo/standard/index.tsx
@@ -212,8 +212,8 @@ export class SmoothlyInputDemoStandard {
 						invalid={this.options.invalid}
 						// TODO - errorMessage
 						showLabel={this.options.showLabel}
-						// TODO - placeholder
-					>
+						placeholder={this.options.placeholder}
+						alwaysShowFormat={this.options.alwaysShowFormat}>
 						{this.options.showLabel && <span>Date</span>}
 						<smoothly-input-clear slot="end" />
 					</smoothly-input-date>

--- a/src/components/input/demo/standard/index.tsx
+++ b/src/components/input/demo/standard/index.tsx
@@ -13,6 +13,7 @@ type Options = {
 	errorMessage?: string
 	showLabel?: boolean
 	placeholder?: string
+	alwaysShowFormat?: boolean
 }
 
 @Component({
@@ -76,6 +77,9 @@ export class SmoothlyInputDemoStandard {
 							Show Label
 						</smoothly-input-checkbox>
 						<smoothly-input name="placeholder">Placeholder</smoothly-input>
+						<smoothly-input-checkbox name="alwaysShowFormat">
+							Always Show Format (for date inputs)
+						</smoothly-input-checkbox>
 					</smoothly-form>
 				</div>
 				<div class="input-wrapper" style={{ "--smoothly-input-border-radius": `${this.options.borderRadius}rem` }}>
@@ -240,6 +244,7 @@ export class SmoothlyInputDemoStandard {
 						invalid={this.options.invalid}
 						// TODO - errorMessage
 						placeholder={this.options.placeholder}
+						alwaysShowFormat={this.options.alwaysShowFormat}
 						showLabel={this.options.showLabel}
 						// TODO - placeholder
 					>

--- a/src/components/input/demo/standard/index.tsx
+++ b/src/components/input/demo/standard/index.tsx
@@ -13,7 +13,7 @@ type Options = {
 	errorMessage?: string
 	showLabel?: boolean
 	placeholder?: string
-	alwaysShowFormat?: boolean
+	alwaysShowGuide?: boolean
 }
 
 @Component({
@@ -77,8 +77,8 @@ export class SmoothlyInputDemoStandard {
 							Show Label
 						</smoothly-input-checkbox>
 						<smoothly-input name="placeholder">Placeholder</smoothly-input>
-						<smoothly-input-checkbox name="alwaysShowFormat">
-							Always Show Format (for date inputs)
+						<smoothly-input-checkbox name="alwaysShowGuide">
+							Always Show Guide (for date inputs)
 						</smoothly-input-checkbox>
 					</smoothly-form>
 				</div>
@@ -213,7 +213,7 @@ export class SmoothlyInputDemoStandard {
 						// TODO - errorMessage
 						showLabel={this.options.showLabel}
 						placeholder={this.options.placeholder}
-						alwaysShowFormat={this.options.alwaysShowFormat}>
+						alwaysShowGuide={this.options.alwaysShowGuide}>
 						{this.options.showLabel && <span>Date</span>}
 						<smoothly-input-clear slot="end" />
 					</smoothly-input-date>
@@ -244,7 +244,7 @@ export class SmoothlyInputDemoStandard {
 						invalid={this.options.invalid}
 						// TODO - errorMessage
 						placeholder={this.options.placeholder}
-						alwaysShowFormat={this.options.alwaysShowFormat}
+						alwaysShowGuide={this.options.alwaysShowGuide}
 						showLabel={this.options.showLabel}
 						// TODO - placeholder
 					>

--- a/src/components/input/index.tsx
+++ b/src/components/input/index.tsx
@@ -198,7 +198,7 @@ export class SmoothlyInput implements Clearable, Input, Editable {
 				onclick={() => this.inputElement?.focus()}>
 				<slot name="start" />
 				<div class="smoothly-input-container">
-					<div class={"ghost"}>
+					<div class={"guide"}>
 						<div class={"value"}>{this.state?.value}</div>
 						<div class={"remainder"}>{this.state?.remainder}</div>
 					</div>

--- a/src/components/input/shared.css
+++ b/src/components/input/shared.css
@@ -93,6 +93,7 @@
 :host[placeholder] ::slotted([slot=label]),
 :host[readonly] ::slotted([slot=label]),
 :host.has-value .label,
+:host.has-text .label,
 :host[placeholder] .label,
 :host[readonly] .label,
 :host:not([readonly]):focus-within .label.float-on-focus {

--- a/src/components/input/shared.css
+++ b/src/components/input/shared.css
@@ -92,6 +92,7 @@
 :host.has-value ::slotted([slot=label]),
 :host[placeholder] ::slotted([slot=label]),
 :host[readonly] ::slotted([slot=label]),
+:host.floating-label .label,
 :host.has-value .label,
 :host.has-text .label,
 :host[placeholder] .label,

--- a/src/components/input/style.css
+++ b/src/components/input/style.css
@@ -27,7 +27,7 @@
 	padding: 0 var(--input-padding-side);
 }
 
-:host>.smoothly-input-container>div.ghost {
+:host>.smoothly-input-container>div.guide {
 	position: absolute;
   box-sizing: border-box;
   align-content: center;
@@ -38,12 +38,12 @@
 		var(--input-value-padding-bottom) 
 		var(--input-padding-side);
 }
-:host>.smoothly-input-container>div.ghost>div.value {
+:host>.smoothly-input-container>div.guide>div.value {
 	display: inline;
 	pointer-events: none;
 	opacity: 0;
 }
-:host>.smoothly-input-container>div.ghost>div.remainder {
+:host>.smoothly-input-container>div.guide>div.remainder {
 	display: inline;
 	pointer-events: none;
 	opacity: 0.5;


### PR DESCRIPTION
## Changes

Make `smoothly-input-date` and `smoothly-input-date-range` inputs writeable with a custom `smoothly-date-text` component.
Switched date components to using `smoothly-date-text` which isn't based on tidily, and has it's own implementation, which works for any order Year, month, day (YMD, MDY, DMY).

### Each part (Y/M/D) is separate
Instead of having a text string that is the full date like with the tidily solution, the input is instead broken up into parts that can be set independently. This means:
- No custom solution for each possible order or Year, month and day.
- You can delete any part on it's own, and it won't affect the other parts.


https://github.com/user-attachments/assets/325b02b1-03d9-4475-9948-a297f6d98583


### ⚠️ Breaking change - Partial<isoly.DateRange>
`input-date-range` now emits `Partial<isoly.DateRange>`.
The reason is that emitting Full can cause unindented behaviour when typing date.

Example:
```tsx
<smoothly-input-date-range 
  name="range" 
  start={this.range.start} 
  end={this.range.end} 
  onSmoothlyInput={e => e.detail.range} />
```
When typing a removing a char from e.g. `2025-05-01 - 2025-06-12` to `2025-05-01 - 2025-06-1` would have to input would have to emit undefined which would clear the whole input.

### Showing format
Use `Prop alwaysShowFormat` to always show what the format is. 
Otherwise it's only shown when editing.

<img width="390" height="329" alt="image" src="https://github.com/user-attachments/assets/328c73a4-ecd3-4f3a-99e0-6e3dc3650cee" />

 <img width="390" height="282" alt="Screenshot from 2025-10-20 13-57-33" src="https://github.com/user-attachments/assets/67d37170-e637-4bff-82c7-937295420e39" />



## Future fixes/improvements
### smoothly-input-date-time
`<smoothly-input-date-time />` still uses the old tidily solution for date.

### Phone
Using the input on a phone will open up the regular keyboard - not the number one.
This is because I'm using `<span contenteditable>` to keep the width of what is written.

<img width="400" height="720" alt="image" src="https://github.com/user-attachments/assets/46bef3cd-a9e5-4f88-b712-5415e17eb836" />

This could be fixed in the future by using a both `input`, and `span` together.
- Input to set inputmode
- span to set appropriate width (since input can't fit content)
```tsx
<span>{this.text}</span> /* hidden when !readonly  */
<input inputmode="number" /> /* only shown when readonly */
```
This could be made into a FunctionalComponent that could then also be used for the `hh` and `mm` for date-time.


### smoothly-calendar month is uneffected by typed value 
Would be nice if the month in smoothly-calendar changed when date is typed.

### Enforce start before end in date-range
When typing there is no enforcement that the first date is before the second date.
Maybe a switch should happen when that is typed, so the first date is always the earliest.
