### PR TITLE
Add navigation breakpoint Prop on smoothly-app

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -69,7 +69,6 @@ export namespace Components {
     }
     interface SmoothlyBurger {
         "open": boolean;
-        "setMobileMode": (mobile: boolean) => Promise<void>;
     }
     interface SmoothlyButton {
         "color"?: Color;

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -68,7 +68,6 @@ export namespace Components {
         "right": string;
     }
     interface SmoothlyBurger {
-        "mediaQuery": string;
         "open": boolean;
         "setMobileMode": (mobile: boolean) => Promise<void>;
         "visible": boolean;
@@ -2359,7 +2358,6 @@ declare namespace LocalJSX {
         "right"?: string;
     }
     interface SmoothlyBurger {
-        "mediaQuery"?: string;
         "onSmoothlyNavStatus"?: (event: SmoothlyBurgerCustomEvent<boolean>) => void;
         "open"?: boolean;
         "visible"?: boolean;

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -45,6 +45,7 @@ export namespace Components {
         "home"?: string;
         "label"?: string;
         "menuOpen": boolean;
+        "navBreakpoint": `${number}${"px" | "em" | "rem"}`;
         "selectRoom": (path: string) => Promise<void>;
     }
     interface SmoothlyAppDemo {
@@ -58,6 +59,7 @@ export namespace Components {
         "label"?: string;
         "path": string | URLPattern;
         "selected"?: boolean;
+        "setMobileMode": (mobile: boolean) => Promise<void>;
         "setSelected": (selected: boolean, options?: { history?: boolean; }) => Promise<void>;
     }
     interface SmoothlyBackToTop {
@@ -68,6 +70,7 @@ export namespace Components {
     interface SmoothlyBurger {
         "mediaQuery": string;
         "open": boolean;
+        "setMobileMode": (mobile: boolean) => Promise<void>;
         "visible": boolean;
     }
     interface SmoothlyButton {
@@ -985,7 +988,6 @@ declare global {
     };
     interface HTMLSmoothlyBurgerElementEventMap {
         "smoothlyNavStatus": boolean;
-        "smoothlyVisibleStatus": boolean;
     }
     interface HTMLSmoothlyBurgerElement extends Components.SmoothlyBurger, HTMLStencilElement {
         addEventListener<K extends keyof HTMLSmoothlyBurgerElementEventMap>(type: K, listener: (this: HTMLSmoothlyBurgerElement, ev: SmoothlyBurgerCustomEvent<HTMLSmoothlyBurgerElementEventMap[K]>) => any, options?: boolean | AddEventListenerOptions): void;
@@ -2334,6 +2336,7 @@ declare namespace LocalJSX {
         "home"?: string;
         "label"?: string;
         "menuOpen"?: boolean;
+        "navBreakpoint"?: `${number}${"px" | "em" | "rem"}`;
         "onSmoothlyUrlChange"?: (event: SmoothlyAppCustomEvent<string>) => void;
     }
     interface SmoothlyAppDemo {
@@ -2358,7 +2361,6 @@ declare namespace LocalJSX {
     interface SmoothlyBurger {
         "mediaQuery"?: string;
         "onSmoothlyNavStatus"?: (event: SmoothlyBurgerCustomEvent<boolean>) => void;
-        "onSmoothlyVisibleStatus"?: (event: SmoothlyBurgerCustomEvent<boolean>) => void;
         "open"?: boolean;
         "visible"?: boolean;
     }

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -70,7 +70,6 @@ export namespace Components {
     interface SmoothlyBurger {
         "open": boolean;
         "setMobileMode": (mobile: boolean) => Promise<void>;
-        "visible": boolean;
     }
     interface SmoothlyButton {
         "color"?: Color;
@@ -2360,7 +2359,6 @@ declare namespace LocalJSX {
     interface SmoothlyBurger {
         "onSmoothlyNavStatus"?: (event: SmoothlyBurgerCustomEvent<boolean>) => void;
         "open"?: boolean;
-        "visible"?: boolean;
     }
     interface SmoothlyButton {
         "color"?: Color;

--- a/src/components/app/index.tsx
+++ b/src/components/app/index.tsx
@@ -36,7 +36,8 @@ export class SmoothlyApp {
 		console.log("media query changed", mobileMode)
 		this.mobileMode = mobileMode
 		Object.values(this.rooms).forEach(room => room?.element.setMobileMode(mobileMode))
-		this.burgerElement?.setMobileMode(mobileMode)
+		if (!mobileMode)
+			this.menuOpen = false
 	}
 
 	async componentDidRender() {

--- a/src/components/app/index.tsx
+++ b/src/components/app/index.tsx
@@ -61,10 +61,6 @@ export class SmoothlyApp {
 				this.mainElement.replaceChildren(content)
 		})
 	}
-	burgerStatusHandler(event: CustomEvent<boolean>) {
-		event.stopPropagation()
-		this.menuOpen = event.detail
-	}
 	@Listen("popstate", { target: "window" })
 	async locationChangeHandler(event: PopStateEvent) {
 		this.rooms[event.state.smoothlyPath]?.element.setSelected(true, { history: true })
@@ -118,7 +114,7 @@ export class SmoothlyApp {
 						<smoothly-burger
 							ref={e => (this.burgerElement = e)}
 							open={this.menuOpen}
-							onSmoothlyNavStatus={e => this.burgerStatusHandler(e)}
+							onSmoothlyNavStatus={e => (e.stopPropagation(), (this.menuOpen = e.detail))}
 						/>
 					</header>
 					<main ref={e => (this.mainElement = e)} />

--- a/src/components/app/index.tsx
+++ b/src/components/app/index.tsx
@@ -1,4 +1,4 @@
-import { Component, Event, EventEmitter, h, Listen, Method, Prop, State, Watch } from "@stencil/core"
+import { Component, Event, EventEmitter, h, Host, Listen, Method, Prop, State, Watch } from "@stencil/core"
 import { SmoothlyAppRoomCustomEvent } from "../../components"
 import { Color } from "../../model"
 
@@ -15,13 +15,30 @@ export class SmoothlyApp {
 	@Prop() color: Color
 	@Prop() home?: string
 	@Prop({ mutable: true, reflect: true }) menuOpen = false
+	@Prop({ reflect: true }) navBreakpoint: `${number}${"px" | "em" | "rem"}` = "48rem"
+	@State() mobileMode = false
 	@State() selected?: Room
 	@Event() smoothlyUrlChange: EventEmitter<string>
-	private burgerVisibility: boolean
-	private burgerElement?: HTMLElement
+	private burgerElement?: HTMLSmoothlyBurgerElement
 	private navElement?: HTMLElement
 	mainElement?: HTMLElement
 	rooms: Record<string, Room | undefined> = {}
+
+	componentWillLoad() {
+		const mediaQuery = window.matchMedia(`(max-width: ${this.navBreakpoint})`)
+		this.mobileMode = mediaQuery.matches
+		mediaQuery.addEventListener("change", e => this.updateMobileMode(e.matches))
+	}
+	componentDidLoad() {
+		this.updateMobileMode(this.mobileMode)
+	}
+	updateMobileMode(mobileMode: boolean) {
+		console.log("media query changed", mobileMode)
+		this.mobileMode = mobileMode
+		Object.values(this.rooms).forEach(room => room?.element.setMobileMode(mobileMode))
+		this.burgerElement?.setMobileMode(mobileMode)
+	}
+
 	async componentDidRender() {
 		if (!this.selected && !window.location.search)
 			(this.home && this.rooms[this.home]
@@ -44,9 +61,6 @@ export class SmoothlyApp {
 				this.mainElement.replaceChildren(content)
 		})
 	}
-	burgerVisibilityHandler(event: CustomEvent<boolean>) {
-		this.burgerVisibility = event.detail
-	}
 	burgerStatusHandler(event: CustomEvent<boolean>) {
 		event.stopPropagation()
 		this.menuOpen = event.detail
@@ -59,7 +73,7 @@ export class SmoothlyApp {
 	@Listen("smoothlyRoomSelect")
 	roomSelectedHandler(event: SmoothlyAppRoomCustomEvent<{ history: boolean; query?: string }>) {
 		this.selected = { element: event.target }
-		if (this.burgerVisibility)
+		if (this.mobileMode)
 			this.menuOpen = false
 		if (!event.detail.history) {
 			const path = this.selected.element.path.toString()
@@ -78,37 +92,38 @@ export class SmoothlyApp {
 	}
 	@Listen("click", { target: "window" })
 	clickHandler(event: MouseEvent) {
-		if (this.burgerVisibility && !event.composedPath().some(e => e == this.burgerElement || e == this.navElement))
+		if (this.mobileMode && !event.composedPath().some(e => e == this.burgerElement || e == this.navElement))
 			this.menuOpen = false
 	}
 	render() {
 		return (
-			<smoothly-notifier>
-				<header color={this.color}>
-					<h1>
-						<a href={""}>{this.label}</a>
-					</h1>
-					<slot name="header" />
-					<nav ref={e => (this.navElement = e)}>
-						<ul>
-							<div class={"nav-start-container"}>
-								<slot name="nav-start" />
-							</div>
-							<slot />
-							<div class={"nav-end-container"}>
-								<slot name="nav-end" />
-							</div>
-						</ul>
-					</nav>
-					<smoothly-burger
-						ref={e => (this.burgerElement = e)}
-						open={this.menuOpen}
-						onSmoothlyNavStatus={e => this.burgerStatusHandler(e)}
-						onSmoothlyVisibleStatus={e => this.burgerVisibilityHandler(e)}
-					/>
-				</header>
-				<main ref={e => (this.mainElement = e)} />
-			</smoothly-notifier>
+			<Host class={{ "smoothly-mobile-mode": this.mobileMode }}>
+				<smoothly-notifier>
+					<header color={this.color}>
+						<h1>
+							<a href={""}>{this.label}</a>
+						</h1>
+						<slot name="header" />
+						<nav ref={e => (this.navElement = e)}>
+							<ul>
+								<div class={"nav-start-container"}>
+									<slot name="nav-start" />
+								</div>
+								<slot />
+								<div class={"nav-end-container"}>
+									<slot name="nav-end" />
+								</div>
+							</ul>
+						</nav>
+						<smoothly-burger
+							ref={e => (this.burgerElement = e)}
+							open={this.menuOpen}
+							onSmoothlyNavStatus={e => this.burgerStatusHandler(e)}
+						/>
+					</header>
+					<main ref={e => (this.mainElement = e)} />
+				</smoothly-notifier>
+			</Host>
 		)
 	}
 }

--- a/src/components/app/room/index.tsx
+++ b/src/components/app/room/index.tsx
@@ -43,7 +43,7 @@ export class SmoothlyAppRoom {
 		this.selected && window.history.replaceState({ smoothlyPath: this.path }, "", window.location.href)
 	}
 	@Method()
-	setMobileMode(mobile: boolean): void {
+	async setMobileMode(mobile: boolean) {
 		this.mobileMode = mobile
 	}
 	@Method()

--- a/src/components/app/room/index.tsx
+++ b/src/components/app/room/index.tsx
@@ -8,6 +8,7 @@ import {
 	Listen,
 	Method,
 	Prop,
+	State,
 	VNode,
 } from "@stencil/core"
 import "urlpattern-polyfill"
@@ -26,6 +27,7 @@ export class SmoothlyAppRoom {
 	@Prop() path: string | URLPattern = ""
 	@Prop({ reflect: true, mutable: true }) selected?: boolean
 	@Prop() content?: VNode | FunctionalComponent
+	@State() mobileMode = false
 	@Event() smoothlyRoomSelect: EventEmitter<{ history: boolean; query?: string }>
 	@Event() smoothlyRoomLoad: EventEmitter<{ selected: boolean }>
 	@Event() smoothlyUrlChange: EventEmitter<string>
@@ -39,6 +41,10 @@ export class SmoothlyAppRoom {
 		)
 		this.smoothlyRoomLoad.emit({ selected: this.selected })
 		this.selected && window.history.replaceState({ smoothlyPath: this.path }, "", window.location.href)
+	}
+	@Method()
+	setMobileMode(mobile: boolean): void {
+		this.mobileMode = mobile
 	}
 	@Method()
 	async getContent(): Promise<HTMLElement | undefined> {
@@ -73,7 +79,7 @@ export class SmoothlyAppRoom {
 
 	render() {
 		return (
-			<Host>
+			<Host class={{ "smoothly-mobile-mode": this.mobileMode }}>
 				<li>
 					<a href={typeof this.path == "string" ? this.path : this.path.pathname} onClick={e => this.clickHandler(e)}>
 						{this.icon && <smoothly-icon name={this.icon} />}

--- a/src/components/app/room/style.css
+++ b/src/components/app/room/style.css
@@ -72,24 +72,22 @@
 	border-radius: .25rem;
 }
 
-
-@media screen and (max-width: 900px) {
-	:host>li>a {
-		padding: 0;
-	}
-	:host[icon]>li>a>.label {
-		display: unset;
-		padding: 0 1rem;
-	}
-
-	:host>li>a {
-		margin-left: -1.5rem;
-		margin-right: -1.5rem;
-		padding-left: 1.5rem;
-		padding-right: 1.5rem;
-	}
-	:host([icon][label]):hover::before,
-	:host([icon][label]):hover::after {
-		content: unset;
-	}
+/* Mobile mode */
+:host.smoothly-mobile-mode>li>a {
+	padding: 0;
 }
+:host.smoothly-mobile-mode[icon]>li>a>.label {
+	display: unset;
+	padding: 0 1rem;
+}
+:host.smoothly-mobile-mode>li>a {
+	margin-left: -1.5rem;
+	margin-right: -1.5rem;
+	padding-left: 1.5rem;
+	padding-right: 1.5rem;
+}
+:host.smoothly-mobile-mode[icon][label]:hover::before,
+:host.smoothly-mobile-mode[icon][label]:hover::after {
+	content: unset;
+}
+

--- a/src/components/app/style.css
+++ b/src/components/app/style.css
@@ -98,62 +98,65 @@ smoothly-app>smoothly-notifier>header>nav>ul li a {
 	align-self: center;
 }
 
-@media screen and (max-width: 900px) {
-	smoothly-app>smoothly-notifier>header>nav {
-		width: fit-content;
-		max-width: 100%;
-		top: 100%;
-		position: absolute;
-		max-height: calc(100dvh - var(--header-height));
-		overflow-y: scroll;
-		right: 0;
-		height: auto;
-	}
-
-	smoothly-app>smoothly-notifier>header>nav,
-	smoothly-app>smoothly-notifier>header>nav>ul {
-		flex-direction: column;
-		background-color: rgba(var(--smoothly-color));
-	}
-
-	smoothly-app>smoothly-notifier>header>nav>ul {
-		padding: 1.5rem;
-		box-sizing: border-box;
-	}
-
-	smoothly-app>smoothly-notifier>header>nav>ul li {
-		margin-right: 0;
-		width: 100%;
-	}
-
-	smoothly-app>smoothly-notifier>header>smoothly-burger {
-		position: absolute;
-		top: 0;
-		right: 0;
-	}
-
-	smoothly-app>smoothly-notifier>header>nav>ul>[slot="nav-start"] {
-		display: none;
-	}
-
-	smoothly-app>smoothly-notifier>header>nav>ul>div.nav-start-container,
-	smoothly-app>smoothly-notifier>header>nav>ul>div.nav-end-container {
-		flex-direction: column;
-		margin: 0;
-		align-items: start;
-		justify-content: center;
-	}
-
-	smoothly-app>smoothly-notifier>header>nav>ul>div.nav-start-container>*:last-child {
-		margin-bottom: 1em;
-	}
-}
-
-smoothly-app:not([menu-open])>smoothly-notifier>header>nav {
+/* TODO: Remove this. nav visibility should be controlled by smoothly-app that listens to burger event if needed */
+/* smoothly-app:not([menu-open])>smoothly-notifier>header>nav {
 	display: none;
-}
+} */
 
 smoothly-app>smoothly-notifier>main>div {
 	overflow-y: scroll;
 	height: 100%;
 }
+
+/* Mobile mode */
+smoothly-app.smoothly-mobile-mode>smoothly-notifier>header>nav {
+	width: fit-content;
+	max-width: 100%;
+	top: 100%;
+	position: absolute;
+	max-height: calc(100dvh - var(--header-height));
+	overflow-y: scroll;
+	right: 0;
+	height: auto;
+}
+
+smoothly-app.smoothly-mobile-mode>smoothly-notifier>header>nav,
+smoothly-app.smoothly-mobile-mode>smoothly-notifier>header>nav>ul {
+	flex-direction: column;
+	background-color: rgba(var(--smoothly-color));
+}
+
+smoothly-app.smoothly-mobile-mode>smoothly-notifier>header>nav>ul {
+	padding: 1.5rem;
+	box-sizing: border-box;
+}
+
+smoothly-app.smoothly-mobile-mode>smoothly-notifier>header>nav>ul li {
+	margin-right: 0;
+	width: 100%;
+}
+smoothly-app:not(.smoothly-mobile-mode)>smoothly-notifier>header>smoothly-burger {
+	display: none;
+}
+smoothly-app.smoothly-mobile-mode>smoothly-notifier>header>smoothly-burger {
+	position: absolute;
+	top: 0;
+	right: 0;
+}
+
+smoothly-app.smoothly-mobile-mode>smoothly-notifier>header>nav>ul>[slot="nav-start"] {
+	display: none;
+}
+
+smoothly-app.smoothly-mobile-mode>smoothly-notifier>header>nav>ul>div.nav-start-container,
+smoothly-app.smoothly-mobile-mode>smoothly-notifier>header>nav>ul>div.nav-end-container {
+	flex-direction: column;
+	margin: 0;
+	align-items: start;
+	justify-content: center;
+}
+
+smoothly-app.smoothly-mobile-mode>smoothly-notifier>header>nav>ul>div.nav-start-container>*:last-child {
+	margin-bottom: 1em;
+}
+

--- a/src/components/app/style.css
+++ b/src/components/app/style.css
@@ -16,7 +16,7 @@ smoothly-app>smoothly-notifier {
 	background: none;
 }
 
-header:has(smoothly-burger[visible])>nav>ul smoothly-app-room {
+smoothly-app.smoothly-mobile-mode>smoothly-notifier>header:has(smoothly-burger)>nav>ul smoothly-app-room {
 	width: 100%;
 	height: 4em;
 }
@@ -98,10 +98,9 @@ smoothly-app>smoothly-notifier>header>nav>ul li a {
 	align-self: center;
 }
 
-/* TODO: Remove this. nav visibility should be controlled by smoothly-app that listens to burger event if needed */
-/* smoothly-app:not([menu-open])>smoothly-notifier>header>nav {
+smoothly-app.smoothly-mobile-mode:not([menu-open])>smoothly-notifier>header>nav {
 	display: none;
-} */
+}
 
 smoothly-app>smoothly-notifier>main>div {
 	overflow-y: scroll;

--- a/src/components/burger/index.tsx
+++ b/src/components/burger/index.tsx
@@ -7,14 +7,16 @@ import { Component, Element, Event, EventEmitter, h, Host, Listen, Method, Prop,
 })
 export class SmoothlyBurger {
 	@Element() element: HTMLSmoothlyBurgerElement
-	@Prop({ mutable: true, reflect: true }) visible: boolean
-	@Prop({ mutable: true, reflect: true }) open = false
+	@Prop({ reflect: true, mutable: true }) open = false
+	@State() visible: boolean
 	@State() history: boolean
 	@Event() smoothlyNavStatus: EventEmitter<boolean>
 
 	@Method()
 	setMobileMode(mobile: boolean): void {
 		this.visible = mobile
+		if (!mobile)
+			this.open = false
 	}
 
 	@Watch("open")
@@ -30,7 +32,7 @@ export class SmoothlyBurger {
 
 	render() {
 		return (
-			<Host>
+			<Host class={{ "smoothly-burger-visible": this.visible }}>
 				<span class="burger">
 					<smoothly-icon name="menu" />
 				</span>

--- a/src/components/burger/index.tsx
+++ b/src/components/burger/index.tsx
@@ -33,9 +33,7 @@ export class SmoothlyBurger {
 	render() {
 		return (
 			<Host class={{ "smoothly-burger-visible": this.visible }}>
-				<span class="burger">
-					<smoothly-icon name="menu" />
-				</span>
+				<smoothly-icon name="menu" />
 			</Host>
 		)
 	}

--- a/src/components/burger/index.tsx
+++ b/src/components/burger/index.tsx
@@ -1,4 +1,4 @@
-import { Component, Element, Event, EventEmitter, h, Host, Listen, Prop, State, Watch } from "@stencil/core"
+import { Component, Element, Event, EventEmitter, h, Host, Listen, Method, Prop, State, Watch } from "@stencil/core"
 
 @Component({
 	tag: "smoothly-burger",
@@ -12,16 +12,20 @@ export class SmoothlyBurger {
 	@Prop({ reflect: true }) mediaQuery = "(max-width: 900px)"
 	@State() history: boolean
 	@Event() smoothlyNavStatus: EventEmitter<boolean>
-	@Event() smoothlyVisibleStatus: EventEmitter<boolean>
 
 	componentWillLoad() {
-		this.history = window.matchMedia(this.mediaQuery).matches
-		if (!window.matchMedia(this.mediaQuery).matches)
-			this.visible = false
-		else
-			this.visible = true
-		this.smoothlyNavStatus.emit(!this.visible)
-		this.smoothlyVisibleStatus.emit(this.visible)
+		// this.history = window.matchMedia(this.mediaQuery).matches
+		// if (!window.matchMedia(this.mediaQuery).matches)
+		// 	this.visible = false
+		// else
+		// 	this.visible = true
+		// this.smoothlyNavStatus.emit(!this.visible)
+		// this.smoothlyVisibleStatus.emit(this.visible)
+	}
+
+	@Method()
+	setMobileMode(mobile: boolean): void {
+		this.visible = mobile
 	}
 
 	@Watch("open")
@@ -30,27 +34,27 @@ export class SmoothlyBurger {
 	}
 
 	@Listen("click")
-	clickHandler(event: MouseEvent) {
+	clickHandler() {
 		if (this.visible)
 			this.open = !this.open
 	}
 
-	@Listen("resize", { target: "window" })
-	resizeHandler() {
-		const result = window.matchMedia(this.mediaQuery).matches
-		if (result != this.history) {
-			if (result) {
-				this.visible = true
-				this.open = false
-			} else {
-				this.visible = false
-				this.open = false
-			}
-			this.smoothlyVisibleStatus.emit(this.visible)
-			this.smoothlyNavStatus.emit(!this.visible)
-		}
-		this.history = result
-	}
+	// @Listen("resize", { target: "window" })
+	// resizeHandler() {
+	// 	const result = window.matchMedia(this.mediaQuery).matches
+	// 	if (result != this.history) {
+	// 		if (result) {
+	// 			this.visible = true
+	// 			this.open = false
+	// 		} else {
+	// 			this.visible = false
+	// 			this.open = false
+	// 		}
+	// 		this.smoothlyVisibleStatus.emit(this.visible)
+	// 		this.smoothlyNavStatus.emit(!this.visible)
+	// 	}
+	// 	this.history = result
+	// }
 
 	render() {
 		return (

--- a/src/components/burger/index.tsx
+++ b/src/components/burger/index.tsx
@@ -9,19 +9,8 @@ export class SmoothlyBurger {
 	@Element() element: HTMLSmoothlyBurgerElement
 	@Prop({ mutable: true, reflect: true }) visible: boolean
 	@Prop({ mutable: true, reflect: true }) open = false
-	@Prop({ reflect: true }) mediaQuery = "(max-width: 900px)"
 	@State() history: boolean
 	@Event() smoothlyNavStatus: EventEmitter<boolean>
-
-	componentWillLoad() {
-		// this.history = window.matchMedia(this.mediaQuery).matches
-		// if (!window.matchMedia(this.mediaQuery).matches)
-		// 	this.visible = false
-		// else
-		// 	this.visible = true
-		// this.smoothlyNavStatus.emit(!this.visible)
-		// this.smoothlyVisibleStatus.emit(this.visible)
-	}
 
 	@Method()
 	setMobileMode(mobile: boolean): void {
@@ -38,23 +27,6 @@ export class SmoothlyBurger {
 		if (this.visible)
 			this.open = !this.open
 	}
-
-	// @Listen("resize", { target: "window" })
-	// resizeHandler() {
-	// 	const result = window.matchMedia(this.mediaQuery).matches
-	// 	if (result != this.history) {
-	// 		if (result) {
-	// 			this.visible = true
-	// 			this.open = false
-	// 		} else {
-	// 			this.visible = false
-	// 			this.open = false
-	// 		}
-	// 		this.smoothlyVisibleStatus.emit(this.visible)
-	// 		this.smoothlyNavStatus.emit(!this.visible)
-	// 	}
-	// 	this.history = result
-	// }
 
 	render() {
 		return (

--- a/src/components/burger/index.tsx
+++ b/src/components/burger/index.tsx
@@ -1,4 +1,4 @@
-import { Component, Element, Event, EventEmitter, h, Host, Listen, Method, Prop, State, Watch } from "@stencil/core"
+import { Component, Element, Event, EventEmitter, h, Host, Listen, Prop, Watch } from "@stencil/core"
 
 @Component({
 	tag: "smoothly-burger",
@@ -8,16 +8,7 @@ import { Component, Element, Event, EventEmitter, h, Host, Listen, Method, Prop,
 export class SmoothlyBurger {
 	@Element() element: HTMLSmoothlyBurgerElement
 	@Prop({ reflect: true, mutable: true }) open = false
-	@State() visible: boolean
-	@State() history: boolean
 	@Event() smoothlyNavStatus: EventEmitter<boolean>
-
-	@Method()
-	setMobileMode(mobile: boolean): void {
-		this.visible = mobile
-		if (!mobile)
-			this.open = false
-	}
 
 	@Watch("open")
 	openChanged() {
@@ -26,13 +17,12 @@ export class SmoothlyBurger {
 
 	@Listen("click")
 	clickHandler() {
-		if (this.visible)
-			this.open = !this.open
+		this.open = !this.open
 	}
 
 	render() {
 		return (
-			<Host class={{ "smoothly-burger-visible": this.visible }}>
+			<Host>
 				<smoothly-icon name="menu" />
 			</Host>
 		)

--- a/src/components/burger/style.css
+++ b/src/components/burger/style.css
@@ -1,11 +1,11 @@
-:host(.smoothly-burger-visible) {
+:host {
 	display: flex;
 	justify-content: center;
 	align-items: center;
 	height: 100%;
 	cursor: pointer;
 }
-:host(.smoothly-burger-visible) smoothly-icon {
+:host smoothly-icon {
 	--smoothly-icon-size: 3rem;
 	margin-right: 1em;
 }

--- a/src/components/burger/style.css
+++ b/src/components/burger/style.css
@@ -1,12 +1,12 @@
 :host(.smoothly-burger-visible) {
-display: flex;
-justify-content: center;
-align-items: center;
-height: 100%;
-}
-:host(.smoothly-burger-visible) .burger smoothly-icon {
-	--smoothly-icon-size: 3rem;
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	height: 100%;
 	cursor: pointer;
+}
+:host(.smoothly-burger-visible) smoothly-icon {
+	--smoothly-icon-size: 3rem;
 	margin-right: 1em;
 }
 :host:not([open]) smoothly-icon {

--- a/src/components/burger/style.css
+++ b/src/components/burger/style.css
@@ -1,10 +1,10 @@
-:host([visible]) {
+:host(.smoothly-burger-visible) {
 display: flex;
 justify-content: center;
 align-items: center;
 height: 100%;
 }
-:host([visible]) .burger smoothly-icon {
+:host(.smoothly-burger-visible) .burger smoothly-icon {
 	--smoothly-icon-size: 3rem;
 	cursor: pointer;
 	margin-right: 1em;

--- a/src/components/burger/style.css
+++ b/src/components/burger/style.css
@@ -9,9 +9,6 @@ height: 100%;
 	cursor: pointer;
 	margin-right: 1em;
 }
-:host:not([visible]){
-	display: none;
-}
 :host:not([open]) smoothly-icon {
 	transform: rotate(0deg);
 	transition: transform 100ms ease-in-out;


### PR DESCRIPTION
## Problem
`smoothly-app`, `-room`, and `-burger`, all had separately defined breakpoints, that all needed to match for things to work.
This also meant that you had several places checking the breakpoint instead of just one.

## Solution
This PR changes so that smoothly-app defined the breakpoint for all, this also means you can specify your own breakpoint on `smoothly-app`.
```tsx
<smoothly-app nav-breakpoint="64rem">
```