### PR TITLE
Fix bug when changing smoothly-input type

### DIFF
--- a/src/components/input/InputStateHandler.ts
+++ b/src/components/input/InputStateHandler.ts
@@ -204,13 +204,15 @@ export class InputStateHandler {
 	private toString(value: any): string {
 		return this.formatter.toString(value)
 	}
-	public initialState(value: any): Readonly<tidily.State> & tidily.Settings {
+	public initialState(value: any, inputElement?: HTMLInputElement): Readonly<tidily.State> & tidily.Settings {
 		const stringValue = this.toString(value) || ""
 		const start = stringValue.length
 		const state = this.createFormattedState({
 			value: stringValue,
 			selection: { start, end: start, direction: "none" },
 		})
+		if (inputElement)
+			inputElement.value = state.value
 		return state
 	}
 	public setValue(

--- a/src/components/input/index.tsx
+++ b/src/components/input/index.tsx
@@ -138,9 +138,7 @@ export class SmoothlyInput implements Clearable, Input, Editable {
 				this.stateHandler = InputStateHandler.create(this.type, getLocale())
 				break
 		}
-		this.state = this.stateHandler.initialState(this.value ?? this.state?.value)
-		this.inputElement &&
-			(this.state = this.stateHandler.setValue(this.inputElement, this.state, this.value ?? this.state?.value))
+		this.state = this.stateHandler.initialState(this.value ?? this.state?.value, this.inputElement)
 	}
 	@Watch("state")
 	stateChange() {

--- a/src/components/input/index.tsx
+++ b/src/components/input/index.tsx
@@ -139,7 +139,8 @@ export class SmoothlyInput implements Clearable, Input, Editable {
 				break
 		}
 		this.state = this.stateHandler.initialState(this.value ?? this.state?.value)
-		this.inputElement && (this.state = this.stateHandler.setValue(this.inputElement, this.state, this.value))
+		this.inputElement &&
+			(this.state = this.stateHandler.setValue(this.inputElement, this.state, this.value ?? this.state?.value))
 	}
 	@Watch("state")
 	stateChange() {


### PR DESCRIPTION
**Example:** When showing hiding password, the show/hide is broken. 
This is because the value was set the `this.value` but should have been set to `this.value ?? this.state.value`. 
Updating `initialState` method so we only need to update `this.state` once.

### Before
https://github.com/user-attachments/assets/620b0c7f-9dd8-4f5d-9ce2-9f867e1e0dbe

### After
https://github.com/user-attachments/assets/6422bd10-93d5-46d2-bb1f-d73c57af542b

