### PR TITLE
Make form input buttons directly disablable.

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -381,10 +381,7 @@ export namespace Components {
     }
     interface SmoothlyInputClear {
         "color"?: Color;
-        /**
-          * @default false
-         */
-        "disabled": boolean;
+        "disabled"?: boolean;
         /**
           * @default true
          */
@@ -737,10 +734,7 @@ export namespace Components {
     }
     interface SmoothlyInputReset {
         "color"?: Color;
-        /**
-          * @default false
-         */
-        "disabled": boolean;
+        "disabled"?: boolean;
         /**
           * @default true
          */
@@ -2948,9 +2942,6 @@ declare namespace LocalJSX {
     }
     interface SmoothlyInputClear {
         "color"?: Color;
-        /**
-          * @default false
-         */
         "disabled"?: boolean;
         /**
           * @default true
@@ -3286,9 +3277,6 @@ declare namespace LocalJSX {
     }
     interface SmoothlyInputReset {
         "color"?: Color;
-        /**
-          * @default false
-         */
         "disabled"?: boolean;
         /**
           * @default true

--- a/src/components/input/clear/index.tsx
+++ b/src/components/input/clear/index.tsx
@@ -15,7 +15,7 @@ export class SmoothlyInputClear {
 	@Prop() color?: Color
 	@Prop({ reflect: true }) expand?: "block" | "full"
 	@Prop({ reflect: true }) fill?: Fill = "clear"
-	@Prop({ reflect: true, mutable: true }) disabled = false
+	@Prop({ reflect: true, mutable: true }) disabled?: boolean
 	@Prop({ reflect: true }) size: "small" | "large" | "icon" | "flexible" = "icon"
 	@Prop({ reflect: true }) shape?: "rounded"
 	@Prop({ reflect: true, mutable: true }) display = true
@@ -35,10 +35,16 @@ export class SmoothlyInputClear {
 							this.display = defined && !p.readonly && !p.disabled
 						}
 						if (p instanceof SmoothlyForm) {
-							this.disabled = p.readonly || Object.values(p.value).filter(val => val).length < 1
 							this.display = !p.readonly
 						}
 					})
+					if (typeof this.disabled !== "boolean") {
+						parent.listen(async p => {
+							if (p instanceof SmoothlyForm) {
+								this.disabled = p.readonly || Object.values(p.value).filter(val => val).length < 1
+							}
+						})
+					}
 				}
 			}
 		})

--- a/src/components/input/reset/index.tsx
+++ b/src/components/input/reset/index.tsx
@@ -14,7 +14,7 @@ export class SmoothlyInputReset {
 	@Prop() color?: Color
 	@Prop({ reflect: true }) expand?: "block" | "full"
 	@Prop({ reflect: true }) fill?: Fill
-	@Prop({ reflect: true, mutable: true }) disabled = false
+	@Prop({ reflect: true, mutable: true }) disabled?: boolean
 	@Prop({ reflect: true }) size: "flexible" | "small" | "large" | "icon" = "icon"
 	@Prop({ reflect: true }) shape?: "rounded"
 	@Prop({ reflect: true, mutable: true }) display = true
@@ -27,7 +27,6 @@ export class SmoothlyInputReset {
 		this.smoothlyInputLoad.emit(parent => {
 			if (Editable.Element.type.is(parent)) {
 				this.parent = parent
-				this.readonlyAtLoad = parent.readonly
 				parent.listen(async p => {
 					if (Input.is(p)) {
 						const defined = typeof p.defined == "boolean" ? p.defined : Boolean(await p.getValue())
@@ -35,9 +34,16 @@ export class SmoothlyInputReset {
 					}
 					if (p instanceof SmoothlyForm) {
 						this.display = !p.readonly
-						this.disabled = !this.readonlyAtLoad && !p.isDifferentFromInitial
 					}
 				})
+				if (typeof this.disabled !== "boolean") {
+					this.readonlyAtLoad = parent.readonly
+					parent.listen(async p => {
+						if (p instanceof SmoothlyForm) {
+							this.disabled = !this.readonlyAtLoad && !p.isDifferentFromInitial
+						}
+					})
+				}
 			}
 		})
 	}

--- a/src/components/input/submit/index.tsx
+++ b/src/components/input/submit/index.tsx
@@ -28,12 +28,18 @@ export class SmoothlyInputSubmit implements ComponentWillLoad {
 				this.parent = parent
 				parent.listen(async p => {
 					this.display = !p.readonly
-					this.disabled =
-						!this.delete &&
-						(p.readonly ||
-							("validator" in p && p.validator instanceof isly.Type && !p.validator?.is(Data.convertArrays(p.value))) ||
-							!p.isDifferentFromInitial)
 				})
+				if (typeof this.disabled !== "boolean") {
+					parent.listen(async p => {
+						this.disabled =
+							!this.delete &&
+							(p.readonly ||
+								("validator" in p &&
+									p.validator instanceof isly.Type &&
+									!p.validator?.is(Data.convertArrays(p.value))) ||
+								!p.isDifferentFromInitial)
+					})
+				}
 			}
 		})
 	}


### PR DESCRIPTION
Allow setting disabled directly on the and `smoothly-input-submit`, `-reset` and `-clear`.
This will override the default smoothly behaviour for the button.