### PR TITLE
css variables for display-json

### DIFF
--- a/src/components/display/json/primitive/style.css
+++ b/src/components/display/json/primitive/style.css
@@ -8,21 +8,20 @@
 	display: none;
 }
 
-:host(.string), 
-:host(.number),
-:host(.boolean) {
-	font-weight: bold;
-}
 :host(.string) {
-	color: rgb(var(--smoothly-primary-color));
+	font-weight: var(--smoothly-display-json-string-font-weight, bold);
+	color: rgb(var(--smoothly-display-json-string, var(--smoothly-primary-color)));
 }
 :host(.number) {
-	color: rgb(var(--smoothly-secondary-color));
+	font-weight: var(--smoothly-display-json-number-font-weight, bold);
+	color: rgb(var(--smoothly-display-json-number, var(--smoothly-secondary-color)));
 }
 :host(.boolean) {
-	color: rgb(var(--smoothly-tertiary-color));
+	font-weight: var(--smoothly-display-json-boolean-font-weight, bold);
+	color: rgb(var(--smoothly-display-json-boolean, var(--smoothly-tertiary-color)));
 }
 :host(.null),
 :host(.undefined) {
-	color: rgb(var(--smoothly-medium-color));
+	font-weight: var(--smoothly-display-json-undefined-font-weight, normal);
+	color: rgb(var(--smoothly-display-json-undefined, var(--smoothly-medium-color)));
 }

--- a/src/components/theme/demo/index.tsx
+++ b/src/components/theme/demo/index.tsx
@@ -17,7 +17,7 @@ export class SmoothlyThemeDemo {
 					<smoothly-item value="https://app.issuefab.com/assets/style/index.css">Issuefab</smoothly-item>
 					<smoothly-item value="https://app.proquse.com/assets/style/index.css">Proquse</smoothly-item>
 					<smoothly-item value="https://app.weekmeter.com/assets/style/index.css">Weekmeter</smoothly-item>
-					<smoothly-item value="https://dash.pax2pay.app/p2pdash.css">Pax2Pay Dashboard</smoothly-item>
+					<smoothly-item value="https://test.dash.pax2pay.app/p2pdash.css">Pax2Pay Dashboard</smoothly-item>
 					<smoothly-item value="https://ui.pax2pay.app/assets/style/pax2pay.css">Pax2Pay Portal</smoothly-item>
 					<smoothly-item value="https://theme.payfunc.com/intergiro/index.css">Intergiro Monitor</smoothly-item>
 					<smoothly-item value="https://theme.payfunc.com/light/index.css">Payfunc Light</smoothly-item>


### PR DESCRIPTION
Ability to set colors and font-weight for display-json.

Examples:
<img width="354" height="166" alt="Screenshot from 2026-01-16 11-58-45" src="https://github.com/user-attachments/assets/78a4fb52-46fa-4344-b9f6-b90b1431d44c" />

<img width="354" height="166" alt="Screenshot from 2026-01-16 11-58-58" src="https://github.com/user-attachments/assets/8476ff22-30e9-4cd3-ab35-b7f85d56d573" />
