### PR TITLE
Remove semantic elements from date inputs

### DIFF
--- a/src/components/input/date/index.tsx
+++ b/src/components/input/date/index.tsx
@@ -163,25 +163,23 @@ export class SmoothlyInputDate implements ComponentWillLoad, Clearable, Input, E
 					<slot name={"end"} />
 				</span>
 				{this.open && !this.readonly && (
-					<nav>
-						<smoothly-calendar
-							doubleInput={false}
-							value={this.value}
-							onSmoothlyValueChange={event => {
-								this.value = event.detail
-								this.smoothlyUserInput.emit({ name: this.name, value: this.value })
-								event.stopPropagation()
-							}}
-							max={this.max}
-							min={this.min}>
-							<div slot={"year-label"}>
-								<slot name={"year-label"} />
-							</div>
-							<div slot={"month-label"}>
-								<slot name={"month-label"} />
-							</div>
-						</smoothly-calendar>
-					</nav>
+					<smoothly-calendar
+						doubleInput={false}
+						value={this.value}
+						onSmoothlyValueChange={event => {
+							this.value = event.detail
+							this.smoothlyUserInput.emit({ name: this.name, value: this.value })
+							event.stopPropagation()
+						}}
+						max={this.max}
+						min={this.min}>
+						<div slot={"year-label"}>
+							<slot name={"year-label"} />
+						</div>
+						<div slot={"month-label"}>
+							<slot name={"month-label"} />
+						</div>
+					</smoothly-calendar>
 				)}
 			</Host>
 		)

--- a/src/components/input/date/range/index.tsx
+++ b/src/components/input/date/range/index.tsx
@@ -160,32 +160,30 @@ export class SmoothlyInputDateRange implements Clearable, Input, Editable {
 					<slot name={"end"} />
 				</span>
 				{this.open && (
-					<nav>
-						<smoothly-calendar
-							doubleInput={true}
-							onSmoothlyValueChange={e => e.stopPropagation()}
-							onSmoothlyStartChange={e => {
-								e.stopPropagation()
-								this.start = e.detail
-							}}
-							onSmoothlyEndChange={e => {
-								e.stopPropagation()
-								this.end = e.detail
-							}}
-							onSmoothlyDateSet={e => e.stopPropagation()}
-							onSmoothlyDateRangeSet={e => {
-								e.stopPropagation()
-								this.open = false
-								this.smoothlyInput.emit({ [this.name]: e.detail })
-								this.smoothlyUserInput.emit({ name: this.name, value: e.detail })
-							}}
-							value={this.start}
-							start={this.start}
-							end={this.end}
-							max={this.max}
-							min={this.min}
-						/>
-					</nav>
+					<smoothly-calendar
+						doubleInput={true}
+						onSmoothlyValueChange={e => e.stopPropagation()}
+						onSmoothlyStartChange={e => {
+							e.stopPropagation()
+							this.start = e.detail
+						}}
+						onSmoothlyEndChange={e => {
+							e.stopPropagation()
+							this.end = e.detail
+						}}
+						onSmoothlyDateSet={e => e.stopPropagation()}
+						onSmoothlyDateRangeSet={e => {
+							e.stopPropagation()
+							this.open = false
+							this.smoothlyInput.emit({ [this.name]: e.detail })
+							this.smoothlyUserInput.emit({ name: this.name, value: e.detail })
+						}}
+						value={this.start}
+						start={this.start}
+						end={this.end}
+						max={this.max}
+						min={this.min}
+					/>
 				)}
 			</Host>
 		)

--- a/src/components/input/date/range/index.tsx
+++ b/src/components/input/date/range/index.tsx
@@ -135,7 +135,9 @@ export class SmoothlyInputDateRange implements Clearable, Input, Editable {
 		const locale = navigator.language as isoly.Locale
 		return (
 			<Host tabindex={this.disabled ? undefined : 0}>
-				<section onClick={() => !this.readonly && !this.disabled && (this.open = !this.open)}>
+				<span
+					class="smoothly-date-range-input-part"
+					onClick={() => !this.readonly && !this.disabled && (this.open = !this.open)}>
 					<smoothly-input
 						type="text" // TODO: date-range tidily thing
 						name="dateRangeInput"
@@ -155,7 +157,7 @@ export class SmoothlyInputDateRange implements Clearable, Input, Editable {
 						}}>
 						<slot />
 					</smoothly-input>
-				</section>
+				</span>
 				<span class={"icons"}>
 					<slot name={"end"} />
 				</span>

--- a/src/components/input/date/range/style.scss
+++ b/src/components/input/date/range/style.scss
@@ -10,16 +10,16 @@
 	}
 }
 
