### PR TITLE
Filled input-checkbox when checked - clear distinction

### DIFF
--- a/src/components/input/checkbox/index.tsx
+++ b/src/components/input/checkbox/index.tsx
@@ -32,7 +32,7 @@ export class SmoothlyInputCheckbox implements Input, Clearable, Editable, Compon
 	@Prop({ reflect: true }) name: string
 	@Prop({ reflect: true, mutable: true }) readonly = false
 	@Prop({ reflect: true }) disabled: boolean
-	@Prop({ mutable: true }) checked = false
+	@Prop({ mutable: true, reflect: true }) checked = false
 	@Prop() value?: Record<"true" | "false", any>
 	@Prop({ reflect: true, mutable: true }) looks?: Looks
 	@Prop({ reflect: true, mutable: true }) color?: Color
@@ -125,7 +125,7 @@ export class SmoothlyInputCheckbox implements Input, Clearable, Editable, Compon
 						this.smoothlyUserInput.emit({ name: this.name, value: await this.getValue() })
 					}}
 				/>
-				{this.checked && <smoothly-icon name="checkmark-outline" size="tiny" />}
+				{this.checked && <smoothly-icon name="checkmark-sharp" size="tiny" />}
 				<label htmlFor={this.id}>
 					<slot />
 				</label>

--- a/src/components/input/checkbox/style.css
+++ b/src/components/input/checkbox/style.css
@@ -16,21 +16,19 @@
 	padding-right: 0;
 }
 
-:host>smoothly-icon {
-	position: absolute;
-	z-index: 1;
-	pointer-events: none;
-}
-
 :host>input {
 	-webkit-appearance: none;
 	-moz-appearance: none;
 	appearance: none;
 	height: 1.25rem;
 	width: 1.25rem;
+	border-radius: 0.25rem;
 	border: 1px solid rgb(var(--smoothly-input-foreground));
 	color: rgb(var(--smoothly-input-foreground));
 	display: block;
+}
+:host([checked])>input {
+	background-color: rgb(var(--smoothly-input-foreground));
 }
 
 :host:not([readonly]):not([disabled])>input,
@@ -46,8 +44,12 @@
 	cursor: not-allowed;
 }
 
-:host>smoothly-icon { 
-	--smoothly-color-contrast: var(--smoothly-input-foreground);
+:host>smoothly-icon {
+	position: absolute;
+	z-index: 1;
+	pointer-events: none;
+	--smoothly-color-contrast: var(--smoothly-input-background);
+	/* outline: 2px solid blue; */
 }
 
 :host[looks="transparent"] {


### PR DESCRIPTION
Make checked and unchecked smoothly-input-checkbox, clear at a glance.


**Before**
Really not clear what is checked at a glance. You have to scan through the options to see it well.

<img width="1228" height="417" alt="Screenshot from 2025-12-18 10-25-04" src="https://github.com/user-attachments/assets/1be73996-7181-425c-9455-3d6d943f6aae" />


**After**
Immediately obvious.
<img width="1228" height="417" alt="Screenshot from 2025-12-18 10-24-25" src="https://github.com/user-attachments/assets/9f9ca63d-f67d-4c46-8a33-b78942ce0f71" />

