### PR TITLE
Use input-foreground color in select search

### DIFF
--- a/src/components/input/select/style.css
+++ b/src/components/input/select/style.css
@@ -149,9 +149,9 @@
 	top: 0;
 	gap: 1rem;
 	background-color: rgb(var(--smoothly-input-background));
-	color: rgb(var(--smoothly-color-contrast));
-	fill: rgb(var(--smoothly-color-contrast));
-	stroke: rgb(var(--smoothly-color-contrast));
+	color: rgb(var(--smoothly-input-foreground, var(--smoothly-color-contrast)));
+	fill: rgb(var(--smoothly-input-foreground, var(--smoothly-color-contrast)));
+	stroke: rgb(var(--smoothly-input-foreground, var(--smoothly-color-contrast)));
 }
 :host>div.options::slotted(div.search-preview)::before {
 	/* Hack to not make the search-preview have opacity without showing what is underneath */
@@ -160,6 +160,12 @@
 	inset: 0;
 	background-color: rgba(var(--smoothly-primary-tint), 0.5);
 	z-index: -1;
+}
+:host>div.options>div.search-preview>smoothly-icon[name="search-outline"],
+:host>div.options>div.search-preview>smoothly-icon[name="backspace-outline"] {
+	color: rgb(var(--smoothly-input-foreground, var(--smoothly-color-contrast)));
+	fill: rgb(var(--smoothly-input-foreground, var(--smoothly-color-contrast)));
+	stroke: rgb(var(--smoothly-input-foreground, var(--smoothly-color-contrast)));
 }
 
 :host>div.options>div.search-preview>smoothly-icon[name="backspace-outline"] {


### PR DESCRIPTION


Icon and text in select search would get color if some parent had prop color set.
Now icon and text are set from `--smoothly-input-foreground`

Before vs After
<img width="380" height="293" alt="image" src="https://github.com/user-attachments/assets/0ee5cfd6-71a5-450c-937c-28b56666aa74" /> <img width="380" height="289" alt="Screenshot from 2026-04-08 13-27-04" src="https://github.com/user-attachments/assets/315fbb5c-6e92-4557-b38e-f3b5ead0b8c5" />
