### PR TITLE
Allow multiple paths per room

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -64,7 +64,7 @@ export namespace Components {
         /**
           * @default ""
          */
-        "path": string | URLPattern;
+        "path": string | URLPattern | (string | URLPattern)[];
         "selected"?: boolean;
         "setMobileMode": (mobile: boolean) => Promise<void>;
         "setSelected": (selected: boolean, options?: { history?: boolean; }) => Promise<void>;
@@ -1321,7 +1321,7 @@ declare global {
         new (): HTMLSmoothlyAppDemoElement;
     };
     interface HTMLSmoothlyAppRoomElementEventMap {
-        "smoothlyRoomSelect": { history: boolean; query?: string };
+        "smoothlyRoomSelect": { history: boolean; path: string; query?: string };
         "smoothlyRoomLoad": { selected: boolean };
         "smoothlyUrlChange": string;
     }
@@ -2617,12 +2617,12 @@ declare namespace LocalJSX {
         "icon"?: Icon;
         "label"?: string;
         "onSmoothlyRoomLoad"?: (event: SmoothlyAppRoomCustomEvent<{ selected: boolean }>) => void;
-        "onSmoothlyRoomSelect"?: (event: SmoothlyAppRoomCustomEvent<{ history: boolean; query?: string }>) => void;
+        "onSmoothlyRoomSelect"?: (event: SmoothlyAppRoomCustomEvent<{ history: boolean; path: string; query?: string }>) => void;
         "onSmoothlyUrlChange"?: (event: SmoothlyAppRoomCustomEvent<string>) => void;
         /**
           * @default ""
          */
-        "path"?: string | URLPattern;
+        "path"?: string | URLPattern | (string | URLPattern)[];
         "selected"?: boolean;
     }
     interface SmoothlyBackToTop {
@@ -3691,7 +3691,7 @@ declare namespace LocalJSX {
         "label": string;
         "icon": Icon;
         "disabled": boolean;
-        "path": string | URLPattern;
+        "path": string | URLPattern | (string | URLPattern)[];
         "selected": boolean;
     }
     interface SmoothlyBackToTopAttributes {

--- a/src/components/app/index.tsx
+++ b/src/components/app/index.tsx
@@ -70,13 +70,13 @@ export class SmoothlyApp {
 		this.smoothlyUrlChange.emit(window.location.href)
 	}
 	@Listen("smoothlyRoomSelect")
-	roomSelectedHandler(event: SmoothlyAppRoomCustomEvent<{ history: boolean; query?: string }>) {
+	roomSelectedHandler(event: SmoothlyAppRoomCustomEvent<{ history: boolean; path: string; query?: string }>) {
 		this.selected = { element: event.target }
 		if (this.mobileMode) {
 			this.menuOpen = false
 		}
 		if (!event.detail.history) {
-			const path = this.selected.element.path.toString()
+			const path = event.detail.path
 			const location = new URL(window.location.pathname == path ? window.location.href : window.location.origin)
 			location.pathname = path
 			location.search = event.detail.query ? `?${event.detail.query}` : ""

--- a/src/components/app/room/index.tsx
+++ b/src/components/app/room/index.tsx
@@ -24,11 +24,12 @@ export class SmoothlyAppRoom {
 	@Prop({ reflect: true }) label?: string
 	@Prop({ reflect: true }) icon?: Icon
 	@Prop({ reflect: true }) disabled: boolean
-	@Prop() path: string | URLPattern = ""
+	@Prop() path: string | URLPattern | (string | URLPattern)[] = ""
+	@State() paths: URLPattern[]
 	@Prop({ reflect: true, mutable: true }) selected?: boolean
 	@Prop() content?: VNode | FunctionalComponent
 	@State() mobileMode = false
-	@Event() smoothlyRoomSelect: EventEmitter<{ history: boolean; query?: string }>
+	@Event() smoothlyRoomSelect: EventEmitter<{ history: boolean; path: string; query?: string }>
 	@Event() smoothlyRoomLoad: EventEmitter<{ selected: boolean }>
 	@Event() smoothlyUrlChange: EventEmitter<string>
 	private contentElement?: HTMLElement
@@ -36,11 +37,11 @@ export class SmoothlyAppRoom {
 		this.selected && this.smoothlyUrlChange.emit(window.location.href)
 	}
 	componentWillLoad() {
-		this.selected = (typeof this.path == "string" ? new URLPattern({ pathname: this.path }) : this.path).test(
-			window.location
-		)
+		const stringOrPatternPaths = Array.isArray(this.path) ? this.path : [this.path]
+		this.paths = stringOrPatternPaths.map(path => (typeof path == "string" ? new URLPattern({ pathname: path }) : path))
+		this.selected = this.paths.some(pattern => pattern.test(window.location.href))
 		this.smoothlyRoomLoad.emit({ selected: this.selected })
-		this.selected && window.history.replaceState({ smoothlyPath: this.path }, "", window.location.href)
+		this.selected && window.history.replaceState({ smoothlyPath: this.paths[0].pathname }, "", window.location.href)
 	}
 	@Method()
 	async setMobileMode(mobile: boolean) {
@@ -54,7 +55,7 @@ export class SmoothlyAppRoom {
 	async setSelected(selected: boolean, options?: { history?: boolean }): Promise<void> {
 		this.selected = selected
 		if (selected) {
-			this.smoothlyRoomSelect.emit({ history: !!options?.history, query: this.query })
+			this.smoothlyRoomSelect.emit({ history: !!options?.history, path: this.paths[0].pathname, query: this.query })
 		}
 	}
 	@Listen("smoothlyUrlUpdate", { target: "window" })
@@ -81,7 +82,7 @@ export class SmoothlyAppRoom {
 		return (
 			<Host class={{ "smoothly-mobile-mode": this.mobileMode }}>
 				<li>
-					<a href={typeof this.path == "string" ? this.path : this.path.pathname} onClick={e => this.clickHandler(e)}>
+					<a href={this.paths[0]?.pathname} onClick={e => this.clickHandler(e)}>
 						{this.icon && <smoothly-icon name={this.icon} />}
 						{this.label && <span class="label">{this.label}</span>}
 					</a>


### PR DESCRIPTION

Example:
```tsx
<smoothly-app-room
  label="Orders"
  path={["/orders", "/orders/:id"]} 
/>
```