### PR TITLE
date-range only emit input event when date clicked - not for date hovered

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -1037,7 +1037,6 @@ declare global {
         new (): HTMLSmoothlyButtonDemoStandardElement;
     };
     interface HTMLSmoothlyCalendarElementEventMap {
-        "smoothlyValueChange": isoly.Date;
         "smoothlyDateSet": isoly.Date;
         "smoothlyDateRangeSet": isoly.DateRange;
     }
@@ -2392,7 +2391,6 @@ declare namespace LocalJSX {
         "month"?: isoly.Date;
         "onSmoothlyDateRangeSet"?: (event: SmoothlyCalendarCustomEvent<isoly.DateRange>) => void;
         "onSmoothlyDateSet"?: (event: SmoothlyCalendarCustomEvent<isoly.Date>) => void;
-        "onSmoothlyValueChange"?: (event: SmoothlyCalendarCustomEvent<isoly.Date>) => void;
         "start"?: isoly.Date;
         "value"?: isoly.Date;
     }

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -1038,8 +1038,6 @@ declare global {
     };
     interface HTMLSmoothlyCalendarElementEventMap {
         "smoothlyValueChange": isoly.Date;
-        "smoothlyStartChange": isoly.Date;
-        "smoothlyEndChange": isoly.Date;
         "smoothlyDateSet": isoly.Date;
         "smoothlyDateRangeSet": isoly.DateRange;
     }
