### PR TITLE
Use same locale on all date components

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -124,7 +124,7 @@ export namespace Components {
         "deselect": () => Promise<void>;
         "disabled": boolean;
         "invalid": boolean;
-        "locale": isoly.Locale;
+        "locale"?: isoly.Locale;
         "readonly": boolean;
         "select": (place?: "start" | "end") => Promise<void>;
         "setValue": (value: isoly.Date | undefined) => Promise<void>;
@@ -347,7 +347,7 @@ export namespace Components {
         "getValue": () => Promise<isoly.Date | undefined>;
         "invalid"?: boolean;
         "listen": (listener: Editable.Observer.Listener) => Promise<void>;
-        "locale": isoly.Locale;
+        "locale"?: isoly.Locale;
         "looks"?: Looks;
         "max": isoly.Date;
         "min": isoly.Date;
@@ -374,7 +374,7 @@ export namespace Components {
         "getValue": () => Promise<Partial<isoly.DateRange | undefined>>;
         "invalid"?: boolean;
         "listen": (listener: Editable.Observer.Listener) => Promise<void>;
-        "locale": isoly.Locale;
+        "locale"?: isoly.Locale;
         "looks"?: Looks;
         "max"?: isoly.Date;
         "min"?: isoly.Date;

--- a/src/components/input/date/index.tsx
+++ b/src/components/input/date/index.tsx
@@ -29,7 +29,7 @@ export class SmoothlyInputDate implements ComponentWillLoad, Clearable, Input, E
 	private iconsElement?: HTMLElement
 	private calendarElement?: HTMLElement
 	@Element() element: HTMLElement
-	@Prop({ reflect: true }) locale: isoly.Locale = navigator.language as isoly.Locale
+	@Prop({ reflect: true }) locale?: isoly.Locale
 	@Prop({ reflect: true, mutable: true }) color?: Color
 	@Prop({ reflect: true, mutable: true }) looks?: Looks
 	@Prop({ reflect: true }) name: string

--- a/src/components/input/date/range/index.tsx
+++ b/src/components/input/date/range/index.tsx
@@ -15,7 +15,7 @@ export class SmoothlyInputDateRange implements Clearable, Input, Editable {
 	private startTextElement?: HTMLSmoothlyDateTextElement
 	private endTextElement?: HTMLSmoothlyDateTextElement
 	@Element() element: HTMLElement
-	@Prop({ reflect: true }) locale: isoly.Locale = navigator.language as isoly.Locale
+	@Prop({ reflect: true }) locale?: isoly.Locale
 	@Prop({ reflect: true }) name: string = "dateRange"
 	@Prop({ reflect: true, mutable: true }) color?: Color
 	@Prop({ reflect: true, mutable: true }) looks?: Looks

--- a/src/components/input/date/text/DateFormat.ts
+++ b/src/components/input/date/text/DateFormat.ts
@@ -59,7 +59,7 @@ export namespace DateFormat {
 	export type Order = "YMD" | "DMY" | "MDY"
 
 	export namespace Order {
-		export function fromLocale(locale: isoly.Locale): Order {
+		export function fromLocale(locale?: isoly.Locale): Order {
 			switch (locale) {
 				case "en-US":
 					return "MDY"
@@ -94,7 +94,7 @@ export namespace DateFormat {
 
 	export type Separator = "-" | "/" | "."
 	export namespace Separator {
-		export function fromLocale(locale: isoly.Locale): Separator {
+		export function fromLocale(locale?: isoly.Locale): Separator {
 			switch (locale) {
 				case "sq-AL":
 				case "es-AR":

--- a/src/components/input/date/text/index.tsx
+++ b/src/components/input/date/text/index.tsx
@@ -1,5 +1,6 @@
 import { Component, Element, Event, EventEmitter, h, Host, Listen, Method, Prop, State, Watch } from "@stencil/core"
 import { isoly } from "isoly"
+import { getLocale } from "../../../../model"
 import { DateFormat } from "./DateFormat"
 import { InputSelection } from "./InputSelection"
 
@@ -15,7 +16,7 @@ export class SmoothlyInputDateRangeText {
 		1: undefined,
 		2: undefined,
 	}
-	@Prop() locale: isoly.Locale = navigator.language as isoly.Locale
+	@Prop() locale?: isoly.Locale = getLocale()
 	@Prop({ reflect: true }) readonly: boolean
 	@Prop({ reflect: true }) disabled: boolean
 	@Prop({ reflect: true }) invalid: boolean


### PR DESCRIPTION
Missed that other components where using the `getLocale` component when making the `smoothly-date-text`.