### PR TITLE
Remove smoothly-date-text warning

### DIFF
--- a/src/components/input/date/text/index.tsx
+++ b/src/components/input/date/text/index.tsx
@@ -37,9 +37,10 @@ export class SmoothlyInputDateRangeText {
 	componentWillLoad() {
 		this.order = DateFormat.Order.fromLocale(this.locale)
 		this.separator = DateFormat.Separator.fromLocale(this.locale)
+		this.parts = DateFormat.Parts.fromDate(this.value) ?? {}
 	}
-	async componentDidLoad() {
-		await this.setValue(this.value)
+	componentDidLoad() {
+		this.updateInputs()
 	}
 
 	@Watch("parts")
@@ -64,6 +65,9 @@ export class SmoothlyInputDateRangeText {
 
 	setAllParts(parts?: DateFormat.Parts) {
 		this.parts = parts ?? {}
+		this.updateInputs()
+	}
+	updateInputs() {
 		const yearIndex = this.order.indexOf("Y")
 		const monthIndex = this.order.indexOf("M")
 		const dayIndex = this.order.indexOf("D")


### PR DESCRIPTION

Remove warning 

<img width="1039" height="121" alt="Screenshot from 2025-11-17 12-02-42" src="https://github.com/user-attachments/assets/59bbb1bd-be46-4a36-92a3-e33049505801" />


This is fixed by assigning `this.parts` before render, and updating the elements after render.
