### PR TITLE
Fix button height in smoothly-input-file

### DIFF
--- a/src/components/input/file/style.css
+++ b/src/components/input/file/style.css
@@ -57,6 +57,7 @@
 }
 
 :host>div>smoothly-button {
+	--smoothly-button-height: 1.4rem;
 	margin: 0;
 	border: none;
 }


### PR DESCRIPTION
### Before
<img width="636" height="96" alt="Screenshot from 2025-12-15 10-08-06" src="https://github.com/user-attachments/assets/e1c0b08f-a381-4d43-bde8-15f95529f177" />

<img width="636" height="96" alt="Screenshot from 2025-12-15 10-08-40" src="https://github.com/user-attachments/assets/c2c6ae47-9080-489a-afb5-217f1c24a340" /> 

Button takes up to much height.
This happened because of the button height refactor.

### After
<img width="672" height="69" alt="Screenshot from 2025-12-15 10-07-08" src="https://github.com/user-attachments/assets/4bd3e55e-efb3-4afb-9a77-b624e1696d6e" />
