### PR TITLE
Fix input-remainder positioning for no-label input

### DIFF
--- a/src/components/input/style.css
+++ b/src/components/input/style.css
@@ -32,11 +32,10 @@
   box-sizing: border-box;
   align-content: center;
 	height: 100%;
-	padding: 
-		var(--input-value-padding-top) 
-		var(--input-padding-side) 
-		var(--input-value-padding-bottom) 
-		var(--input-padding-side);
+	padding-inline: var(--input-padding-side);
+}
+:host([show-label])>.smoothly-input-container>div.guide {
+	padding-block: var(--input-value-padding-top) var(--input-value-padding-bottom);
 }
 :host>.smoothly-input-container>div.guide>div.value {
 	display: inline;


### PR DESCRIPTION
Fix remainder positioning when no label

Before
<img width="664" height="133" alt="image" src="https://github.com/user-attachments/assets/67617091-c889-421a-9302-42bba7d03fd2" />


After
<img width="699" height="128" alt="image" src="https://github.com/user-attachments/assets/640d9962-867c-449e-b84a-198fd84dc48e" />