-:host:not([readonly])>section>smoothly-input {
+:host:not([readonly]) > section > smoothly-input {
 	cursor: pointer;
 }
 
 :host[disabled],
-:host[disabled]>section>smoothly-input {
+:host[disabled] > section > smoothly-input {
 	cursor: not-allowed;
 }
 
-:host>nav {
+:host > smoothly-calendar {
 	position: absolute;
 	z-index: 10;
 	top: 4rem;
@@ -28,14 +28,13 @@
 	min-width: 18rem;
 }
 
-:host>nav>smoothly-calendar::before {
+:host > smoothly-calendar::before {
 	content: "";
 	position: absolute;
-	box-sizing: border-box;
-	top: 1px;
-	left: -7rem;
+	top: -0.55rem;
+	left: 3rem;
 	z-index: 9;
-	transform: translate(10em, -0.55rem) rotate(45deg);
+	transform: rotate(45deg);
 	width: 1rem;
 	height: 1rem;
 	background-color: rgb(var(--smoothly-input-background));
@@ -43,7 +42,7 @@
 	border-left: 1px solid rgb(var(--smoothly-input-border));
 }
 
-:host>section {
+:host > section {
 	display: flex;
 	width: 100%;
 	background-color: var(--smoothly-input-background);
@@ -51,20 +50,20 @@
 	cursor: pointer;
 }
 
-:host>section>smoothly-input {
+:host > section > smoothly-input {
 	min-width: 15rem;
 	width: 100%;
 	background-color: transparent;
 	--input-min-height: calc(var(--input-min-height) - 2px);
 }
 
-:host>section>span {
+:host > section > span {
 	padding-block: 0.5rem;
 	padding-inline: 0.2rem;
 	align-self: center;
 }
 
-:host>span.icons {
+:host > span.icons {
 	display: flex;
 	flex-direction: row;
 	align-items: center;

--- a/src/components/input/date/range/style.scss
+++ b/src/components/input/date/range/style.scss
@@ -10,12 +10,12 @@
 	}
 }
 
-:host:not([readonly]) > section > smoothly-input {
+:host:not([readonly]) > .smoothly-date-range-input-part > smoothly-input {
 	cursor: pointer;
 }
 
 :host[disabled],
-:host[disabled] > section > smoothly-input {
+:host[disabled] > .smoothly-date-range-input-part > smoothly-input {
 	cursor: not-allowed;
 }
 
@@ -42,7 +42,7 @@
 	border-left: 1px solid rgb(var(--smoothly-input-border));
 }
 
-:host > section {
+:host > .smoothly-date-range-input-part {
 	display: flex;
 	width: 100%;
 	background-color: var(--smoothly-input-background);
@@ -50,14 +50,14 @@
 	cursor: pointer;
 }
 
-:host > section > smoothly-input {
+:host > .smoothly-date-range-input-part > smoothly-input {
 	min-width: 15rem;
 	width: 100%;
 	background-color: transparent;
 	--input-min-height: calc(var(--input-min-height) - 2px);
 }
 
-:host > section > span {
+:host > .smoothly-date-range-input-part > span {
 	padding-block: 0.5rem;
 	padding-inline: 0.2rem;
 	align-self: center;

--- a/src/components/input/date/style.css
+++ b/src/components/input/date/style.css
@@ -27,23 +27,23 @@
 	outline: none;
 }
 
-:host>nav {
+:host>smoothly-calendar {
 	position: absolute;
 	z-index: 10;
-	top: 4em;
+	top: 4rem;
 	background-color: rgb(var(--smoothly-input-background));
-	min-width: 18em;
+	min-width: 18rem;
 }
 
-:host>nav>smoothly-calendar::before {
+:host>smoothly-calendar::before {
 	content: "";
-	box-sizing: border-box;
 	position: absolute;
-	top: 1px;
+	left: 2rem;
+	top: -0.55rem;
 	z-index: 9;
-	transform: translate(2em, -0.55em) rotate(45deg);
-	width: 1em;
-	height: 1em;
+	transform: rotate(45deg);
+	width: 1rem;
+	height: 1rem;
 	background-color: rgb(var(--smoothly-input-background));
 	border-top: 1px solid rgb(var(--smoothly-input-border));
 	border-left: 1px solid rgb(var(--smoothly-input-border));
@@ -56,11 +56,7 @@
 }
 
 @media screen and (min-width: 400px) {
-	:host>nav {
-		position: absolute;
-		z-index: 10;
-		top: 4em;
-		background-color: rgb(var(--smoothly-input-background));
-		max-width: 22em;
+	:host>smoothly-calendar {
+		max-width: 22rem;
 	}
 }

--- a/src/components/input/date/style.css
+++ b/src/components/input/date/style.css
@@ -33,6 +33,7 @@
 	top: 4rem;
 	background-color: rgb(var(--smoothly-input-background));
 	min-width: 18rem;
+	max-width: 22rem;
 }
 
 :host>smoothly-calendar::before {
@@ -53,10 +54,4 @@
 	display: flex;
 	flex-direction: row;
 	align-items: center;
-}
-
-@media screen and (min-width: 400px) {
-	:host>smoothly-calendar {
-		max-width: 22rem;
-	}
 }

--- a/src/components/input/date/time/index.tsx
+++ b/src/components/input/date/time/index.tsx
@@ -234,29 +234,27 @@ export class SmoothlyInputDateTime implements ComponentWillLoad, Clearable, Inpu
 					<slot name={"end"} />
 				</span>
 				{this.open && !this.readonly && (
-					<nav>
-						<smoothly-calendar
-							doubleInput={false}
-							value={this.value ? isoly.DateTime.getDate(this.value) : undefined}
-							min={this.min ? isoly.DateTime.getDate(this.min) : undefined}
-							max={this.max ? isoly.DateTime.getDate(this.max) : undefined}
-							onSmoothlyValueChange={async e => {
-								e.stopPropagation()
-								this.date = e.detail
-								this.smoothlyUserInput.emit({ name: this.name, value: await this.getValue() })
-							}}
-							onSmoothlyDateSet={e => {
-								e.stopPropagation()
-								this.open = false
-							}}>
-							<div slot={"year-label"}>
-								<slot name={"year-label"} />
-							</div>
-							<div slot={"month-label"}>
-								<slot name={"month-label"} />
-							</div>
-						</smoothly-calendar>
-					</nav>
+					<smoothly-calendar
+						doubleInput={false}
+						value={this.value ? isoly.DateTime.getDate(this.value) : undefined}
+						min={this.min ? isoly.DateTime.getDate(this.min) : undefined}
+						max={this.max ? isoly.DateTime.getDate(this.max) : undefined}
+						onSmoothlyValueChange={async e => {
+							e.stopPropagation()
+							this.date = e.detail
+							this.smoothlyUserInput.emit({ name: this.name, value: await this.getValue() })
+						}}
+						onSmoothlyDateSet={e => {
+							e.stopPropagation()
+							this.open = false
+						}}>
+						<div slot={"year-label"}>
+							<slot name={"year-label"} />
+						</div>
+						<div slot={"month-label"}>
+							<slot name={"month-label"} />
+						</div>
+					</smoothly-calendar>
 				)}
 			</Host>
 		)

--- a/src/components/input/date/time/style.css
+++ b/src/components/input/date/time/style.css
@@ -27,23 +27,25 @@
 	outline: none;
 }
 
-:host>nav {
+:host>smoothly-calendar {
 	position: absolute;
 	z-index: 10;
-	top: 4em;
+	top: 4rem;
 	background-color: rgb(var(--smoothly-input-background));
-	min-width: 18em;
+	min-width: 18rem;
+	max-width: 22rem;
 }
 
-:host>nav>smoothly-calendar::before {
+:host>smoothly-calendar::before {
 	content: "";
 	box-sizing: border-box;
 	position: absolute;
-	top: 1px;
+	top: -0.55rem;
+	left: 2rem;
 	z-index: 9;
-	transform: translate(2em, -0.55em) rotate(45deg);
-	width: 1em;
-	height: 1em;
+	transform: rotate(45deg);
+	width: 1rem;
+	height: 1rem;
 	background-color: rgb(var(--smoothly-input-background));
 	border-top: 1px solid rgb(var(--smoothly-input-border));
 	border-left: 1px solid rgb(var(--smoothly-input-border));
@@ -79,14 +81,4 @@
 }
 :host[invalid]>.icons>.smoothly-invalid {
 	display: flex;
-}
-
-@media screen and (min-width: 400px) {
-	:host>nav {
-		position: absolute;
-		z-index: 10;
-		top: 4em;
-		background-color: rgb(var(--smoothly-input-background));
-		max-width: 22em;
-	}
 }


### PR DESCRIPTION
I suggest hide indentation when reviewing.

Remove `nav` and `section` from input-date components.

Looks and works the same:

<img width="260" height="377" alt="Screenshot from 2025-10-16 11-38-36" src="https://github.com/user-attachments/assets/e00a3c6b-8829-4abd-8cd5-2465d27458a9" />
<img width="260" height="377" alt="Screenshot from 2025-10-16 11-38-41" src="https://github.com/user-attachments/assets/d9d5fa58-6729-4dd8-9038-ff3a4a0d8b31" />
<img width="260" height="377" alt="Screenshot from 2025-10-16 11-38-48" src="https://github.com/user-attachments/assets/d8be8841-e66f-47f2-9449-02eecb08f824" />

