### PR TITLE
Stop sticky nested table headers from covering each other.

### DIFF
--- a/src/assets/style/mapping.css
+++ b/src/assets/style/mapping.css
@@ -66,7 +66,7 @@ smoothly-color {
 	--smoothly-button-focus-border: var(--smoothly-color-shade);
 	--smoothly-button-border-radius: 0.25rem;
 	
-	/* smoothly-calendar */
+	/* smoothly-calendar !!!! */
 	--smoothly-calendar-weekend-foreground: var(--smoothly-danger-color);
 	
 	/* smoothly-modal */

--- a/src/assets/style/mapping.css
+++ b/src/assets/style/mapping.css
@@ -66,7 +66,7 @@ smoothly-color {
 	--smoothly-button-focus-border: var(--smoothly-color-shade);
 	--smoothly-button-border-radius: 0.25rem;
 	
-	/* smoothly-calendar !!!! */
+	/* smoothly-calendar */
 	--smoothly-calendar-weekend-foreground: var(--smoothly-danger-color);
 	
 	/* smoothly-modal */

--- a/src/components/table/head/style.css
+++ b/src/components/table/head/style.css
@@ -4,7 +4,7 @@
 	grid-template-columns: subgrid;
 	top: 0;
 	position: sticky;
-	z-index: 1;
+	z-index: 2;
 	--smoothly-color: var(--smoothly-table-header-background);
 	--smoothly-color-contrast: var(--smoothly-table-header-foreground);
 	background-color: rgb(var(--smoothly-table-header-background));

--- a/src/components/table/style.css
+++ b/src/components/table/style.css
@@ -5,3 +5,13 @@
 	stroke: rgb(var(--smoothly-table-foreground));
 	fill: rgb(var(--smoothly-table-foreground));
 }
+
+:host smoothly-table smoothly-table-head {
+	top: var(--smoothly-table-cell-min-height);
+	z-index: 1
+}
+
+:host smoothly-table smoothly-table-head:nth-child(2) {
+	top: calc(var(--smoothly-table-cell-min-height) * 2);
+	z-index: 1
+}


### PR DESCRIPTION
When scrolling in a table with nested tables the sticky headers stacks on top of each other, this makes the nested table-header stick on the bottom of the parent-header.

### Before
[before.webm](https://github.com/user-attachments/assets/a17b3619-eea3-4e17-a290-b642234d88f3)

### After
[after.webm](https://github.com/user-attachments/assets/93180fe7-07cc-4343-a4fe-3fb46d85e39b)