@@ -2394,8 +2392,6 @@ declare namespace LocalJSX {
         "month"?: isoly.Date;
         "onSmoothlyDateRangeSet"?: (event: SmoothlyCalendarCustomEvent<isoly.DateRange>) => void;
         "onSmoothlyDateSet"?: (event: SmoothlyCalendarCustomEvent<isoly.Date>) => void;
-        "onSmoothlyEndChange"?: (event: SmoothlyCalendarCustomEvent<isoly.Date>) => void;
-        "onSmoothlyStartChange"?: (event: SmoothlyCalendarCustomEvent<isoly.Date>) => void;
         "onSmoothlyValueChange"?: (event: SmoothlyCalendarCustomEvent<isoly.Date>) => void;
         "start"?: isoly.Date;
         "value"?: isoly.Date;

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -374,7 +374,7 @@ export namespace Components {
         "disabled"?: boolean;
         "edit": (editable: boolean) => Promise<void>;
         "end": isoly.Date | undefined;
-        "getValue": () => Promise<Partial<isoly.DateRange | undefined>>;
+        "getValue": () => Promise<Partial<isoly.DateRange> | undefined>;
         "invalid"?: boolean;
         "listen": (listener: Editable.Observer.Listener) => Promise<void>;
         "locale"?: isoly.Locale;

--- a/src/components/calendar/index.tsx
+++ b/src/components/calendar/index.tsx
@@ -22,7 +22,6 @@ export class Calendar {
 	@Event() smoothlyValueChange: EventEmitter<isoly.Date>
 	@Event() smoothlyDateSet: EventEmitter<isoly.Date>
 	@Event() smoothlyDateRangeSet: EventEmitter<isoly.DateRange>
-	@State() firstSelected: boolean
 
 	componentWillLoad() {
 		this.onStart()

--- a/src/components/calendar/index.tsx
+++ b/src/components/calendar/index.tsx
@@ -19,7 +19,6 @@ export class Calendar {
 	@Prop({ reflect: true }) doubleInput: boolean
 	@State() startInternal?: isoly.Date
 	@State() endInternal?: isoly.Date
-	@Event() smoothlyValueChange: EventEmitter<isoly.Date>
 	@Event() smoothlyDateSet: EventEmitter<isoly.Date>
 	@Event() smoothlyDateRangeSet: EventEmitter<isoly.DateRange>
 
@@ -50,21 +49,20 @@ export class Calendar {
 
 	private clickCounter = 0
 	private onClick(date: isoly.Date) {
-		this.smoothlyValueChange.emit((this.value = date))
+		this.value = date
+		this.smoothlyDateSet.emit(this.value)
+	}
+	private onClickDoubleInput(date: isoly.Date) {
 		this.clickCounter += 1
-		if (this.doubleInput) {
-			if (this.clickCounter % 2 == 1) {
-				this.startInternal = this.endInternal = this.frozenDate = date
-			} else {
-				const start = this.startInternal! > date ? date : this.startInternal
-				const end = this.endInternal! < date ? date : this.endInternal
-				this.startInternal = start
-				this.endInternal = end
-			}
+		if (this.clickCounter % 2 == 1) {
+			this.startInternal = this.endInternal = this.frozenDate = date
+		} else {
+			const start = this.startInternal! > date ? date : this.startInternal
+			const end = this.endInternal! < date ? date : this.endInternal
+			this.startInternal = start
+			this.endInternal = end
 		}
-		!this.doubleInput && this.smoothlyDateSet.emit(this.value)
-		this.doubleInput &&
-			this.clickCounter % 2 == 0 &&
+		this.clickCounter % 2 == 0 &&
 			this.startInternal &&
 			this.endInternal &&
 			this.smoothlyDateRangeSet.emit({ start: this.startInternal, end: this.endInternal })
@@ -120,8 +118,12 @@ export class Calendar {
 							{week.map(date => (
 								<td
 									tabindex={1}
-									onMouseOver={() => (this.withinLimit(date) ? this.onHover(date) : undefined)}
-									onClick={this.withinLimit(date) ? () => this.onClick(date) : undefined}
+									onMouseOver={this.withinLimit(date) ? () => this.onHover(date) : undefined}
+									onClick={
+										this.withinLimit(date)
+											? () => (this.doubleInput ? this.onClickDoubleInput(date) : this.onClick(date))
+											: undefined
+									}
 									class={{
 										selected:
 											date == this.value ||

--- a/src/components/input/date/index.tsx
+++ b/src/components/input/date/index.tsx
@@ -195,7 +195,7 @@ export class SmoothlyInputDate implements ComponentWillLoad, Clearable, Input, E
 						ref={el => (this.calendarElement = el)}
 						doubleInput={false}
 						value={this.value}
-						onSmoothlyValueChange={e => (e.stopPropagation(), this.onUserChangedValue(e))}
+						onSmoothlyDateSet={e => (e.stopPropagation(), this.onUserChangedValue(e))}
 						max={this.max}
 						min={this.min}>
 						<div slot={"year-label"}>

--- a/src/components/input/date/range/index.tsx
+++ b/src/components/input/date/range/index.tsx
@@ -136,7 +136,7 @@ export class SmoothlyInputDateRange implements Clearable, Input, Editable {
 		Input.formRemove(this)
 	}
 	@Method()
-	async getValue(): Promise<Partial<isoly.DateRange | undefined>> {
+	async getValue(): Promise<Partial<isoly.DateRange> | undefined> {
 		return this.start || this.end ? { start: this.start, end: this.end } : undefined
 	}
 	@Method()

--- a/src/components/input/date/range/index.tsx
+++ b/src/components/input/date/range/index.tsx
@@ -225,12 +225,12 @@ export class SmoothlyInputDateRange implements Clearable, Input, Editable {
 						ref={el => (this.calendarElement = el)}
 						doubleInput={true}
 						onSmoothlyValueChange={e => e.stopPropagation()}
-						onSmoothlyStartChange={e => (e.stopPropagation(), (this.start = e.detail))}
-						onSmoothlyEndChange={e => (e.stopPropagation(), (this.end = e.detail))}
 						onSmoothlyDateSet={e => e.stopPropagation()}
 						onSmoothlyDateRangeSet={e => {
 							e.stopPropagation()
 							this.open = false
+							this.start = e.detail.start
+							this.end = e.detail.end
 							this.smoothlyInput.emit({ [this.name]: e.detail })
 							this.smoothlyUserInput.emit({ name: this.name, value: e.detail })
 						}}

--- a/src/components/input/date/range/index.tsx
+++ b/src/components/input/date/range/index.tsx
@@ -223,8 +223,7 @@ export class SmoothlyInputDateRange implements Clearable, Input, Editable {
 				{this.open && (
 					<smoothly-calendar
 						ref={el => (this.calendarElement = el)}
-						doubleInput={true}
-						onSmoothlyValueChange={e => e.stopPropagation()}
+						doubleInput
 						onSmoothlyDateSet={e => e.stopPropagation()}
 						onSmoothlyDateRangeSet={e => {
 							e.stopPropagation()

--- a/src/components/input/date/time/index.tsx
+++ b/src/components/input/date/time/index.tsx
@@ -239,13 +239,10 @@ export class SmoothlyInputDateTime implements ComponentWillLoad, Clearable, Inpu
 						value={this.value ? isoly.DateTime.getDate(this.value) : undefined}
 						min={this.min ? isoly.DateTime.getDate(this.min) : undefined}
 						max={this.max ? isoly.DateTime.getDate(this.max) : undefined}
-						onSmoothlyValueChange={async e => {
+						onSmoothlyDateSet={async e => {
 							e.stopPropagation()
 							this.date = e.detail
 							this.smoothlyUserInput.emit({ name: this.name, value: await this.getValue() })
-						}}
-						onSmoothlyDateSet={e => {
-							e.stopPropagation()
 							this.open = false
 						}}>
 						<div slot={"year-label"}>


### PR DESCRIPTION
## Changes
In smoothly-calendar:
- separate Prop `start`/`end` from State `startInternal`/`endInternal`
- Remove State `firstSelected` - never used State
- Remove `smoothlyStartChange` and `smoothlyEndChange` not needed anymore.
- Remove event `smoothlyValueChange` - does the same thing as `smoothlyDateSet` 


### Before
Event is emitted every time new date is hovered, when selecting.

[Screencast from 2025-11-27 11_48_10.webm](https://github.com/user-attachments/assets/a957d854-b575-438b-90e7-fa253a3d01bc)

### After
No date-range is emitted until both are selected.

https://github.com/user-attachments/assets/4f522673-c9ee-4425-ac4d-8bc8157e5afa

