### PR TITLE
Fix smoothly-select filtering

### DIFF
--- a/src/components/item/style.css
+++ b/src/components/item/style.css
@@ -12,7 +12,7 @@
 	cursor: not-allowed;
 }
 
-:host {
+:host:not([hidden]) {
 	display: flex;
 	align-items: center;
 	padding: 0.5em;


### PR DESCRIPTION
smoothly-item did get property `hidden`. 
Browser styling (the user-agent stylesheet) dictates that hidden should have `display: none;`
But any styling added by smoothly will overwrite display, since user-agent has least priority.