### PR TITLE
Input select: display selected icons fix.

### DIFF
--- a/src/components/input/select/index.tsx
+++ b/src/components/input/select/index.tsx
@@ -40,6 +40,7 @@ export class SmoothlyInputSelect implements Input, Editable, Clearable, Componen
 	private searchElement?: HTMLInputElement
 	private items: HTMLSmoothlyItemElement[] = []
 	private itemHeight: number | undefined
+	private readonly displaySeparator = '<span style="display:inline-block;width:0.8rem"></span>'
 	@Element() element: HTMLSmoothlyInputSelectElement
 	@Prop({ reflect: true }) invalid?: boolean = false
 	@Prop({ reflect: true }) errorMessage?: string
@@ -352,7 +353,11 @@ export class SmoothlyInputSelect implements Input, Editable, Clearable, Componen
 				class={{ "has-value": this.selected.length !== 0, open: this.open, "has-filter": this.filter !== "" }}
 				onClick={(e: MouseEvent) => this.onClick(e)}>
 				<div class="select-display">
-					{this.display.length > 0 ? <div class="value" innerHTML={this.display.join("  ")}></div> : this.placeholder}
+					{this.display.length > 0 ? (
+						<div class="value" innerHTML={this.display.join(this.displaySeparator)}></div>
+					) : (
+						this.placeholder
+					)}
 				</div>
 				<div class="icons" ref={element => (this.iconsElement = element)}>
 					<smoothly-icon class="smoothly-invalid" name="alert-circle" size="small" tooltip={this.errorMessage} />

--- a/src/components/input/select/index.tsx
+++ b/src/components/input/select/index.tsx
@@ -245,7 +245,15 @@ export class SmoothlyInputSelect implements Input, Editable, Clearable, Componen
 		return selected.length === initialValue.length && initialValue.every(value => selected.includes(value))
 	}
 	displaySelected(): void {
-		this.display = this.selected.map(option => option.innerHTML)
+		this.display = this.selected.map(option => {
+			const clone = option.cloneNode(true) as HTMLElement
+			clone.querySelectorAll("smoothly-icon").forEach(icon => {
+				const style = (icon as HTMLElement).style
+				style.display = "inline-flex"
+				style.verticalAlign = "middle"
+			})
+			return clone.innerHTML
+		})
 	}
 	onKeyDown(event: KeyboardEvent) {
 		event.stopPropagation()
@@ -344,7 +352,7 @@ export class SmoothlyInputSelect implements Input, Editable, Clearable, Componen
 				class={{ "has-value": this.selected.length !== 0, open: this.open, "has-filter": this.filter !== "" }}
 				onClick={(e: MouseEvent) => this.onClick(e)}>
 				<div class="select-display">
-					{this.display.length > 0 ? <div innerHTML={this.display.join(", ")}></div> : this.placeholder}
+					{this.display.length > 0 ? <div class="value" innerHTML={this.display.join("  ")}></div> : this.placeholder}
 				</div>
 				<div class="icons" ref={element => (this.iconsElement = element)}>
 					<smoothly-icon class="smoothly-invalid" name="alert-circle" size="small" tooltip={this.errorMessage} />

--- a/src/components/input/select/style.css
+++ b/src/components/input/select/style.css
@@ -26,10 +26,11 @@
 
 }
 
-:host>.select-display>div {
+:host>.select-display>.value {
+	min-width: 0;
 	overflow: hidden;
 	text-overflow: ellipsis;
-	
+	white-space: nowrap;
 }
 
 :host:not([readonly]):not([disabled])>.select-display {


### PR DESCRIPTION
I previously fixed overflow not being cutoff and displayed with ellipsis in input-select, that fix broke displaying of icons:
<img width="674" height="177" alt="image" src="https://github.com/user-attachments/assets/6147fd2c-4f8e-4fe5-9eff-596b8448078c" />

This fixes that:
<img width="615" height="154" alt="image" src="https://github.com/user-attachments/assets/c07df0dd-ce7f-41e8-8335-04b5d4ddaf51" />
