### PR TITLE
Don't allow smoothly-icon to shrink

### DIFF
--- a/src/components/icon/style.css
+++ b/src/components/icon/style.css
@@ -3,6 +3,7 @@
 }
 :host {
 	display: flex;
+	flex-shrink: 0;
 	align-items: center;
 	justify-content: center;
 	box-sizing: content-box;


### PR DESCRIPTION
The smoothly-icon often shrink when put into a flex box with something that takes a lot of space.

## Example (the warning icon)

Before
<img width="453" height="129" alt="Screenshot from 2025-11-05 16-12-51" src="https://github.com/user-attachments/assets/1d71f126-b397-4b2f-959c-461d393bbc51" />

After
<img width="453" height="129" alt="Screenshot from 2025-11-05 16-12-47" src="https://github.com/user-attachments/assets/fe3d56de-1224-4b3b-a27c-006c5032d265" />
