### PR TITLE
Fix editing autofilled values in Chrome

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -417,6 +417,8 @@ export namespace Components {
     }
     interface SmoothlyInputDemoStandard {
     }
+    interface SmoothlyInputDemoTypes {
+    }
     interface SmoothlyInputDemoUserInput {
     }
     interface SmoothlyInputEdit {
@@ -1607,6 +1609,12 @@ declare global {
         prototype: HTMLSmoothlyInputDemoStandardElement;
         new (): HTMLSmoothlyInputDemoStandardElement;
     };
+    interface HTMLSmoothlyInputDemoTypesElement extends Components.SmoothlyInputDemoTypes, HTMLStencilElement {
+    }
+    var HTMLSmoothlyInputDemoTypesElement: {
+        prototype: HTMLSmoothlyInputDemoTypesElement;
+        new (): HTMLSmoothlyInputDemoTypesElement;
+    };
     interface HTMLSmoothlyInputDemoUserInputElement extends Components.SmoothlyInputDemoUserInput, HTMLStencilElement {
     }
     var HTMLSmoothlyInputDemoUserInputElement: {
@@ -2268,6 +2276,7 @@ declare global {
         "smoothly-input-date-time": HTMLSmoothlyInputDateTimeElement;
         "smoothly-input-demo": HTMLSmoothlyInputDemoElement;
         "smoothly-input-demo-standard": HTMLSmoothlyInputDemoStandardElement;
+        "smoothly-input-demo-types": HTMLSmoothlyInputDemoTypesElement;
         "smoothly-input-demo-user-input": HTMLSmoothlyInputDemoUserInputElement;
         "smoothly-input-edit": HTMLSmoothlyInputEditElement;
         "smoothly-input-file": HTMLSmoothlyInputFileElement;
@@ -2707,6 +2716,8 @@ declare namespace LocalJSX {
     }
     interface SmoothlyInputDemoStandard {
     }
+    interface SmoothlyInputDemoTypes {
+    }
     interface SmoothlyInputDemoUserInput {
     }
     interface SmoothlyInputEdit {
@@ -3087,6 +3098,7 @@ declare namespace LocalJSX {
         "smoothly-input-date-time": SmoothlyInputDateTime;
         "smoothly-input-demo": SmoothlyInputDemo;
         "smoothly-input-demo-standard": SmoothlyInputDemoStandard;
+        "smoothly-input-demo-types": SmoothlyInputDemoTypes;
         "smoothly-input-demo-user-input": SmoothlyInputDemoUserInput;
         "smoothly-input-edit": SmoothlyInputEdit;
         "smoothly-input-file": SmoothlyInputFile;
@@ -3203,6 +3215,7 @@ declare module "@stencil/core" {
             "smoothly-input-date-time": LocalJSX.SmoothlyInputDateTime & JSXBase.HTMLAttributes<HTMLSmoothlyInputDateTimeElement>;
             "smoothly-input-demo": LocalJSX.SmoothlyInputDemo & JSXBase.HTMLAttributes<HTMLSmoothlyInputDemoElement>;
             "smoothly-input-demo-standard": LocalJSX.SmoothlyInputDemoStandard & JSXBase.HTMLAttributes<HTMLSmoothlyInputDemoStandardElement>;
+            "smoothly-input-demo-types": LocalJSX.SmoothlyInputDemoTypes & JSXBase.HTMLAttributes<HTMLSmoothlyInputDemoTypesElement>;
             "smoothly-input-demo-user-input": LocalJSX.SmoothlyInputDemoUserInput & JSXBase.HTMLAttributes<HTMLSmoothlyInputDemoUserInputElement>;
             "smoothly-input-edit": LocalJSX.SmoothlyInputEdit & JSXBase.HTMLAttributes<HTMLSmoothlyInputEditElement>;
             "smoothly-input-file": LocalJSX.SmoothlyInputFile & JSXBase.HTMLAttributes<HTMLSmoothlyInputFileElement>;

--- a/src/components/input/InputStateHandler.ts
+++ b/src/components/input/InputStateHandler.ts
@@ -111,13 +111,18 @@ export class InputStateHandler {
 			const result = this.eventHandlers.input[event.inputType]?.(event, this.unformatState(state), state) ?? state
 
 			const formatted = this.partialFormatState(result)
-			if (event.defaultPrevented) {
+			if (
+				input.value != formatted.value ||
+				input.selectionStart != formatted.selection.start ||
+				input.selectionEnd != formatted.selection.end
+			) {
 				input.value = formatted.value
 				input.selectionStart = formatted.selection.start
 				input.selectionEnd = formatted.selection.end
 				input.selectionDirection = formatted.selection.direction ?? null
 			}
-			console.log(event.type, "new Event", event, formatted)
+
+			console.log(event.type, event.inputType, "new Event", event, formatted)
 			return formatted
 		}
 	}

--- a/src/components/input/InputStateHandler.ts
+++ b/src/components/input/InputStateHandler.ts
@@ -95,12 +95,14 @@ export class InputStateHandler {
 	public onInputEvent(event: InputEvent, state: tidily.State): Readonly<tidily.State> & tidily.Settings {
 		const input = event.target as HTMLInputElement
 		if (this.nextFormattedState) {
-			input.value = this.nextFormattedState.value
-			input.selectionStart = this.nextFormattedState.selection.start
-			input.selectionEnd = this.nextFormattedState.selection.end
-			input.selectionDirection = this.nextFormattedState.selection.direction ?? null
-			console.log(event.type, event.inputType, "using nextFormattedState", event, this.nextFormattedState)
-			return this.nextFormattedState
+			const result = this.nextFormattedState
+			this.nextFormattedState = undefined
+			input.value = result.value
+			input.selectionStart = result.selection.start
+			input.selectionEnd = result.selection.end
+			input.selectionDirection = result.selection.direction ?? null
+			console.log(event.type, event.inputType, "using nextFormattedState", event, result)
+			return result
 		} else {
 			// state.selection.start = input.selectionStart ?? state.selection.start
 			// state.selection.end = input.selectionEnd ?? state.selection.end

--- a/src/components/input/InputStateHandler.ts
+++ b/src/components/input/InputStateHandler.ts
@@ -95,6 +95,7 @@ export class InputStateHandler {
 	public onInputEvent(event: InputEvent, state: tidily.State, commitState: CommitState): void {
 		const input = event.target as HTMLInputElement
 		if (!event.inputType) {
+			// Chrome will dispatch an input event without inputType on autofill (this event is not reliable, but it's be best Chrome provides)
 			const newValue = input.value
 			this.requestAnimationFrameId && cancelAnimationFrame(this.requestAnimationFrameId)
 			clearTimeout(this.timeoutId)
@@ -176,8 +177,6 @@ export class InputStateHandler {
 				this.type == "password" ? { ...state, value: (event.target as HTMLInputElement).value } : state,
 			deleteWordForward: (event, state) =>
 				this.type == "password" ? { ...state, value: (event.target as HTMLInputElement).value } : state,
-			// Chrome will dispatch an input event without inputType when auto-filling
-			// undefined: (event, state) => ({ ...state, value: (event.target as HTMLInputElement).value }),
 		},
 	}
 

--- a/src/components/input/InputStateHandler.ts
+++ b/src/components/input/InputStateHandler.ts
@@ -81,17 +81,16 @@ export class InputStateHandler {
 	}
 
 	private nextFormattedState?: Readonly<tidily.State> & Readonly<tidily.Settings> // Set in beforeinput event - used in input event
-	public onBeforeInputEvent(event: InputEvent, state: tidily.State): Readonly<tidily.State> & tidily.Settings {
+	public onBeforeInputEvent(event: InputEvent, state: tidily.State) {
 		const input = event.target as HTMLInputElement
 		state.selection.start = input.selectionStart ?? state.selection.start
 		state.selection.end = input.selectionEnd ?? state.selection.end
 		state.selection.direction = input.selectionDirection ?? state.selection.direction
 
-		const result = this.eventHandlers.beforeinput[event.inputType]?.(event, this.unformatState(state), state) ?? state
-		const formatted = this.partialFormatState(result)
+		const result = this.eventHandlers.beforeinput[event.inputType]?.(event, this.unformatState(state), state)
+		const formatted = result ? this.partialFormatState(result) : undefined
 		this.nextFormattedState = formatted
-		console.log(event.type, this.nextFormattedState)
-		return formatted
+		console.log(event.type, event.inputType, event, this.nextFormattedState)
 	}
 	public onInputEvent(event: InputEvent, state: tidily.State): Readonly<tidily.State> & tidily.Settings {
 		const input = event.target as HTMLInputElement
@@ -100,6 +99,7 @@ export class InputStateHandler {
 			input.selectionStart = this.nextFormattedState.selection.start
 			input.selectionEnd = this.nextFormattedState.selection.end
 			input.selectionDirection = this.nextFormattedState.selection.direction ?? null
+			console.log(event.type, event.inputType, "using nextFormattedState", event, this.nextFormattedState)
 			return this.nextFormattedState
 		} else {
 			// state.selection.start = input.selectionStart ?? state.selection.start
@@ -115,6 +115,7 @@ export class InputStateHandler {
 				input.selectionEnd = formatted.selection.end
 				input.selectionDirection = formatted.selection.direction ?? null
 			}
+			console.log(event.type, "new Event", event, formatted)
 			return formatted
 		}
 	}

--- a/src/components/input/InputStateHandler.ts
+++ b/src/components/input/InputStateHandler.ts
@@ -97,31 +97,25 @@ export class InputStateHandler {
 	public onInputEvent(event: InputEvent, state: tidily.State, commitState: CommitState): void {
 		const input = event.target as HTMLInputElement
 		if (!event.inputType) {
+			const newValue = input.value
 			this.requestAnimationFrameId && cancelAnimationFrame(this.requestAnimationFrameId)
 			clearTimeout(this.timeoutId)
-			const valueBeforeRAF = input.value
-
 			this.requestAnimationFrameId = requestAnimationFrame(() => {
-				// this.timeoutId = setTimeout(() => {
-				const newValue = state.value != input.value ? input.value : valueBeforeRAF
-				console.log("autofill?", { state: state.value, inputValue: input.value, valueBeforeRAF, newValue })
-				if (state.value != newValue) {
-					const result = { ...state, value: newValue }
-					const formatted = this.partialFormatState(result)
-					commitState(formatted)
-					console.log(event.type, event.inputType, "autofill", event, result)
-				}
-				// }, 100)
+				console.log("autofill?", { lastValue: state.value, newValue })
+				const result = { ...state, value: newValue }
+				const formatted = this.partialFormatState(result)
+				commitState(formatted)
+				console.log(event.type, event.inputType, "autofill", event, result)
 			})
 		} else if (this.nextFormattedState) {
-			const result = this.nextFormattedState
+			const newState = this.nextFormattedState
 			this.nextFormattedState = undefined
-			console.log(event.type, event.inputType, "using nextFormattedState", event, result)
-			input.value = result.value
-			input.selectionStart = result.selection.start
-			input.selectionEnd = result.selection.end
-			input.selectionDirection = result.selection.direction ?? null
-			commitState(result)
+			console.log(event.type, event.inputType, "using nextFormattedState", event, newState)
+			input.value = newState.value
+			input.selectionStart = newState.selection.start
+			input.selectionEnd = newState.selection.end
+			input.selectionDirection = newState.selection.direction ?? null
+			commitState(newState)
 		} else {
 			state.selection.start = input.selectionStart ?? state.selection.start
 			state.selection.end = input.selectionEnd ?? state.selection.end

--- a/src/components/input/InputStateHandler.ts
+++ b/src/components/input/InputStateHandler.ts
@@ -86,11 +86,9 @@ export class InputStateHandler {
 		state.selection.start = input.selectionStart ?? state.selection.start
 		state.selection.end = input.selectionEnd ?? state.selection.end
 		state.selection.direction = input.selectionDirection ?? state.selection.direction
-
-		const result = this.eventHandlers.beforeinput[event.inputType]?.(event, this.unformatState(state), state)
-		const formatted = result ? this.partialFormatState(result) : undefined
+		const unformatted = this.eventHandlers.beforeinput[event.inputType]?.(event, this.unformatState(state), state)
+		const formatted = unformatted ? this.partialFormatState(unformatted) : undefined
 		this.nextFormattedState = formatted
-		console.log(event.type, event.inputType, event, this.nextFormattedState)
 	}
 	private requestAnimationFrameId: number | undefined
 	private timeoutId: NodeJS.Timeout | undefined
@@ -101,16 +99,13 @@ export class InputStateHandler {
 			this.requestAnimationFrameId && cancelAnimationFrame(this.requestAnimationFrameId)
 			clearTimeout(this.timeoutId)
 			this.requestAnimationFrameId = requestAnimationFrame(() => {
-				console.log("autofill?", { lastValue: state.value, newValue })
-				const result = { ...state, value: newValue }
-				const formatted = this.partialFormatState(result)
+				const newState = { ...state, value: newValue }
+				const formatted = this.partialFormatState(newState)
 				commitState(formatted)
-				console.log(event.type, event.inputType, "autofill", event, result)
 			})
 		} else if (this.nextFormattedState) {
 			const newState = this.nextFormattedState
 			this.nextFormattedState = undefined
-			console.log(event.type, event.inputType, "using nextFormattedState", event, newState)
 			input.value = newState.value
 			input.selectionStart = newState.selection.start
 			input.selectionEnd = newState.selection.end
@@ -132,7 +127,6 @@ export class InputStateHandler {
 				input.selectionEnd = formatted.selection.end
 				input.selectionDirection = formatted.selection.direction ?? null
 			}
-			console.log(event.type, event.inputType, "new Event", event, formatted)
 			commitState(formatted)
 		}
 	}

--- a/src/components/input/demo/index.tsx
+++ b/src/components/input/demo/index.tsx
@@ -18,6 +18,7 @@ export class SmoothlyInputDemo {
 				<smoothly-input-demo-standard />
 				<smoothly-input-date-demo />
 				<smoothly-input-demo-user-input />
+				<smoothly-input-demo-types />
 				<div class="inputs">
 					<h2>Calendar</h2>
 					<smoothly-input-date name="some-date">Calendar</smoothly-input-date>

--- a/src/components/input/demo/types/index.tsx
+++ b/src/components/input/demo/types/index.tsx
@@ -24,7 +24,7 @@ export class SmoothlyInputDemoTypes {
 			<Host>
 				<h3>Input Types</h3>
 				{this.types.map(type => (
-					<smoothly-input name={type} type={type} key={type}>
+					<smoothly-input name={type} type={type} key={type} looks="border">
 						{type}
 						<smoothly-input-clear slot="end" />
 					</smoothly-input>

--- a/src/components/input/demo/types/index.tsx
+++ b/src/components/input/demo/types/index.tsx
@@ -1,0 +1,35 @@
+import { Component, h, Host } from "@stencil/core"
+import { tidily } from "tidily"
+
+@Component({
+	tag: "smoothly-input-demo-types",
+	styleUrl: "style.css",
+	scoped: true,
+})
+export class SmoothlyInputDemoTypes {
+	types: tidily.Type[] = [
+		"text",
+		"integer",
+		"price",
+		"percent",
+		"password",
+		"email",
+		"card-number",
+		"card-expires",
+		"card-csc",
+	] as const
+
+	render() {
+		return (
+			<Host>
+				<h3>Input Types</h3>
+				{this.types.map(type => (
+					<smoothly-input name={type} type={type} key={type}>
+						{type}
+						<smoothly-input-clear slot="end" />
+					</smoothly-input>
+				))}
+			</Host>
+		)
+	}
+}

--- a/src/components/input/demo/types/style.css
+++ b/src/components/input/demo/types/style.css
@@ -1,0 +1,9 @@
+:host {
+	display: block;
+	max-width: min(calc(100% - 0.5rem), 48rem);
+	margin: auto;
+}
+:host smoothly-input {
+	width: 100%;
+}
+

--- a/src/components/input/index.tsx
+++ b/src/components/input/index.tsx
@@ -178,12 +178,15 @@ export class SmoothlyInput implements Clearable, Input, Editable {
 		if (!this.element.isConnected)
 			await this.unregister()
 	}
-	@Listen("input")
 	@Listen("beforeinput")
-	onEvent(event: InputEvent) {
+	onBeforeInput(event: InputEvent) {
+		this.stateHandler.onBeforeInputEvent(event, this.state)
+	}
+	@Listen("input")
+	onInput(event: InputEvent) {
 		this.state = this.stateHandler.onInputEvent(event, this.state)
-		if (event.type == "input" || event.defaultPrevented)
-			this.smoothlyUserInput.emit({ name: this.name, value: this.stateHandler.getValue(this.state) })
+		this.smoothlyUserInput.emit({ name: this.name, value: this.stateHandler.getValue(this.state) })
+		console.log("updating state!!", this.state)
 	}
 	copyText(value?: string) {
 		if (value) {

--- a/src/components/input/index.tsx
+++ b/src/components/input/index.tsx
@@ -188,8 +188,6 @@ export class SmoothlyInput implements Clearable, Input, Editable {
 			this.state = state
 			this.smoothlyUserInput.emit({ name: this.name, value: this.stateHandler.getValue(this.state) })
 		})
-		// this.smoothlyUserInput.emit({ name: this.name, value: this.stateHandler.getValue(this.state) })
-		// console.log("updating state!!", this.state)
 	}
 	copyText(value?: string) {
 		if (value) {

--- a/src/components/input/index.tsx
+++ b/src/components/input/index.tsx
@@ -171,8 +171,8 @@ export class SmoothlyInput implements Clearable, Input, Editable {
 		this.observer.publish()
 	}
 	componentDidLoad() {
-		if (this.inputElement)
-			this.inputElement.value = this.state.value
+		// if (this.inputElement)
+		// 	this.inputElement.value = this.state.value
 	}
 	async disconnectedCallback() {
 		if (!this.element.isConnected)
@@ -184,8 +184,11 @@ export class SmoothlyInput implements Clearable, Input, Editable {
 	}
 	@Listen("input")
 	onInput(event: InputEvent) {
-		this.state = this.stateHandler.onInputEvent(event, this.state)
-		this.smoothlyUserInput.emit({ name: this.name, value: this.stateHandler.getValue(this.state) })
+		this.stateHandler.onInputEvent(event, this.state, state => {
+			this.state = state
+			this.smoothlyUserInput.emit({ name: this.name, value: this.stateHandler.getValue(this.state) })
+		})
+		// this.smoothlyUserInput.emit({ name: this.name, value: this.stateHandler.getValue(this.state) })
 		// console.log("updating state!!", this.state)
 	}
 	copyText(value?: string) {

--- a/src/components/input/index.tsx
+++ b/src/components/input/index.tsx
@@ -186,7 +186,7 @@ export class SmoothlyInput implements Clearable, Input, Editable {
 	onInput(event: InputEvent) {
 		this.state = this.stateHandler.onInputEvent(event, this.state)
 		this.smoothlyUserInput.emit({ name: this.name, value: this.stateHandler.getValue(this.state) })
-		console.log("updating state!!", this.state)
+		// console.log("updating state!!", this.state)
 	}
 	copyText(value?: string) {
 		if (value) {


### PR DESCRIPTION
This PR removes all `preventDefault` from `beforeinput` events.
The `preventDefault` made it seem to Chrome that the user never typed and so it would autofill the value again when it changed.


https://github.com/user-attachments/assets/5bdc5020-92bc-43c9-a4e6-4be65e0e7e69



Unfortunately the autofill is still not perfect since if you keep switching what values are autofill it will sometimes not autofill the correct values you choose (this bug is not new). Makes me think that maybe logins should just use regular input and form elements, and just listen to the submit for formdata instead. But this PR is at least an improvement.