### PR TITLE
smoothly-summary improvements

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -626,10 +626,7 @@ export namespace Components {
         "type": "link" | "button";
     }
     interface SmoothlySummary {
-        "color": Color;
-        "fill": Fill;
         "open": boolean;
-        "size": "tiny" | "small" | "medium" | "large";
     }
     interface SmoothlyTab {
         "disabled": boolean;
@@ -2918,11 +2915,8 @@ declare namespace LocalJSX {
         "type"?: "link" | "button";
     }
     interface SmoothlySummary {
-        "color"?: Color;
-        "fill"?: Fill;
         "onSmoothlySummaryOpen"?: (event: SmoothlySummaryCustomEvent<boolean>) => void;
         "open"?: boolean;
-        "size"?: "tiny" | "small" | "medium" | "large";
     }
     interface SmoothlyTab {
         "disabled"?: boolean;

--- a/src/components/display/demo/index.tsx
+++ b/src/components/display/demo/index.tsx
@@ -319,18 +319,14 @@ export class SmoothlyDisplayDemo {
 						<p slot="summary">Some title</p>
 						<p slot="content">Some content</p>
 					</smoothly-summary>
-					<smoothly-summary size="large">
-						<p slot="summary">Some title</p>
-						<p slot="content">Some content</p>
-					</smoothly-summary>
-					<smoothly-summary color="danger" fill="clear">
+					<smoothly-summary>
 						<div slot="summary" style={{ display: "flex", gap: "0.3rem" }}>
 							<span>Person</span>
 							<smoothly-icon name="person" color="light" fill="clear" size="tiny" />
 						</div>
 						<p slot="content">Some person information.</p>
 					</smoothly-summary>
-					<smoothly-summary color="danger" fill="clear" open>
+					<smoothly-summary open>
 						<p slot="summary">Some other title</p>
 						<p slot="content">
 							A lot more content, yes please. A lot more content, yes please. A lot more content, yes please. A lot more

--- a/src/components/display/demo/index.tsx
+++ b/src/components/display/demo/index.tsx
@@ -317,7 +317,14 @@ export class SmoothlyDisplayDemo {
 					<h2>Smoothly summary</h2>
 					<smoothly-summary>
 						<p slot="summary">Some title</p>
-						<p slot="content">Some content</p>
+						<smoothly-summary slot="content">
+							<p slot="summary">Some other title</p>
+							<p slot="content">
+								A lot more content, yes please. A lot more content, yes please. A lot more content, yes please. A lot
+								more content, yes please. A lot more content, yes please.A lot more content, yes please. A lot more
+								content, yes please. A lot more content, yes please. A lot more content, yes please.
+							</p>
+						</smoothly-summary>
 					</smoothly-summary>
 					<smoothly-summary>
 						<div slot="summary" style={{ display: "flex", gap: "0.3rem" }}>
@@ -326,14 +333,7 @@ export class SmoothlyDisplayDemo {
 						</div>
 						<p slot="content">Some person information.</p>
 					</smoothly-summary>
-					<smoothly-summary open>
-						<p slot="summary">Some other title</p>
-						<p slot="content">
-							A lot more content, yes please. A lot more content, yes please. A lot more content, yes please. A lot more
-							content, yes please. A lot more content, yes please.A lot more content, yes please. A lot more content,
-							yes please. A lot more content, yes please. A lot more content, yes please.
-						</p>
-					</smoothly-summary>
+
 					<h2>Label</h2>
 					{labels.map(l => (
 						<smoothly-label hue={l.hue} description={l.description} shape={"rectangle"}>

--- a/src/components/display/demo/index.tsx
+++ b/src/components/display/demo/index.tsx
@@ -316,14 +316,14 @@ export class SmoothlyDisplayDemo {
 				<fieldset>
 					<h2>Smoothly summary</h2>
 					<smoothly-summary>
-						<p slot="summary">Some title</p>
+						<span slot="summary">Some title</span>
 						<smoothly-summary slot="content">
-							<p slot="summary">Some other title</p>
-							<p slot="content">
+							<div slot="summary">Some other title</div>
+							<div slot="content">
 								A lot more content, yes please. A lot more content, yes please. A lot more content, yes please. A lot
 								more content, yes please. A lot more content, yes please.A lot more content, yes please. A lot more
 								content, yes please. A lot more content, yes please. A lot more content, yes please.
-							</p>
+							</div>
 						</smoothly-summary>
 					</smoothly-summary>
 					<smoothly-summary>

--- a/src/components/form/demo/pet/index.tsx
+++ b/src/components/form/demo/pet/index.tsx
@@ -129,47 +129,6 @@ export class SmoothlyFormDemoPet {
 							</smoothly-input-checkbox>
 						</Fragment>
 					)}
-					<smoothly-summary>
-						<span slot="summary">Summary</span>
-						<div slot="content">
-							<smoothly-input type="price" name="summary.price" currency="EUR">
-								Summary Price
-							</smoothly-input>
-							<smoothly-input-file name="summary.picture">
-								<span slot="label">Summary picture</span>
-								<smoothly-input-clear slot="end" />
-							</smoothly-input-file>
-							<smoothly-input-date name="summary.birthday">Summary birthday</smoothly-input-date>
-							<smoothly-input-date-range name="summary.ownedRange" start="2020-01-01" end="2020-01-15">
-								Summary ownedRange
-								<smoothly-input-reset slot="end" />
-							</smoothly-input-date-range>
-							<smoothly-input-range name="summary.height" label={"Height"}>
-								<smoothly-input-reset slot="end" />
-							</smoothly-input-range>
-							<smoothly-input-select name="summary.favoriteHat">
-								<span slot="label">Summary's Favorite Hat</span>
-								{["🎩 top hat", "🧢 cap", "👒 sun hat", "❌ none"].map((value, index) => (
-									<smoothly-item value={value} key={index}>
-										{value}
-									</smoothly-item>
-								))}
-							</smoothly-input-select>
-							<smoothly-input-month name="summary.month">
-								<span slot={"month-label"}>Summary month</span>
-							</smoothly-input-month>
-							<smoothly-input-color name="summary.color">Summary Color</smoothly-input-color>
-							<smoothly-input-radio name="summary.favoritePizza">
-								<span slot="label">Summary's Favorite Pizza</span>
-								{["vesuvio", "capricciosa", "quattro formaggi"].map((value, index) => (
-									<smoothly-input-radio-item value={value} key={index}>
-										{value}
-									</smoothly-input-radio-item>
-								))}
-							</smoothly-input-radio>
-							<smoothly-input-checkbox name="summary.hasPet">Has Pet</smoothly-input-checkbox>
-						</div>
-					</smoothly-summary>
 					<smoothly-tabs>
 						<smoothly-tab label="Dog" name="dog">
 							<smoothly-input type={"text"} name="dog.breed">
@@ -202,6 +161,44 @@ export class SmoothlyFormDemoPet {
 						</smoothly-tab>
 						<smoothly-tab label="Cat" name="cat" open>
 							<smoothly-input name={"cat.favoriteFood"}>Favorite Food</smoothly-input>
+						</smoothly-tab>
+						<smoothly-tab label="Parrot" name="parrot">
+							<smoothly-input type="price" name="parrot.price" currency="EUR">
+								Summary Price
+							</smoothly-input>
+							<smoothly-input-file name="parrot.picture">
+								<span slot="label">Summary picture</span>
+								<smoothly-input-clear slot="end" />
+							</smoothly-input-file>
+							<smoothly-input-date name="parrot.birthday">Summary birthday</smoothly-input-date>
+							<smoothly-input-date-range name="parrot.ownedRange" start="2020-01-01" end="2020-01-15">
+								Summary ownedRange
+								<smoothly-input-reset slot="end" />
+							</smoothly-input-date-range>
+							<smoothly-input-range name="parrot.height" label={"Height"}>
+								<smoothly-input-reset slot="end" />
+							</smoothly-input-range>
+							<smoothly-input-select name="parrot.favoriteHat">
+								<span slot="label">Summary's Favorite Hat</span>
+								{["🎩 top hat", "🧢 cap", "👒 sun hat", "❌ none"].map((value, index) => (
+									<smoothly-item value={value} key={index}>
+										{value}
+									</smoothly-item>
+								))}
+							</smoothly-input-select>
+							<smoothly-input-month name="parrot.month">
+								<span slot={"month-label"}>Summary month</span>
+							</smoothly-input-month>
+							<smoothly-input-color name="parrot.color">Summary Color</smoothly-input-color>
+							<smoothly-input-radio name="parrot.favoritePizza">
+								<span slot="label">Summary's Favorite Pizza</span>
+								{["vesuvio", "capricciosa", "quattro formaggi"].map((value, index) => (
+									<smoothly-input-radio-item value={value} key={index}>
+										{value}
+									</smoothly-input-radio-item>
+								))}
+							</smoothly-input-radio>
+							<smoothly-input-checkbox name="parrot.hasPet">Has Pet</smoothly-input-checkbox>
 						</smoothly-tab>
 					</smoothly-tabs>
 					<smoothly-input-submit size="icon" slot="submit" color="success" fill="solid" />

--- a/src/components/form/demo/pet/style.css
+++ b/src/components/form/demo/pet/style.css
@@ -7,7 +7,6 @@
 }
 
 :host smoothly-input-checkbox[name="hasOwner"],
-:host > smoothly-form smoothly-summary,
 :host > smoothly-form smoothly-tabs {
 	flex-basis: 100%;
 }

--- a/src/components/summary/index.tsx
+++ b/src/components/summary/index.tsx
@@ -1,5 +1,4 @@
 import { Component, Event, EventEmitter, h, Prop } from "@stencil/core"
-import { Color, Fill } from "../../model"
 @Component({
 	tag: "smoothly-summary",
 	styleUrl: "style.css",
@@ -7,9 +6,6 @@ import { Color, Fill } from "../../model"
 })
 export class SmoothlySummary {
 	@Prop({ mutable: true, reflect: true }) open = false
-	@Prop() color: Color
-	@Prop() fill: Fill = "solid"
-	@Prop() size: "tiny" | "small" | "medium" | "large" = "tiny"
 	@Event() smoothlySummaryOpen: EventEmitter<boolean>
 
 	async toggleHandler(event: Event) {
@@ -23,7 +19,7 @@ export class SmoothlySummary {
 		return (
 			<details onToggle={e => this.toggleHandler(e)} open={this.open}>
 				<summary>
-					<smoothly-icon name="caret-forward" color={this.color} fill={this.fill} size={this.size} />
+					<smoothly-icon name="caret-forward" fill="solid" size="tiny" />
 					<slot name="summary" />
 				</summary>
 				<slot name="content" />

--- a/src/components/summary/index.tsx
+++ b/src/components/summary/index.tsx
@@ -1,13 +1,11 @@
-import { Component, Event, EventEmitter, h, Listen, Prop } from "@stencil/core"
+import { Component, Event, EventEmitter, h, Prop } from "@stencil/core"
 import { Color, Fill } from "../../model"
-import { Input } from "../input/Input"
 @Component({
 	tag: "smoothly-summary",
 	styleUrl: "style.css",
 	scoped: true,
 })
 export class SmoothlySummary {
-	private inputs: Record<string, Input.Element> = {}
 	@Prop({ mutable: true, reflect: true }) open = false
 	@Prop() color: Color
 	@Prop() fill: Fill = "solid"
@@ -18,19 +16,6 @@ export class SmoothlySummary {
 		if (event.target instanceof HTMLDetailsElement) {
 			this.open = event.target.open
 			this.smoothlySummaryOpen.emit(this.open)
-			this.open
-				? await Promise.all(Object.values(this.inputs).map(input => input.register()))
-				: await Promise.all(Object.values(this.inputs).map(input => input.unregister()))
-		}
-	}
-
-	@Listen("smoothlyInputLoad")
-	@Listen("smoothlyInput")
-	onInputLoad(event: CustomEvent) {
-		if (Input.Element.is(event.target)) {
-			this.inputs[event.target.name] = event.target
-			if (!this.open)
-				event.stopPropagation()
 		}
 	}
 

--- a/src/components/summary/style.css
+++ b/src/components/summary/style.css
@@ -21,7 +21,7 @@
 }
 
 :host>details::slotted([slot=content]) {
-	margin-left: var(--smoothly-summary-content-indentation, 1.5rem);
+	margin-left: var(--smoothly-summary-content-indent, 1.5rem);
 }
 
 @media (prefers-reduced-motion) { 

--- a/src/components/summary/style.css
+++ b/src/components/summary/style.css
@@ -1,3 +1,7 @@
+:host {
+	display: block;
+}
+
 :host>details>summary {
 	display: flex;
 	column-gap: 0.25rem;

--- a/src/components/summary/style.css
+++ b/src/components/summary/style.css
@@ -1,17 +1,7 @@
-:host {
-	display: grid;
-	grid-template-columns: auto 1fr;
-	column-gap: 0.3rem;
-}
-
-:host>details {
-	display: contents;
-}
-
 :host>details>summary {
-	display: grid;
-	grid-template-columns: subgrid;
-	grid-column: 1/-1;
+	display: flex;
+	column-gap: 0.25rem;
+	width: fit-content;
 	list-style: none;
 	align-items: center;
 	cursor: pointer;
@@ -31,17 +21,11 @@
 }
 
 :host>details::slotted([slot=content]) {
-	grid-column: 2;
+	margin-left: var(--smoothly-summary-content-indentation, 1.5rem);
 }
 
 @media (prefers-reduced-motion) { 
 	:host>details>summary>smoothly-icon {
 		transition: none;
-	}
-}
- /* chromium specific */
-@supports selector(details::details-content) {
-	:host>details::details-content {
-		grid-column: 2;
 	}
 }


### PR DESCRIPTION
## Make summary click-to-open-area smaller
### Before
Click area would be entire width of component.
<img width="1266" height="138" alt="image" src="https://github.com/user-attachments/assets/6f9ddc19-6297-45ff-a477-fdc8a40ce30e" />

### After
Click area is just the carrot-icon and the summary text.
<img width="481" height="125" alt="Screenshot from 2025-11-03 10-09-24" src="https://github.com/user-attachments/assets/c8e2d3b7-7e25-435f-ae3f-f1e5117117bc" />

## Add indentation css-variable
Use `--smoothly-summary-content-indent` to set indentation of summary. 
Useful for mobile were there is little horizontal space.

## Remove props that no one uses 
- `@Prop() color: Color`
- `@Prop() fill: Fill = "solid"`
- `@Prop() size: "tiny" | "small" | "medium" | "large" = "tiny"`

These props were used to style the carrot-icon, but no one used them. 
In my opinion, css-variables would be more useful to add if someone wanted to style the carrot-icon.

## Don't block input events in closed summary. 
Before we would block/remove inputs from smoothly-form if the inputs are within a closed summary.
This did not make much sense since users don't expect this behaviour when closing summary, so it was never used.
So this behaviour has been removed.