### PR TITLE
Fix input-checkbox for looks=transparent

### DIFF
--- a/src/components/input/checkbox/style.css
+++ b/src/components/input/checkbox/style.css
@@ -27,6 +27,7 @@
 	color: rgb(var(--smoothly-input-foreground));
 	display: block;
 }
+:host([checked][looks=transparent])>input, /* Override shared.css transparent styling */
 :host([checked])>input {
 	background-color: rgb(var(--smoothly-input-foreground));
 }


### PR DESCRIPTION
Bug: Checked checkbox will look invisible, when `looks="transparent"`.
This PR fixes that.