### PR TITLE
Align input with radio button icon.

### DIFF
--- a/src/components/input/radio/item/style.css
+++ b/src/components/input/radio/item/style.css
@@ -28,7 +28,6 @@ smoothly-input-radio:not([disabled]):not([readonly]) :host>smoothly-icon[name=ch
 	width: 1.5em;
 	height: 1.5em;
 	position: absolute;
-	transform: translateX(50%);
 }
 :host>label {
 	padding: 0 .3em;


### PR DESCRIPTION
If you clicked on the left side of the radio button you can miss clicking the input.

### Before
<img width="1559" height="360" alt="Screenshot from 2026-07-06 15-26-20" src="https://github.com/user-attachments/assets/82425c6a-ee18-4e77-b277-0f13064f44aa" />

### After
<img width="1559" height="360" alt="Screenshot from 2026-07-06 15-26-09" src="https://github.com/user-attachments/assets/b25b2feb-bc9a-4a21-bd3b-e86bfdfbd533" />
