### PR TITLE
Fix for table header: positioning styling is now more specific.

### DIFF
--- a/src/components/table/head/index.tsx
+++ b/src/components/table/head/index.tsx
@@ -26,9 +26,7 @@ export class SmoothlyTableHead {
 			if (currentElement.tagName.toLowerCase() === "smoothly-table") {
 				const head = currentElement.querySelector("smoothly-table-head") as HTMLSmoothlyTableHeadElement
 				if (head !== this.element) {
-					const rows = Array.from(
-						head.querySelectorAll("smoothly-table-row") as NodeListOf<HTMLSmoothlyTableHeadElement>
-					)
+					const rows = Array.from(head.querySelectorAll(":scope > smoothly-table-row"))
 					depth += rows.length
 				}
 			}


### PR DESCRIPTION
There was a bug, if a header was nested in an expandable cell in a header the calculation of styling values didnt work, this makes it more specific and works for all cases. 

Before: 
<img width="1701" height="543" alt="image" src="https://github.com/user-attachments/assets/562118b7-ef91-4423-99e5-696fd298c2bc" />

After: 
<img width="1701" height="543" alt="image" src="https://github.com/user-attachments/assets/c869a325-2da1-4ab8-9f17-1241ecf2629d" />

