### PR TITLE
Range input: dual mode label bug fix.

### DIFF
--- a/src/components/input/range/demo/index.tsx
+++ b/src/components/input/range/demo/index.tsx
@@ -22,14 +22,7 @@ export class SmoothlyInputRangeDemo {
 				<h3>Dual (start / end)</h3>
 				<smoothly-input-range dual min={90.86} max={10000000} step={1} name="dualRange" label="Range" />
 				<h3>Dual percent</h3>
-				<smoothly-input-range
-					dual
-					name="dualRangePercent"
-					type="percent"
-					min={0}
-					max={1}
-					step={0.01}
-					label="Percent range">
+				<smoothly-input-range dual name="dualRangePercent" type="percent" min={0} max={1} step={0.01}>
 					<smoothly-input-clear size="icon" slot="end" />
 				</smoothly-input-range>
 			</Host>

--- a/src/components/input/range/index.tsx
+++ b/src/components/input/range/index.tsx
@@ -253,7 +253,7 @@ export class SmoothlyInputRange implements Input, Clearable, Editable, Component
 				readonly={this.readonly}
 				disabled={this.disabled}
 				right={part == "start"}>
-				{`${this.label ? this.label : ""} ${part == "start" ? "from" : "to"}`}
+				{`${this.label ? this.label : ""} ${part == "start" ? "From" : "To"}`}
 			</smoothly-input>
 		)
 	}

--- a/src/components/input/range/index.tsx
+++ b/src/components/input/range/index.tsx
@@ -253,7 +253,7 @@ export class SmoothlyInputRange implements Input, Clearable, Editable, Component
 				readonly={this.readonly}
 				disabled={this.disabled}
 				right={part == "start"}>
-				{part == "start" ? "From" : "To"}
+				{`${this.label ? this.label : ""} ${part == "start" ? "from" : "to"}`}
 			</smoothly-input>
 		)
 	}
@@ -290,7 +290,7 @@ export class SmoothlyInputRange implements Input, Clearable, Editable, Component
 			<Host
 				class={{
 					"output-side-right": this.outputSide === "right",
-					"show-label": this.outputSide === "left" && !!this.label,
+					"show-label": this.dual || (this.outputSide === "left" && !!this.label),
 					dual: this.dual,
 				}}>
 				<slot name="start" />

--- a/src/components/input/range/style.css
+++ b/src/components/input/range/style.css
@@ -146,8 +146,7 @@ input::-webkit-inner-spin-button {
 
 /*--------------------DUAL MODE------------------ */
 :host(.dual)>div>smoothly-input {
-	width: 6rem;
-	flex: 0 0 auto;
+	width: 7rem;
 }
 :host(.dual) .track {
 	position: relative;

--- a/src/components/input/range/style.css
+++ b/src/components/input/range/style.css
@@ -147,6 +147,7 @@ input::-webkit-inner-spin-button {
 /*--------------------DUAL MODE------------------ */
 :host(.dual)>div>smoothly-input {
 	width: 7rem;
+	flex: 0 0 auto;
 }
 :host(.dual) .track {
 	position: relative;


### PR DESCRIPTION
The label for the two text inputs in `smoothly-input-range` dual mode didn't show as expected, this PR fixes that.