### PR TITLE
Demos looks better on mobile

### DIFF
--- a/src/components/form/demo/style.css
+++ b/src/components/form/demo/style.css
@@ -7,5 +7,5 @@
 :host>div {
 	margin: auto;
 	width: 1200px;
-	max-width: 100%;
+	max-width: calc(100% - 0.5rem);
 }

--- a/src/components/form/style.css
+++ b/src/components/form/style.css
@@ -22,7 +22,7 @@ smoothly-form > form > fieldset {
 }
 smoothly-form > form > fieldset > * {
 	flex-grow: 1;
-	min-width: min(100%, var(--smoothly-form-input-min-width, 10rem));
+	min-width: min(100%, var(--smoothly-form-input-min-width, 14rem));
 	flex-basis: 40%;
 }
 

--- a/src/components/input/demo/standard/style.css
+++ b/src/components/input/demo/standard/style.css
@@ -1,5 +1,5 @@
 :host {
-	width: 50%;
+	max-width: min(calc(100% - 0.5rem), 48rem);
 	margin: auto;
 }
 
@@ -7,13 +7,16 @@
 :host p {
 	margin: .5rem 0;
 }
+:host > .description {
+	--smoothly-form-input-min-width: 18rem;
+}
 :host smoothly-input-range[name=borderRadius] {
 	flex-basis: 100%;
 }
 div.input-wrapper {
 	display: grid;
 	margin-top: 1rem;
-	grid-template-columns: 2fr 1fr;
+	grid-template-columns: 1fr 9rem;
 	gap: 1rem;
 	position: relative;
 	justify-content: space-around;

--- a/src/components/input/demo/style.css
+++ b/src/components/input/demo/style.css
@@ -18,8 +18,8 @@ smoothly-input-demo-standard {
 }
 
 div.inputs {
+	max-width: min(calc(100% - 2rem), 56rem);
 	margin: auto;
-	width: 50%;
 }
 
 div.inputs>h2:not(:first-child) {
@@ -37,12 +37,13 @@ div.inputs>h2:not(:first-child) {
 
 .select-div {
 	display: flex;
-	justify-content: space-between;
+	/* justify-content: space-between; */
 	gap: 1em;
 	flex-wrap: wrap;
 }
 
-.select-div>smoothly-color>*,
 .select-div>* {
-	flex-basis: 49%;
+	flex-grow: 1;
+	min-width: min(100%, var(--smoothly-form-input-min-width, 18rem));
+	flex-basis: 40%;
 }

--- a/src/components/input/demo/user-input/style.css
+++ b/src/components/input/demo/user-input/style.css
@@ -8,3 +8,11 @@
 :host > div {
 	grid-column: 1 / -1;
 }
+
+
+/* Mobile */
+@media (max-width: 48rem) {
+	:host {
+		grid-template-columns: 1fr;
+	}
+}

--- a/src/components/theme/colors/style.css
+++ b/src/components/theme/colors/style.css
@@ -1,7 +1,7 @@
 :host {
 	display: grid;
 	grid-template-columns: repeat(3, 1fr);
-	row-gap: 1em;
-	column-gap: 1em;
+	row-gap: 1rem;
+	column-gap: 0.5rem;
 	width: fit-content;
 }

--- a/src/components/theme/demo/index.tsx
+++ b/src/components/theme/demo/index.tsx
@@ -23,10 +23,10 @@ export class SmoothlyThemeDemo {
 					<smoothly-item value="https://theme.payfunc.com/light/index.css">Payfunc Light</smoothly-item>
 					<smoothly-item value="https://theme.payfunc.com/dark/index.css">Payfunc Dark</smoothly-item>
 				</smoothly-theme-picker>
-				<span>
+				<div>
 					<smoothly-theme-colors />
 					<smoothly-theme-guide />
-				</span>
+				</div>
 				<smoothly-button type="link" link="/redirect">
 					To redirect
 				</smoothly-button>

--- a/src/components/theme/demo/style.css
+++ b/src/components/theme/demo/style.css
@@ -1,7 +1,7 @@
 :host {
-	display: flex;
-	width: 50%;
+	max-width: min(calc(100% - 2rem), 56rem);
 	margin: auto;
+	display: flex;
 	flex-direction: column;
 	gap: 2em;
 	margin-top: 2em;
@@ -11,8 +11,9 @@
 	width: 20em;
 }
 
-:host>span {
+:host>div {
 	display: flex;
 	flex-direction: row;
-	gap: 10em;
+	justify-content: space-between;
+	gap: 1rem;
 }

--- a/src/components/theme/guide/style.css
+++ b/src/components/theme/guide/style.css
@@ -1,0 +1,3 @@
+:host {
+	max-width: 50ch;
+}


### PR DESCRIPTION
## theme
before vs after

<img width="380" src="https://github.com/user-attachments/assets/617fbbef-1a16-4484-be08-1b3d21424603" /> <img width="380" src="https://github.com/user-attachments/assets/3f51875c-dadb-4376-bfb4-45d8afb9c3e8" />


## form
:warning: The only change outside of demo is that the fallback value for `--smoothly-form-input-min-width` is changed from `10rem` to `14rem`, since `10rem` was ridiculously small.

before vs after

<img width="380" src="https://github.com/user-attachments/assets/10fe29f7-1505-4eb2-8180-955308d2a3ec" /> <img width="380" src="https://github.com/user-attachments/assets/06b3191b-fd8a-4333-a1c6-2ae168ed7d7d" />


## Input
before vs after

<img width="380" src="https://github.com/user-attachments/assets/42f98d31-5a59-459e-9365-a8b9c8797b8b" /> <img width="380" src="https://github.com/user-attachments/assets/605a0c67-d3ac-4fea-ae7a-1b557bcdded5" />



