### PR TITLE
Add input-invalid-icon css-var + Add invalid prop on input-date, -range

### DIFF
--- a/src/assets/style/mapping.css
+++ b/src/assets/style/mapping.css
@@ -36,6 +36,7 @@ smoothly-color {
 	--smoothly-input-disabled-border: var(--smoothly-default-shade);
 	--smoothly-input-border-readonly: var(--smoothly-input-border), 50%;
 	--smoothly-input-border-radius: 0;
+	--smoothly-input-invalid-icon: var(--smoothly-danger-color);
 
 	--smoothly-input-hover-background: var(--smoothly-primary-tint);
 	--smoothly-input-hover-foreground: var(--smoothly-primary-contrast);

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -126,7 +126,6 @@ export namespace Components {
     interface SmoothlyDateText {
         "deselect": () => Promise<void>;
         "disabled": boolean;
-        "invalid": boolean;
         "locale"?: isoly.Locale;
         "readonly": boolean;
         "select": (place?: "start" | "end") => Promise<void>;
@@ -374,6 +373,7 @@ export namespace Components {
         "disabled"?: boolean;
         "edit": (editable: boolean) => Promise<void>;
         "end": isoly.Date | undefined;
+        "errorMessage"?: string;
         "getValue": () => Promise<Partial<isoly.DateRange> | undefined>;
         "invalid"?: boolean;
         "listen": (listener: Editable.Observer.Listener) => Promise<void>;
@@ -2413,7 +2413,6 @@ declare namespace LocalJSX {
     }
     interface SmoothlyDateText {
         "disabled"?: boolean;
-        "invalid"?: boolean;
         "locale"?: isoly.Locale;
         "onSmoothlyDateHasPartialDate"?: (event: SmoothlyDateTextCustomEvent<DateFormat.Parts>) => void;
         "onSmoothlyDateTextChange"?: (event: SmoothlyDateTextCustomEvent<isoly.Date | undefined>) => void;
@@ -2666,6 +2665,7 @@ declare namespace LocalJSX {
         "color"?: Color;
         "disabled"?: boolean;
         "end"?: isoly.Date | undefined;
+        "errorMessage"?: string;
         "invalid"?: boolean;
         "locale"?: isoly.Locale;
         "looks"?: Looks;

--- a/src/components/input/date/index.tsx
+++ b/src/components/input/date/index.tsx
@@ -188,14 +188,7 @@ export class SmoothlyInputDate implements ComponentWillLoad, Clearable, Input, E
 					onSmoothlyDateTextDone={e => (e.stopPropagation(), (this.open = false), this.dateTextElement?.deselect())}
 				/>
 				<span class="smoothly-icons" ref={el => (this.iconsElement = el)}>
-					<smoothly-icon
-						class="smoothly-invalid"
-						name="alert-circle"
-						color="danger"
-						fill="clear"
-						size="small"
-						tooltip={this.errorMessage}
-					/>
+					<smoothly-icon class="smoothly-invalid" name="alert-circle" size="small" tooltip={this.errorMessage} />
 					<slot name={"end"} />
 				</span>
 				{this.open && !this.readonly && (

--- a/src/components/input/date/index.tsx
+++ b/src/components/input/date/index.tsx
@@ -35,7 +35,7 @@ export class SmoothlyInputDate implements ComponentWillLoad, Clearable, Input, E
 	@Prop({ reflect: true }) name: string
 	@Prop({ reflect: true, mutable: true }) readonly = false
 	@Prop({ reflect: true }) disabled?: boolean
-	@Prop() invalid?: boolean = false
+	@Prop({ reflect: true }) invalid?: boolean = false
 	@Prop({ reflect: true }) errorMessage?: string
 	@Prop({ reflect: true }) placeholder?: string
 	@Prop({ reflect: true }) alwaysShowGuide = false
@@ -187,7 +187,15 @@ export class SmoothlyInputDate implements ComponentWillLoad, Clearable, Input, E
 					onSmoothlyDateTextChange={e => (e.stopPropagation(), this.onUserChangedValue(e))}
 					onSmoothlyDateTextDone={e => (e.stopPropagation(), (this.open = false), this.dateTextElement?.deselect())}
 				/>
-				<span class="icons" ref={el => (this.iconsElement = el)}>
+				<span class="smoothly-icons" ref={el => (this.iconsElement = el)}>
+					<smoothly-icon
+						class="smoothly-invalid"
+						name="alert-circle"
+						color="danger"
+						fill="clear"
+						size="small"
+						tooltip={this.errorMessage}
+					/>
 					<slot name={"end"} />
 				</span>
 				{this.open && !this.readonly && (

--- a/src/components/input/date/range/index.tsx
+++ b/src/components/input/date/range/index.tsx
@@ -27,7 +27,8 @@ export class SmoothlyInputDateRange implements Clearable, Input, Editable {
 	@Prop({ mutable: true }) end: isoly.Date | undefined
 	@Prop({ reflect: true }) placeholder: string
 	@Prop({ reflect: true }) alwaysShowGuide = false
-	@Prop() invalid?: boolean = false
+	@Prop({ reflect: true }) invalid?: boolean = false
+	@Prop({ reflect: true }) errorMessage?: string
 	@Prop() max?: isoly.Date
 	@Prop() min?: isoly.Date
 	parent: Editable | undefined
@@ -195,7 +196,6 @@ export class SmoothlyInputDateRange implements Clearable, Input, Editable {
 						value={this.start}
 						readonly={this.readonly}
 						disabled={this.disabled}
-						invalid={this.invalid}
 						showLabel={this.showLabel}
 					/>
 					<span class="smoothly-date-range-separator"> – </span>
@@ -213,11 +213,18 @@ export class SmoothlyInputDateRange implements Clearable, Input, Editable {
 						value={this.end}
 						readonly={this.readonly}
 						disabled={this.disabled}
-						invalid={this.invalid}
 						showLabel={this.showLabel}
 					/>
 				</span>
-				<span class={"icons"}>
+				<span class={"smoothly-icons"}>
+					<smoothly-icon
+						class="smoothly-invalid"
+						name="alert-circle"
+						color="danger"
+						fill="clear"
+						size="small"
+						tooltip={this.errorMessage}
+					/>
 					<slot name={"end"} />
 				</span>
 				{this.open && (

--- a/src/components/input/date/range/index.tsx
+++ b/src/components/input/date/range/index.tsx
@@ -217,14 +217,7 @@ export class SmoothlyInputDateRange implements Clearable, Input, Editable {
 					/>
 				</span>
 				<span class={"smoothly-icons"}>
-					<smoothly-icon
-						class="smoothly-invalid"
-						name="alert-circle"
-						color="danger"
-						fill="clear"
-						size="small"
-						tooltip={this.errorMessage}
-					/>
+					<smoothly-icon class="smoothly-invalid" name="alert-circle" size="small" tooltip={this.errorMessage} />
 					<slot name={"end"} />
 				</span>
 				{this.open && (

--- a/src/components/input/date/range/style.scss
+++ b/src/components/input/date/range/style.scss
@@ -94,8 +94,17 @@
 	cursor: pointer;
 }
 
-:host > span.icons {
+:host > span.smoothly-icons {
 	display: flex;
 	flex-direction: row;
 	align-items: center;
+}
+
+:host > .smoothly-icons > .smoothly-invalid {
+	display: none;
+	padding: 0.5rem;
+}
+
+:host[invalid] > .smoothly-icons > .smoothly-invalid {
+	display: flex;
 }

--- a/src/components/input/date/style.css
+++ b/src/components/input/date/style.css
@@ -64,9 +64,16 @@
 	border-left: 1px solid rgb(var(--smoothly-input-border));
 }
 
-:host>span.icons {
+:host>.smoothly-icons {
 	display: flex;
 	flex-direction: row;
 	align-items: center;
 	margin-left: auto;
+}
+:host>.smoothly-icons>.smoothly-invalid {
+	display: none;
+	padding: 0.5rem;
+}
+:host[invalid]>.smoothly-icons>.smoothly-invalid {
+	display: flex;
 }

--- a/src/components/input/date/text/index.tsx
+++ b/src/components/input/date/text/index.tsx
@@ -19,7 +19,6 @@ export class SmoothlyInputDateRangeText {
 	@Prop() locale?: isoly.Locale = getLocale()
 	@Prop({ reflect: true }) readonly: boolean
 	@Prop({ reflect: true }) disabled: boolean
-	@Prop({ reflect: true }) invalid: boolean
 	@Prop({ reflect: true }) showLabel = true
 	@Prop() value?: isoly.Date // Only used for initial value
 	@State() parts: DateFormat.Parts = {}

--- a/src/components/input/date/time/index.tsx
+++ b/src/components/input/date/time/index.tsx
@@ -223,14 +223,7 @@ export class SmoothlyInputDateTime implements ComponentWillLoad, Clearable, Inpu
 					}}
 				/>
 				<span class="icons">
-					<smoothly-icon
-						class="smoothly-invalid"
-						name="alert-circle"
-						color="danger"
-						fill="clear"
-						size="small"
-						tooltip={this.errorMessage}
-					/>
+					<smoothly-icon class="smoothly-invalid" name="alert-circle" size="small" tooltip={this.errorMessage} />
 					<slot name={"end"} />
 				</span>
 				{this.open && !this.readonly && (

--- a/src/components/input/demo/standard/index.tsx
+++ b/src/components/input/demo/standard/index.tsx
@@ -210,7 +210,7 @@ export class SmoothlyInputDemoStandard {
 						readonly={this.options.readonly}
 						disabled={this.options.disabled}
 						invalid={this.options.invalid}
-						// TODO - errorMessage
+						errorMessage={this.options.errorMessage}
 						showLabel={this.options.showLabel}
 						placeholder={this.options.placeholder}
 						alwaysShowGuide={this.options.alwaysShowGuide}>
@@ -242,12 +242,10 @@ export class SmoothlyInputDemoStandard {
 						readonly={this.options.readonly}
 						disabled={this.options.disabled}
 						invalid={this.options.invalid}
-						// TODO - errorMessage
+						errorMessage={this.options.errorMessage}
 						placeholder={this.options.placeholder}
 						alwaysShowGuide={this.options.alwaysShowGuide}
-						showLabel={this.options.showLabel}
-						// TODO - placeholder
-					>
+						showLabel={this.options.showLabel}>
 						{this.options.showLabel && <span>Date Range</span>}
 						<smoothly-input-clear slot="end" />
 					</smoothly-input-date-range>

--- a/src/components/input/index.tsx
+++ b/src/components/input/index.tsx
@@ -248,14 +248,7 @@ export class SmoothlyInput implements Clearable, Input, Editable {
 						/>
 					</span>
 				)}
-				<smoothly-icon
-					class="smoothly-invalid"
-					name="alert-circle"
-					color="danger"
-					fill="clear"
-					size="small"
-					tooltip={this.errorMessage}
-				/>
+				<smoothly-icon class="smoothly-invalid" name="alert-circle" size="small" tooltip={this.errorMessage} />
 				<slot name="end" />
 			</Host>
 		)

--- a/src/components/input/select/index.tsx
+++ b/src/components/input/select/index.tsx
@@ -363,14 +363,7 @@ export class SmoothlyInputSelect implements Input, Editable, Clearable, Componen
 					{this.placeholder}
 				</div>
 				<div class="icons" ref={element => (this.iconsDiv = element)}>
-					<smoothly-icon
-						class="smoothly-invalid"
-						name="alert-circle"
-						color="danger"
-						fill="clear"
-						size="small"
-						tooltip={this.errorMessage}
-					/>
+					<smoothly-icon class="smoothly-invalid" name="alert-circle" size="small" tooltip={this.errorMessage} />
 					<slot name="end" />
 					{this.looks == "border" && !this.readonly && (
 						<smoothly-icon

--- a/src/components/input/shared.css
+++ b/src/components/input/shared.css
@@ -105,3 +105,6 @@
 :host:not([show-label]):not(.show-label) .label {
 	display: none;
 }
+:host smoothly-icon.smoothly-invalid {
+	fill: rgb(var(--smoothly-input-invalid-icon, var(--smoothly-danger-color)));
+}

--- a/src/components/input/style.css
+++ b/src/components/input/style.css
@@ -73,10 +73,6 @@
 	z-index: 2;
 	padding: 0.5rem;
 }
-:host:not([disabled])>.smoothly-invalid {
-	cursor: pointer;
-}
-
 :host[invalid]>.smoothly-invalid {
 	display: flex;
 }


### PR DESCRIPTION
## Add invalid color css-variable
`--smoothly-input-invalid-icon`
Now you can choose another color, but if you don't it will fallback on `--smoothly-danger-color`.

Examples:
:purple_heart: Purple 
<img width="500" height="207" alt="image" src="https://github.com/user-attachments/assets/9f316388-babd-4a25-a8d2-b1078acf0cfc" />


or `smoothly-danger-shade` with the pax2pay-portal theme
<img width="500" height="208" alt="Screenshot from 2025-12-15 16-25-24" src="https://github.com/user-attachments/assets/50b53fe2-055c-49a0-ae45-583f217489ea" />

## invalid-icon on input-date and input-date-range

Before vs. After
<img width="395" height="210" alt="Screenshot from 2025-12-15 16-07-31" src="https://github.com/user-attachments/assets/2f8fd838-cf31-4856-bce0-886f92ad654f" /> <img width="395" height="210" alt="Screenshot from 2025-12-15 16-07-44" src="https://github.com/user-attachments/assets/c5ea2706-382b-4b7b-94a0-397ac8b93289" />

These are now the inputs with working `invalid` and `errorMessage`
<img width="500" height="683" alt="Screenshot from 2025-12-15 16-25-57" src="https://github.com/user-attachments/assets/047a597c-fcb5-41d0-9793-072643017830" />


